### PR TITLE
Improve remote desktop session lifecycle and transport

### DIFF
--- a/tenvy-client/internal/modules/control/remotedesktop/types.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/types.go
@@ -206,7 +206,9 @@ type RemoteDesktopSession struct {
 	monitorInfos       []RemoteDesktopMonitorInfo
 	monitorsDirty      bool
 	lastMonitorRefresh time.Time
-	cancel             context.CancelFunc
+	ctx                context.Context
+	cancel             context.CancelCauseFunc
+	wg                 sync.WaitGroup
 }
 
 type remoteMonitor struct {
@@ -219,7 +221,8 @@ type RemoteDesktopStreamer struct {
 }
 
 type remoteDesktopSessionController struct {
-	cfg     atomic.Value // stores Config
-	mu      sync.Mutex
-	session *RemoteDesktopSession
+	cfg           atomic.Value // stores Config
+	mu            sync.Mutex
+	session       *RemoteDesktopSession
+	endpointCache atomic.Value
 }


### PR DESCRIPTION
## Summary
- add lifecycle management to the remote desktop session controller so stream goroutines are cancelled with context causes and waited on during stop/shutdown
- sanitize HTTP configuration, cache the frame upload endpoint, and bound response draining to tighten networking and security behaviour
- harden the streaming loop with panic recovery and frame buffer cleanup while reusing the existing adaptive encoding pipeline

## Testing
- go test ./... *(hangs on screenshot dependency in headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e96680c730832b9207114fe232df6a