### PR TITLE
Optimize remote desktop transport stack

### DIFF
--- a/docs/remote-desktop-optimizations.md
+++ b/docs/remote-desktop-optimizations.md
@@ -46,6 +46,7 @@ This note captures proposed optimizations for the Tenvy remote desktop pipeline.
 - Adopt QUIC or WebRTC data channels for combined NAT traversal, congestion control, and optional DTLS encryption.
 - Negotiate codec support and capabilities during session handshake; include encoder hardware telemetry for diagnostics.
 - Support intra-refresh or periodic intra frames to recover from packet loss without forcing full keyframe resets.
+- Harden HTTP fallbacks with aggressive connection pooling, TLS 1.2+ enforcement, and HTTP/2 to minimize handshake overhead when QUIC is unavailable.
 
 ## 6. Observability & Tuning
 
@@ -59,7 +60,7 @@ This note captures proposed optimizations for the Tenvy remote desktop pipeline.
 2. Introduce HEVC pipeline behind a feature flag; collect telemetry for success rates.
 3. Add adaptive bitrate controller and resolution ladder.
 4. Integrate dirty rectangle capture path and fallbacks.
-5. Harden transport (QUIC/WebRTC) and update UI controls.
+5. Harden transport (QUIC/WebRTC) and update UI controls while ensuring HTTP/TLS fallbacks share the optimized connection pool.
 6. Roll out observability dashboards and log sampling.
 
 These steps progressively reduce risk while delivering tangible improvements to the remote desktop experience.

--- a/tenvy-client/internal/modules/control/remotedesktop/controller.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/controller.go
@@ -812,7 +812,9 @@ func sanitizeConfig(cfg Config) Config {
 	cfg.AgentID = strings.TrimSpace(cfg.AgentID)
 	cfg.BaseURL = normalizeBaseURL(strings.TrimSpace(cfg.BaseURL))
 	cfg.AuthKey = strings.TrimSpace(cfg.AuthKey)
+	cfg.Client = secureHTTPClient(cfg.Client)
 	cfg.RequestTimeout = normalizeRequestTimeout(cfg.RequestTimeout)
+	cfg.authHeader = buildAuthHeader(cfg.AuthKey)
 	return cfg
 }
 

--- a/tenvy-client/internal/modules/control/remotedesktop/stream.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/stream.go
@@ -913,8 +913,8 @@ func (c *remoteDesktopSessionController) sendFrame(ctx context.Context, frame Re
 	if ua := strings.TrimSpace(c.userAgent()); ua != "" {
 		req.Header.Set("User-Agent", ua)
 	}
-	if key := strings.TrimSpace(cfg.AuthKey); key != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
+	if cfg.authHeader != "" {
+		req.Header.Set("Authorization", cfg.authHeader)
 	}
 
 	resp, err := client.Do(req)

--- a/tenvy-client/internal/modules/control/remotedesktop/transport.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/transport.go
@@ -1,0 +1,108 @@
+package remotedesktop
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	defaultDialTimeout     = 10 * time.Second
+	defaultDialKeepAlive   = 30 * time.Second
+	defaultIdleConnTimeout = 90 * time.Second
+	defaultTLSHandshake    = 10 * time.Second
+	defaultExpectContinue  = 1 * time.Second
+	minimumMaxIdleConns    = 64
+	minimumMaxIdlePerHost  = 16
+)
+
+func secureHTTPClient(doer HTTPDoer) HTTPDoer {
+	client, ok := doer.(*http.Client)
+	if !ok {
+		if doer != nil {
+			return doer
+		}
+		client = &http.Client{}
+	} else {
+		client = cloneHTTPClient(client)
+	}
+
+	if client.Timeout <= 0 {
+		client.Timeout = defaultFrameRequestTimeout
+	}
+
+	client.Transport = secureHTTPTransport(client.Transport)
+	return client
+}
+
+func secureHTTPTransport(rt http.RoundTripper) http.RoundTripper {
+	transport, ok := rt.(*http.Transport)
+	switch {
+	case ok:
+		transport = transport.Clone()
+	case rt == nil:
+		defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+		if !ok {
+			return rt
+		}
+		transport = defaultTransport.Clone()
+	default:
+		return rt
+	}
+
+	if transport.DialContext == nil {
+		transport.DialContext = (&net.Dialer{
+			Timeout:   defaultDialTimeout,
+			KeepAlive: defaultDialKeepAlive,
+		}).DialContext
+	}
+
+	if transport.MaxIdleConns < minimumMaxIdleConns {
+		transport.MaxIdleConns = minimumMaxIdleConns
+	}
+	if transport.MaxIdleConnsPerHost < minimumMaxIdlePerHost {
+		transport.MaxIdleConnsPerHost = minimumMaxIdlePerHost
+	}
+	if transport.IdleConnTimeout <= 0 {
+		transport.IdleConnTimeout = defaultIdleConnTimeout
+	}
+	if transport.TLSHandshakeTimeout <= 0 {
+		transport.TLSHandshakeTimeout = defaultTLSHandshake
+	}
+	if transport.ExpectContinueTimeout <= 0 {
+		transport.ExpectContinueTimeout = defaultExpectContinue
+	}
+
+	transport.ForceAttemptHTTP2 = true
+
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	} else {
+		cfg := transport.TLSClientConfig.Clone()
+		if cfg.MinVersion < tls.VersionTLS12 {
+			cfg.MinVersion = tls.VersionTLS12
+		}
+		transport.TLSClientConfig = cfg
+	}
+
+	return transport
+}
+
+func buildAuthHeader(key string) string {
+	trimmed := strings.TrimSpace(key)
+	if trimmed == "" {
+		return ""
+	}
+	return fmt.Sprintf("Bearer %s", trimmed)
+}
+
+func cloneHTTPClient(base *http.Client) *http.Client {
+	if base == nil {
+		return &http.Client{}
+	}
+	clone := *base
+	return &clone
+}

--- a/tenvy-client/internal/modules/control/remotedesktop/types.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/types.go
@@ -32,6 +32,7 @@ type Config struct {
 	Logger         Logger
 	UserAgent      string
 	RequestTimeout time.Duration
+	authHeader     string
 }
 
 type RemoteDesktopQuality string


### PR DESCRIPTION
## Summary
- Harden default HTTP client settings with connection pooling, TLS 1.2 minimums, and HTTP/2 for the agent runtime.
- Sanitize remote desktop transport configuration, caching authorization headers, and sharing the tuned HTTP client defaults.
- Update the remote desktop optimization guide to call out the new transport hardening strategy.

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68e984ba3194832b98954247505a361c