### PR TITLE
Display public IP and latency in clients table

### DIFF
--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -16,6 +16,7 @@ export interface AgentMetadata {
         os: string;
         architecture: string;
         ipAddress?: string;
+        publicIpAddress?: string;
         tags?: string[];
         version?: string;
         group?: string;

--- a/tenvy-client/internal/protocol/types.go
+++ b/tenvy-client/internal/protocol/types.go
@@ -35,13 +35,14 @@ type CommandResult struct {
 }
 
 type AgentMetadata struct {
-	Hostname     string   `json:"hostname"`
-	Username     string   `json:"username"`
-	OS           string   `json:"os"`
-	Architecture string   `json:"architecture"`
-	IPAddress    string   `json:"ipAddress,omitempty"`
-	Tags         []string `json:"tags,omitempty"`
-	Version      string   `json:"version,omitempty"`
+	Hostname        string   `json:"hostname"`
+	Username        string   `json:"username"`
+	OS              string   `json:"os"`
+	Architecture    string   `json:"architecture"`
+	IPAddress       string   `json:"ipAddress,omitempty"`
+	PublicIPAddress string   `json:"publicIpAddress,omitempty"`
+	Tags            []string `json:"tags,omitempty"`
+	Version         string   `json:"version,omitempty"`
 }
 
 type AgentRegistrationRequest struct {

--- a/tenvy-server/src/lib/components/clients/clients-table-row.svelte
+++ b/tenvy-server/src/lib/components/clients/clients-table-row.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
-        import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
-        import {
-                ContextMenu,
-                ContextMenuContent,
-                ContextMenuItem,
-                ContextMenuSeparator,
-                ContextMenuSub,
-                ContextMenuSubContent,
-                ContextMenuSubTrigger,
-                ContextMenuTrigger
-        } from '$lib/components/ui/context-menu/index.js';
-        import { TableCell, TableRow } from '$lib/components/ui/table/index.js';
-        import OsLogo from '$lib/components/os-logo.svelte';
-        import { cn } from '$lib/utils.js';
-        import type { AgentSnapshot } from '../../../../../shared/types/agent';
-        import type { SectionKey } from '$lib/client-sections';
+	import { ContextMenu as ContextMenuPrimitive } from 'bits-ui';
+	import {
+		ContextMenu,
+		ContextMenuContent,
+		ContextMenuItem,
+		ContextMenuSeparator,
+		ContextMenuSub,
+		ContextMenuSubContent,
+		ContextMenuSubTrigger,
+		ContextMenuTrigger
+	} from '$lib/components/ui/context-menu/index.js';
+	import { TableCell, TableRow } from '$lib/components/ui/table/index.js';
+	import OsLogo from '$lib/components/os-logo.svelte';
+	import { cn } from '$lib/utils.js';
+	import type { AgentSnapshot } from '../../../../../shared/types/agent';
+	import type { SectionKey } from '$lib/client-sections';
 
-        type TriggerChildProps = Parameters<NonNullable<ContextMenuPrimitive.TriggerProps['child']>>[0];
+	type TriggerChildProps = Parameters<NonNullable<ContextMenuPrimitive.TriggerProps['child']>>[0];
 
 	export let agent: AgentSnapshot;
 	export let openSection: (section: SectionKey, agent: AgentSnapshot) => void;
@@ -28,46 +28,46 @@
 </script>
 
 {#snippet TriggerChild({ props }: TriggerChildProps)}
-        {@const className = cn('cursor-context-menu', (props as { class?: string }).class)}
-        <TableRow {...props} class={className} tabindex={0}>
-            <TableCell>
-				<div class="flex items-center gap-3">
-					<span class="text-2xl" aria-hidden="true">{getAgentLocation(agent).flag}</span>
-					<div class="flex flex-col">
-						<span class="text-sm font-medium text-foreground">{getAgentLocation(agent).label}</span>
-						{#if agent.metadata.hostname}
-							<span class="text-xs text-muted-foreground">{agent.metadata.hostname}</span>
-						{/if}
-					</div>
+	{@const className = cn('cursor-context-menu', (props as { class?: string }).class)}
+	<TableRow {...props} class={className} tabindex={0}>
+		<TableCell>
+			<div class="flex items-center gap-3">
+				<span class="text-2xl" aria-hidden="true">{getAgentLocation(agent).flag}</span>
+				<div class="flex flex-col">
+					<span class="text-sm font-medium text-foreground">{getAgentLocation(agent).label}</span>
+					{#if agent.metadata.hostname}
+						<span class="text-xs text-muted-foreground">{agent.metadata.hostname}</span>
+					{/if}
 				</div>
-			</TableCell>
-			<TableCell class="text-sm text-muted-foreground">
-				{agent.metadata.ipAddress ?? 'Unknown'}
-			</TableCell>
-			<TableCell class="text-sm text-muted-foreground">
-				{agent.metadata.username}
-			</TableCell>
-			<TableCell class="text-sm text-muted-foreground">
-				{getAgentGroup(agent)}
-			</TableCell>
-			<TableCell class="text-center">
-				<OsLogo os={agent.metadata.os} />
-			</TableCell>
-			<TableCell class="text-sm text-muted-foreground">
-				{formatPing(agent)}
-			</TableCell>
-			<TableCell class="text-sm text-muted-foreground">
-				{agent.metadata.version ?? '—'}
-			</TableCell>
-			<TableCell class="text-sm text-muted-foreground">
-				{formatDate(agent.connectedAt)}
-			</TableCell>
-		</TableRow>
+			</div>
+		</TableCell>
+		<TableCell class="text-sm text-muted-foreground">
+			{agent.metadata.publicIpAddress ?? agent.metadata.ipAddress ?? 'Unknown'}
+		</TableCell>
+		<TableCell class="text-sm text-muted-foreground">
+			{agent.metadata.username}
+		</TableCell>
+		<TableCell class="text-sm text-muted-foreground">
+			{getAgentGroup(agent)}
+		</TableCell>
+		<TableCell class="text-center">
+			<OsLogo os={agent.metadata.os} />
+		</TableCell>
+		<TableCell class="text-sm text-muted-foreground">
+			{formatPing(agent)}
+		</TableCell>
+		<TableCell class="text-sm text-muted-foreground">
+			{agent.metadata.version ?? '—'}
+		</TableCell>
+		<TableCell class="text-sm text-muted-foreground">
+			{formatDate(agent.connectedAt)}
+		</TableCell>
+	</TableRow>
 {/snippet}
 
 <ContextMenu>
-    <ContextMenuTrigger child={TriggerChild} />
-    <ContextMenuContent class="w-56">
+	<ContextMenuTrigger child={TriggerChild} />
+	<ContextMenuContent class="w-56">
 		<ContextMenuItem onSelect={() => openSection('systemInfo', agent)}>System Info</ContextMenuItem>
 		<ContextMenuItem onSelect={() => openSection('notes', agent)}>Notes</ContextMenuItem>
 

--- a/tenvy-server/src/lib/stores/clients-table.ts
+++ b/tenvy-server/src/lib/stores/clients-table.ts
@@ -48,6 +48,7 @@ function matchesQuery(agent: AgentSnapshot, query: string): boolean {
 		agent.metadata.username,
 		agent.metadata.os,
 		agent.metadata.ipAddress,
+		agent.metadata.publicIpAddress,
 		...(agent.metadata.tags ?? [])
 	]
 		.filter(Boolean)

--- a/tenvy-server/src/routes/(app)/clients/+page.svelte
+++ b/tenvy-server/src/routes/(app)/clients/+page.svelte
@@ -233,9 +233,9 @@
 	}
 
 	function formatPing(agent: AgentSnapshot): string {
-		const ping = agent.metrics?.pingMs ?? agent.metrics?.latencyMs;
-		if (typeof ping === 'number' && Number.isFinite(ping) && ping >= 0) {
-			return `${Math.round(ping)} ms`;
+		const latency = agent.metrics?.latencyMs ?? agent.metrics?.pingMs;
+		if (typeof latency === 'number' && Number.isFinite(latency) && latency >= 0) {
+			return `${Math.round(latency)} ms`;
 		}
 		return '—';
 	}
@@ -557,7 +557,7 @@
 			id: agent.id,
 			codename: agent.metadata.hostname?.toUpperCase() ?? agent.id.toUpperCase(),
 			hostname: agent.metadata.hostname,
-			ip: agent.metadata.ipAddress ?? 'Unknown',
+			ip: agent.metadata.publicIpAddress ?? agent.metadata.ipAddress ?? 'Unknown',
 			location: getAgentLocation(agent).label,
 			os: agent.metadata.os,
 			platform: inferClientPlatform(agent.metadata.os),
@@ -777,7 +777,7 @@
 					<TableHeader>
 						<TableRow>
 							<TableHead class="w-[22rem]">Location</TableHead>
-							<TableHead class="w-[8rem]">IP</TableHead>
+							<TableHead class="w-[8rem]">Public IP</TableHead>
 							<TableHead class="w-[12rem]">Username</TableHead>
 							<TableHead class="w-[12rem]">Group</TableHead>
 							<TableHead class="w-[7rem] text-center">OS</TableHead>

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/+layout.ts
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/+layout.ts
@@ -44,7 +44,7 @@ function mapAgentToClient(agent: AgentSnapshot): Client {
 		id: agent.id,
 		codename: hostname.toUpperCase(),
 		hostname,
-		ip: agent.metadata.ipAddress ?? 'Unknown',
+		ip: agent.metadata.publicIpAddress ?? agent.metadata.ipAddress ?? 'Unknown',
 		location: 'Unknown',
 		os: agent.metadata.os,
 		platform: inferClientPlatform(agent.metadata.os),

--- a/tenvy-server/src/routes/api/agents/[id]/sync/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/sync/+server.ts
@@ -11,7 +11,7 @@ function getBearerToken(header: string | null): string | undefined {
 	return match?.[1]?.trim();
 }
 
-export const POST: RequestHandler = async ({ params, request }) => {
+export const POST: RequestHandler = async ({ params, request, getClientAddress }) => {
 	const id = params.id;
 	if (!id) {
 		throw error(400, 'Missing agent identifier');
@@ -30,7 +30,9 @@ export const POST: RequestHandler = async ({ params, request }) => {
 	}
 
 	try {
-		const response = registry.syncAgent(id, token, payload);
+		const response = registry.syncAgent(id, token, payload, {
+			remoteAddress: getClientAddress()
+		});
 		return json(response);
 	} catch (err) {
 		if (err instanceof RegistryError) {


### PR DESCRIPTION
## Summary
- add a publicIpAddress field to shared agent metadata and the Go client protocol
- propagate the controller connection address through the registry and sync handler so public IPs stay updated
- show the public IP and latency in the clients table/detail view and include the new field in filtering

## Testing
- bun format
- bunx prettier --check src/lib/components/clients/clients-table-row.svelte 'src/routes/(app)/clients/+page.svelte' src/lib/stores/clients-table.ts src/lib/server/rat/store.ts 'src/routes/api/agents/[id]/sync/+server.ts'


------
https://chatgpt.com/codex/tasks/task_e_68eac0d97b50832baea3bcbe97fa7a4f