### PR TITLE
Improve remote desktop adaptive streaming heuristics

### DIFF
--- a/tenvy-client/internal/modules/control/remotedesktop/types.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/types.go
@@ -174,6 +174,7 @@ type RemoteDesktopSession struct {
 	Height             int
 	TileSize           int
 	ClipQuality        int
+	BaseClipQuality    int
 	FrameInterval      time.Duration
 	Sequence           uint64
 	LastFrame          []byte


### PR DESCRIPTION
## Summary
- track the baseline clip quality for each remote desktop session so we can reason about recovery targets
- extend the auto quality controller to adapt clip quality, tile size, and frame cadence before scaling resolution or bitrate, improving resilience under poor networks

## Testing
- `cd tenvy-client && go test ./internal/modules/control/remotedesktop`


------
https://chatgpt.com/codex/tasks/task_e_68e78330fef4832b906944d2e27b638a