### PR TITLE
Improve audio device enumeration reliability

### DIFF
--- a/tenvy-client/internal/modules/control/audio/backends.go
+++ b/tenvy-client/internal/modules/control/audio/backends.go
@@ -1,0 +1,43 @@
+//go:build cgo
+
+package audio
+
+import (
+	"runtime"
+
+	"github.com/gen2brain/malgo"
+)
+
+func fallbackAudioBackendAttempts() [][]malgo.Backend {
+	switch runtime.GOOS {
+	case "windows":
+		return [][]malgo.Backend{
+			{malgo.BackendWasapi},
+			{malgo.BackendDsound},
+			{malgo.BackendWinmm},
+		}
+	case "darwin":
+		return [][]malgo.Backend{
+			{malgo.BackendCoreAudio},
+		}
+	case "android":
+		return [][]malgo.Backend{
+			{malgo.BackendAAudio},
+			{malgo.BackendOpenSLES},
+		}
+	case "linux":
+		fallthrough
+	case "freebsd":
+		fallthrough
+	case "openbsd":
+		fallthrough
+	case "netbsd":
+		return [][]malgo.Backend{
+			{malgo.BackendPulseAudio},
+			{malgo.BackendAlsa},
+			{malgo.BackendJack},
+		}
+	default:
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary
- try operating-system specific malgo backend combinations when capturing the audio inventory
- reuse a shared inventory enumerator that tolerates partial backend failures before falling back

## Testing
- ⚠️ `go test ./...` *(hangs in this environment; aborted after timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68ea9abf0ed0832bb7a647bd89d13526