### PR TITLE
Add direct agent reconnect and disconnect actions

### DIFF
--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -48,3 +48,13 @@ export interface AgentListResponse {
 export interface AgentDetailResponse {
         agent: AgentSnapshot;
 }
+
+export type AgentConnectionAction = 'disconnect' | 'reconnect';
+
+export interface AgentConnectionRequest {
+        action: AgentConnectionAction;
+}
+
+export interface AgentConnectionResponse {
+        agent: AgentSnapshot;
+}

--- a/tenvy-server/src/lib/server/rat/store.ts
+++ b/tenvy-server/src/lib/server/rat/store.ts
@@ -169,6 +169,32 @@ export class AgentRegistry {
 		return { command };
 	}
 
+	disconnectAgent(id: string): AgentSnapshot {
+		const record = this.agents.get(id);
+		if (!record) {
+			throw new RegistryError('Agent not found', 404);
+		}
+
+		record.status = 'offline';
+		record.lastSeen = new Date();
+
+		return this.toSnapshot(record);
+	}
+
+	reconnectAgent(id: string): AgentSnapshot {
+		const record = this.agents.get(id);
+		if (!record) {
+			throw new RegistryError('Agent not found', 404);
+		}
+
+		const now = new Date();
+		record.status = 'online';
+		record.connectedAt = now;
+		record.lastSeen = now;
+
+		return this.toSnapshot(record);
+	}
+
 	listAgents(): AgentSnapshot[] {
 		return Array.from(this.agents.values()).map((record) => this.toSnapshot(record));
 	}

--- a/tenvy-server/src/routes/api/agents/[id]/connection/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/connection/+server.ts
@@ -1,0 +1,42 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { registry, RegistryError } from '$lib/server/rat/store';
+import type {
+	AgentConnectionAction,
+	AgentConnectionRequest,
+	AgentConnectionResponse
+} from '../../../../../../../shared/types/agent';
+
+function isConnectionAction(value: unknown): value is AgentConnectionAction {
+	return value === 'disconnect' || value === 'reconnect';
+}
+
+export const POST: RequestHandler = async ({ params, request }) => {
+	const id = params.id;
+	if (!id) {
+		throw error(400, 'Missing agent identifier');
+	}
+
+	let payload: AgentConnectionRequest;
+	try {
+		payload = (await request.json()) as AgentConnectionRequest;
+	} catch (err) {
+		throw error(400, 'Invalid connection request payload');
+	}
+
+	if (!isConnectionAction(payload?.action)) {
+		throw error(400, 'Unsupported connection action');
+	}
+
+	try {
+		const agent =
+			payload.action === 'disconnect' ? registry.disconnectAgent(id) : registry.reconnectAgent(id);
+
+		return json({ agent } satisfies AgentConnectionResponse);
+	} catch (err) {
+		if (err instanceof RegistryError) {
+			throw error(err.status, err.message);
+		}
+		throw error(500, 'Failed to update agent connection');
+	}
+};


### PR DESCRIPTION
## Summary
- add shared connection request/response types and server endpoint for reconnecting or disconnecting agents
- extend the in-memory registry with explicit reconnect and disconnect helpers
- trigger the new actions directly from the clients table and context menu without opening placeholder routes

## Testing
- bun run lint *(fails: existing lint violations in untouched files)*
- bun run check

------
https://chatgpt.com/codex/tasks/task_e_68eaa69a7f8c832bb1b4a50e17f02eef