### PR TITLE
Handle case-insensitive environment overrides

### DIFF
--- a/tenvy-client/internal/agent/commands.go
+++ b/tenvy-client/internal/agent/commands.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -252,28 +253,68 @@ func runShell(ctx context.Context, command string, options shellExecutionOptions
 }
 
 func mergeEnvironments(base []string, overrides map[string]string) []string {
-	if len(overrides) == 0 {
-		return base
+	return mergeEnvironmentsWithComparer(base, overrides, runtime.GOOS == "windows")
+}
+
+func mergeEnvironmentsWithComparer(base []string, overrides map[string]string, caseInsensitive bool) []string {
+	type overrideEntry struct {
+		normalized string
+		key        string
+		value      string
 	}
 
-	env := make([]string, 0, len(base)+len(overrides))
-	for _, kv := range base {
-		key := kv
-		if idx := strings.IndexRune(kv, '='); idx >= 0 {
-			key = kv[:idx]
+	overrideIndex := make(map[string]int, len(overrides))
+	overrideEntries := make([]overrideEntry, 0, len(overrides))
+	normalizeKey := func(key string) string {
+		if caseInsensitive {
+			return strings.ToLower(key)
 		}
-		if _, ok := overrides[key]; ok {
+		return key
+	}
+
+	for key, value := range overrides {
+		trimmedKey := strings.TrimSpace(key)
+		if trimmedKey == "" {
 			continue
+		}
+		normalizedKey := normalizeKey(trimmedKey)
+		entry := overrideEntry{normalized: normalizedKey, key: trimmedKey, value: value}
+		if idx, exists := overrideIndex[normalizedKey]; exists {
+			overrideEntries[idx] = entry
+			continue
+		}
+		overrideIndex[normalizedKey] = len(overrideEntries)
+		overrideEntries = append(overrideEntries, entry)
+	}
+
+	sort.SliceStable(overrideEntries, func(i, j int) bool {
+		return overrideEntries[i].key < overrideEntries[j].key
+	})
+
+	env := make([]string, 0, len(base)+len(overrideEntries))
+	seenKeys := make(map[string]struct{}, len(base))
+
+	for _, kv := range base {
+		keyPortion := kv
+		if idx := strings.IndexRune(kv, '='); idx >= 0 {
+			keyPortion = kv[:idx]
+		}
+		trimmedKey := strings.TrimSpace(keyPortion)
+		normalizedKey := normalizeKey(trimmedKey)
+		if normalizedKey != "" {
+			if _, overridden := overrideIndex[normalizedKey]; overridden {
+				continue
+			}
+			if _, seen := seenKeys[normalizedKey]; seen {
+				continue
+			}
+			seenKeys[normalizedKey] = struct{}{}
 		}
 		env = append(env, kv)
 	}
 
-	for key, value := range overrides {
-		trimmed := strings.TrimSpace(key)
-		if trimmed == "" {
-			continue
-		}
-		env = append(env, fmt.Sprintf("%s=%s", trimmed, value))
+	for _, entry := range overrideEntries {
+		env = append(env, fmt.Sprintf("%s=%s", entry.key, entry.value))
 	}
 
 	return env

--- a/tenvy-client/internal/agent/commands_test.go
+++ b/tenvy-client/internal/agent/commands_test.go
@@ -1,0 +1,42 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeEnvironmentsCaseSensitive(t *testing.T) {
+	base := []string{"PATH=/usr/bin", "HOME=/home/test"}
+	overrides := map[string]string{"PATH": "/custom/bin", "EMPTY": ""}
+
+	got := mergeEnvironmentsWithComparer(base, overrides, false)
+	want := []string{"HOME=/home/test", "PATH=/custom/bin", "EMPTY="}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected environment merge result: got %v want %v", got, want)
+	}
+}
+
+func TestMergeEnvironmentsCaseInsensitive(t *testing.T) {
+	base := []string{"Path=/usr/bin", "ComSpec=C:/Windows/System32/cmd.exe"}
+	overrides := map[string]string{"PATH": `C:/Program Files/Custom/bin`}
+
+	got := mergeEnvironmentsWithComparer(base, overrides, true)
+	want := []string{"ComSpec=C:/Windows/System32/cmd.exe", "PATH=C:/Program Files/Custom/bin"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected environment merge result: got %v want %v", got, want)
+	}
+}
+
+func TestMergeEnvironmentsDeduplicatesBase(t *testing.T) {
+	base := []string{"A=1", "A=2", "B=3", " =invalid"}
+	overrides := map[string]string{"C": "4"}
+
+	got := mergeEnvironmentsWithComparer(base, overrides, false)
+	want := []string{"A=1", "B=3", " =invalid", "C=4"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected environment merge result: got %v want %v", got, want)
+	}
+}

--- a/tenvy-client/internal/agent/lifecycle_test.go
+++ b/tenvy-client/internal/agent/lifecycle_test.go
@@ -1,0 +1,82 @@
+package agent
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rootbay/tenvy-client/internal/protocol"
+)
+
+func makeCommandResult(id string) protocol.CommandResult {
+	return protocol.CommandResult{CommandID: id}
+}
+
+func TestEnqueueResultTrimsToMax(t *testing.T) {
+	var a Agent
+	for i := 0; i < maxBufferedResults; i++ {
+		a.pendingResults = append(a.pendingResults, makeCommandResult(fmt.Sprintf("cmd-%d", i)))
+	}
+
+	extra := makeCommandResult("cmd-extra")
+	a.enqueueResult(extra)
+
+	if len(a.pendingResults) != maxBufferedResults {
+		t.Fatalf("unexpected pending results length: got %d want %d", len(a.pendingResults), maxBufferedResults)
+	}
+
+	first := a.pendingResults[0].CommandID
+	if first != "cmd-1" {
+		t.Fatalf("unexpected first command id after trim: got %q want %q", first, "cmd-1")
+	}
+
+	last := a.pendingResults[len(a.pendingResults)-1].CommandID
+	if last != extra.CommandID {
+		t.Fatalf("expected last command to be new result: got %q want %q", last, extra.CommandID)
+	}
+}
+
+func TestEnqueueResultsBatched(t *testing.T) {
+	var a Agent
+	initial := makeCommandResult("cmd-0")
+	a.pendingResults = append(a.pendingResults, initial)
+
+	batch := []protocol.CommandResult{
+		makeCommandResult("cmd-1"),
+		makeCommandResult("cmd-2"),
+	}
+	a.enqueueResults(batch)
+
+	if len(a.pendingResults) != 3 {
+		t.Fatalf("unexpected pending results length: got %d want %d", len(a.pendingResults), 3)
+	}
+
+	for idx, want := range []string{"cmd-0", "cmd-1", "cmd-2"} {
+		if got := a.pendingResults[idx].CommandID; got != want {
+			t.Fatalf("unexpected command id at index %d: got %q want %q", idx, got, want)
+		}
+	}
+}
+
+func TestEnqueueResultsLargeBatch(t *testing.T) {
+	var a Agent
+	batch := make([]protocol.CommandResult, maxBufferedResults+10)
+	for i := range batch {
+		batch[i] = makeCommandResult(fmt.Sprintf("cmd-%d", i))
+	}
+
+	a.enqueueResults(batch)
+
+	if len(a.pendingResults) != maxBufferedResults {
+		t.Fatalf("unexpected pending results length: got %d want %d", len(a.pendingResults), maxBufferedResults)
+	}
+
+	expectedFirst := fmt.Sprintf("cmd-%d", len(batch)-maxBufferedResults)
+	if got := a.pendingResults[0].CommandID; got != expectedFirst {
+		t.Fatalf("unexpected first command id after trimming batch: got %q want %q", got, expectedFirst)
+	}
+
+	expectedLast := fmt.Sprintf("cmd-%d", len(batch)-1)
+	if got := a.pendingResults[len(a.pendingResults)-1].CommandID; got != expectedLast {
+		t.Fatalf("unexpected last command id after trimming batch: got %q want %q", got, expectedLast)
+	}
+}


### PR DESCRIPTION
## Summary
- improve shell command environment merging to honor case-insensitive variables on Windows and skip duplicate entries
- ignore empty override keys and provide deterministic ordering when composing the environment
- add focused unit tests that exercise case-sensitive, case-insensitive, and duplicate-handling behaviour
- batch pending result buffering under a single lock while trimming overflow deterministically
- add unit tests covering result queue trimming for single and batched enqueues

## Testing
- not run (go test ./... hung while compiling dependencies)
- not run (go test ./internal/agent -run TestEnqueue -count=1 -v hung while compiling dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68e7c70aab30832bae4de68c701b1639