### PR TITLE
Remove disconnected agents from registry and alert empty state

### DIFF
--- a/tenvy-server/src/lib/server/rat/store.ts
+++ b/tenvy-server/src/lib/server/rat/store.ts
@@ -178,7 +178,10 @@ export class AgentRegistry {
 		record.status = 'offline';
 		record.lastSeen = new Date();
 
-		return this.toSnapshot(record);
+		const snapshot = this.toSnapshot(record);
+		this.agents.delete(id);
+
+		return snapshot;
 	}
 
 	reconnectAgent(id: string): AgentSnapshot {

--- a/tenvy-server/src/routes/(app)/clients/+page.svelte
+++ b/tenvy-server/src/routes/(app)/clients/+page.svelte
@@ -2,13 +2,6 @@
 	import { browser } from '$app/environment';
 	import { goto, invalidateAll } from '$app/navigation';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import {
-		Card,
-		CardDescription,
-		CardFooter,
-		CardHeader,
-		CardTitle
-	} from '$lib/components/ui/card/index.js';
 	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
@@ -649,19 +642,18 @@
 
 <section class="space-y-6">
 	{#if $clientsTable.agents.length === 0}
-		<Card class="border-dashed border-border/60">
-			<CardHeader>
-				<CardTitle>No agents connected</CardTitle>
-				<CardDescription>
-					Launch a client instance to have it register and appear here automatically.
-				</CardDescription>
-			</CardHeader>
-			<CardFooter>
+		<Alert class="border-dashed border-border/60">
+			<AlertCircle class="h-4 w-4" />
+			<AlertTitle>No agents connected</AlertTitle>
+			<AlertDescription>
+				Launch a client instance to have it register and appear here automatically.
+			</AlertDescription>
+			<div class="col-start-2 mt-3">
 				<Button type="button" onclick={() => (deployDialogOpen = true)}>
 					View deployment guide
 				</Button>
-			</CardFooter>
-		</Card>
+			</div>
+		</Alert>
 	{/if}
 
 	<div class="space-y-4 rounded-lg border border-border/60 bg-background/60 p-4">


### PR DESCRIPTION
## Summary
- delete disconnected agents from the registry so their rows disappear when the controller ends a session
- replace the empty-clients card with a shadcn Alert while keeping the deployment guide action visible

## Testing
- bun format
- bun lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68eaac330548832b8dfeb9d6c5feeff8