### PR TITLE
Enhance remote desktop adaptive tuning

### DIFF
--- a/shared/types/remote-desktop.ts
+++ b/shared/types/remote-desktop.ts
@@ -61,8 +61,13 @@ export interface RemoteDesktopFrameMetrics {
   cpuPercent?: number;
   gpuPercent?: number;
   clipQuality?: number;
+  captureLatencyMs?: number;
+  encodeLatencyMs?: number;
+  processingLatencyMs?: number;
+  frameJitterMs?: number;
   targetBitrateKbps?: number;
   ladderLevel?: number;
+  frameLossPercent?: number;
 }
 
 export interface RemoteDesktopCursorState {


### PR DESCRIPTION
## Summary
- expose frame loss percent telemetry in the shared remote desktop metrics type
- track frame drop pressure in the Go streamer and surface it through metrics
- extend the adaptive controller with AIMD-inspired bitrate/scale adjustments and drop-aware recovery

## Testing
- interrupted `go test ./...` (hangs in headless capture environment)


------
https://chatgpt.com/codex/tasks/task_e_68e6a7479490832bb7117b3ed305b0e0