### PR TITLE
Refactor agent command routing

### DIFF
--- a/tenvy-client/internal/agent/agent.go
+++ b/tenvy-client/internal/agent/agent.go
@@ -27,6 +27,7 @@ type Agent struct {
 	buildVersion   string
 	timing         TimingOverride
 	modules        *moduleRegistry
+	commands       *commandRouter
 }
 
 func (a *Agent) AgentID() string {

--- a/tenvy-client/internal/agent/command_router.go
+++ b/tenvy-client/internal/agent/command_router.go
@@ -1,0 +1,80 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rootbay/tenvy-client/internal/protocol"
+)
+
+type commandHandlerFunc func(context.Context, *Agent, protocol.Command) protocol.CommandResult
+
+type commandRouter struct {
+	handlers map[string]commandHandlerFunc
+}
+
+func newCommandRouter() *commandRouter {
+	return &commandRouter{handlers: make(map[string]commandHandlerFunc)}
+}
+
+func newDefaultCommandRouter() (*commandRouter, error) {
+	router := newCommandRouter()
+	builtins := map[string]commandHandlerFunc{
+		"ping":     pingCommandHandler,
+		"shell":    shellCommandHandler,
+		"open-url": openURLCommandHandler,
+	}
+
+	for name, handler := range builtins {
+		if err := router.register(name, handler); err != nil {
+			return nil, err
+		}
+	}
+
+	return router, nil
+}
+
+func (r *commandRouter) register(name string, handler commandHandlerFunc) error {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return fmt.Errorf("command name cannot be empty")
+	}
+	if handler == nil {
+		return fmt.Errorf("handler for command %q cannot be nil", trimmed)
+	}
+	if _, exists := r.handlers[trimmed]; exists {
+		return fmt.Errorf("command %q already registered", trimmed)
+	}
+	r.handlers[trimmed] = handler
+	return nil
+}
+
+func (r *commandRouter) dispatch(ctx context.Context, agent *Agent, cmd protocol.Command) protocol.CommandResult {
+	if r == nil {
+		return newFailureResult(cmd.ID, "command router not initialized")
+	}
+
+	if handler, ok := r.lookup(cmd.Name); ok {
+		return handler(ctx, agent, cmd)
+	}
+
+	if trimmed := strings.TrimSpace(cmd.Name); trimmed != cmd.Name {
+		if handler, ok := r.lookup(trimmed); ok {
+			return handler(ctx, agent, cmd)
+		}
+	}
+
+	if agent != nil && agent.modules != nil {
+		if handled, result := agent.modules.HandleCommand(ctx, cmd); handled {
+			return result
+		}
+	}
+
+	return newFailureResult(cmd.ID, fmt.Sprintf("unsupported command: %s", cmd.Name))
+}
+
+func (r *commandRouter) lookup(name string) (commandHandlerFunc, bool) {
+	handler, ok := r.handlers[name]
+	return handler, ok
+}

--- a/tenvy-client/internal/agent/command_router_test.go
+++ b/tenvy-client/internal/agent/command_router_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rootbay/tenvy-client/internal/protocol"
+)
+
+func TestCommandRouterDispatchesBuiltins(t *testing.T) {
+	router, err := newDefaultCommandRouter()
+	if err != nil {
+		t.Fatalf("newDefaultCommandRouter() error = %v", err)
+	}
+
+	agent := &Agent{commands: router}
+	cmd := protocol.Command{ID: "cmd-1", Name: "ping"}
+
+	result := router.dispatch(context.Background(), agent, cmd)
+	if !result.Success {
+		t.Fatalf("expected ping command to succeed, got result: %+v", result)
+	}
+	if result.Output != "pong" {
+		t.Fatalf("unexpected ping output: %q", result.Output)
+	}
+}
+
+func TestCommandRouterTrimsNameDuringDispatch(t *testing.T) {
+	router, err := newDefaultCommandRouter()
+	if err != nil {
+		t.Fatalf("newDefaultCommandRouter() error = %v", err)
+	}
+
+	cmd := protocol.Command{ID: "cmd-2", Name: "  shell  ", Payload: []byte(`{"command":"echo hi"}`)}
+	agent := &Agent{commands: router}
+
+	result := router.dispatch(context.Background(), agent, cmd)
+	if !result.Success {
+		t.Fatalf("expected trimmed shell command to succeed, got result: %+v", result)
+	}
+}
+
+func TestCommandRouterRejectsDuplicateRegistration(t *testing.T) {
+	router := newCommandRouter()
+	if err := router.register("ping", pingCommandHandler); err != nil {
+		t.Fatalf("unexpected error registering ping: %v", err)
+	}
+	if err := router.register("ping", pingCommandHandler); err == nil {
+		t.Fatalf("expected duplicate registration error")
+	}
+}
+
+func TestCommandRouterUnsupportedCommand(t *testing.T) {
+	router, err := newDefaultCommandRouter()
+	if err != nil {
+		t.Fatalf("newDefaultCommandRouter() error = %v", err)
+	}
+
+	cmd := protocol.Command{ID: "cmd-3", Name: "does-not-exist"}
+	result := router.dispatch(context.Background(), &Agent{commands: router}, cmd)
+	if result.Success {
+		t.Fatalf("expected unsupported command to fail, got %+v", result)
+	}
+	if result.Error == "" {
+		t.Fatalf("expected unsupported command to include error message")
+	}
+}

--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -73,6 +73,12 @@ func Run(ctx context.Context, opts RuntimeOptions) error {
 	}
 	agent.modules = modules
 
+	router, err := newDefaultCommandRouter()
+	if err != nil {
+		return fmt.Errorf("initialize commands: %w", err)
+	}
+	agent.commands = router
+
 	if notesPath, err := notes.DefaultPath(); err != nil {
 		opts.Logger.Printf("notes disabled (path error): %v", err)
 	} else {

--- a/tenvy-client/internal/agent/util.go
+++ b/tenvy-client/internal/agent/util.go
@@ -8,3 +8,7 @@ func minDuration(a, b time.Duration) time.Duration {
 	}
 	return b
 }
+
+func timestampNow() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}


### PR DESCRIPTION
## Summary
- introduce a reusable command router that registers built-in handlers and delegates to modules as a fallback
- convert ping, shell, and open-url handling into router-compatible functions and add focused command router tests
- initialize the router during agent startup and store it on the agent for consistent dispatching

## Testing
- go test ./... (from tenvy-client)


------
https://chatgpt.com/codex/tasks/task_e_68e93fa32c34832ba91027af27dfe292