### PR TITLE
Implement dynamic dashboard metrics

### DIFF
--- a/tenvy-server/bun.lock
+++ b/tenvy-server/bun.lock
@@ -9,6 +9,7 @@
         "@simplewebauthn/browser": "^13.2.2",
         "@simplewebauthn/server": "^13.2.2",
         "better-sqlite3": "^12.4.1",
+        "d3-geo": "^3.1.1",
         "jszip": "^3.10.1",
         "lucia": "^3.2.2",
         "otplib": "^12.0.1",
@@ -16,6 +17,8 @@
         "rate-limiter-flexible": "^8.0.1",
         "shell-quote": "^1.8.3",
         "systeminformation": "^5.27.11",
+        "topojson-client": "^3.1.0",
+        "world-atlas": "^2.0.2",
         "zod": "^4.1.12",
       },
       "devDependencies": {
@@ -28,12 +31,16 @@
         "@oslojs/encoding": "^1.1.0",
         "@playwright/test": "^1.56.0",
         "@sveltejs/adapter-auto": "^6.1.1",
-        "@sveltejs/kit": "^2.46.2",
+        "@sveltejs/kit": "^2.46.4",
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@tailwindcss/vite": "^4.1.14",
         "@types/better-sqlite3": "^7.6.13",
+        "@types/d3-geo": "^3.1.0",
+        "@types/geojson": "^7946.0.16",
         "@types/jszip": "^3.4.1",
         "@types/node": "^24.7.0",
+        "@types/topojson-client": "^3.1.5",
+        "@types/topojson-specification": "^1.0.5",
         "@vitest/browser": "^3.2.4",
         "bits-ui": "^2.11.4",
         "clsx": "^2.1.1",
@@ -50,8 +57,8 @@
         "prettier": "^3.6.2",
         "prettier-plugin-svelte": "^3.4.0",
         "prettier-plugin-tailwindcss": "^0.6.14",
-        "svelte": "^5.39.10",
-        "svelte-check": "^4.3.2",
+        "svelte": "^5.39.11",
+        "svelte-check": "^4.3.3",
         "svelte-sonner": "^1.0.5",
         "tailwind-merge": "^3.3.1",
         "tailwind-variants": "^3.1.1",
@@ -408,15 +415,23 @@
 
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/jszip": ["@types/jszip@3.4.1", "", { "dependencies": { "jszip": "*" } }, "sha512-TezXjmf3lj+zQ651r6hPqvSScqBLvyPI9FxdXBqpEwBijNGQ2NXpaFW/7joGzveYkKQUil7iiDHLo6LV71Pc0A=="],
 
     "@types/node": ["@types/node@24.7.0", "", { "dependencies": { "undici-types": "~7.14.0" } }, "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw=="],
+
+    "@types/topojson-client": ["@types/topojson-client@3.1.5", "", { "dependencies": { "@types/geojson": "*", "@types/topojson-specification": "*" } }, "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw=="],
+
+    "@types/topojson-specification": ["@types/topojson-specification@1.0.5", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.46.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.46.0", "@typescript-eslint/type-utils": "8.46.0", "@typescript-eslint/utils": "8.46.0", "@typescript-eslint/visitor-keys": "8.46.0", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.46.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-hA8gxBq4ukonVXPy0OKhiaUh/68D0E88GSmtC1iAEnGaieuDi38LhS7jdCHRLi6ErJBNDGCzvh5EnzdPwUc0DA=="],
 
@@ -1028,6 +1043,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "topojson-client": ["topojson-client@3.1.0", "", { "dependencies": { "commander": "2" }, "bin": { "topo2geo": "bin/topo2geo", "topomerge": "bin/topomerge", "topoquantize": "bin/topoquantize" } }, "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw=="],
+
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
@@ -1075,6 +1092,8 @@
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "world-atlas": ["world-atlas@2.0.2", "", {}, "sha512-IXfV0qwlKXpckz1FhwXVwKRjiIhOnWttOskm5CtxMsjgE/MXAYRHWJqgXOpM8IkcPBoXnyTU5lFHcYa5ChG0LQ=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -1149,6 +1168,8 @@
     "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "topojson-client/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 

--- a/tenvy-server/package.json
+++ b/tenvy-server/package.json
@@ -34,8 +34,12 @@
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@tailwindcss/vite": "^4.1.14",
 		"@types/better-sqlite3": "^7.6.13",
+		"@types/d3-geo": "^3.1.0",
+		"@types/geojson": "^7946.0.16",
 		"@types/jszip": "^3.4.1",
 		"@types/node": "^24.7.0",
+		"@types/topojson-client": "^3.1.5",
+		"@types/topojson-specification": "^1.0.5",
 		"@vitest/browser": "^3.2.4",
 		"bits-ui": "^2.11.4",
 		"clsx": "^2.1.1",
@@ -71,6 +75,7 @@
 		"@simplewebauthn/browser": "^13.2.2",
 		"@simplewebauthn/server": "^13.2.2",
 		"better-sqlite3": "^12.4.1",
+		"d3-geo": "^3.1.1",
 		"jszip": "^3.10.1",
 		"lucia": "^3.2.2",
 		"otplib": "^12.0.1",
@@ -78,6 +83,8 @@
 		"rate-limiter-flexible": "^8.0.1",
 		"shell-quote": "^1.8.3",
 		"systeminformation": "^5.27.11",
+		"topojson-client": "^3.1.0",
+		"world-atlas": "^2.0.2",
 		"zod": "^4.1.12"
 	}
 }

--- a/tenvy-server/src/lib/components/dashboard/client-presence-map.svelte
+++ b/tenvy-server/src/lib/components/dashboard/client-presence-map.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+	import type { DashboardClient } from '$lib/data/dashboard';
+	import type { ClientStatus } from '$lib/data/clients';
+	import { geoNaturalEarth1, geoPath, geoGraticule10 } from 'd3-geo';
+	import { feature } from 'topojson-client';
+	import type { Feature, FeatureCollection, GeoJsonProperties, Geometry } from 'geojson';
+	import type {
+		GeometryCollection as TopologyGeometryCollection,
+		Objects,
+		Topology
+	} from 'topojson-specification';
+	import world from 'world-atlas/countries-110m.json';
+
+	type Marker = {
+		client: DashboardClient;
+		x: number;
+		y: number;
+		style: { dot: string; halo: string; stroke: string };
+	};
+
+	type WorldProperties = GeoJsonProperties & {
+		name?: string;
+	};
+
+	type WorldObjects = Objects<WorldProperties>;
+	type WorldGeometryCollection = TopologyGeometryCollection<WorldProperties>;
+
+	export let clients: DashboardClient[] = [];
+	export let highlightCountry: string | null = null;
+
+	const width = 860;
+	const height = 460;
+
+	const topology = world as unknown as Topology<WorldObjects>;
+	const countriesObject = topology.objects.countries as WorldGeometryCollection;
+	const worldFeatures = feature(topology, countriesObject) as FeatureCollection<
+		Geometry,
+		WorldProperties
+	>;
+
+	const projection = geoNaturalEarth1().fitExtent(
+		[
+			[20, 20],
+			[width - 20, height - 20]
+		],
+		worldFeatures
+	);
+	const pathGenerator = geoPath(projection);
+	const graticulePath = pathGenerator(geoGraticule10()) ?? '';
+	const landPaths = worldFeatures.features.map(
+		(entry: Feature<Geometry, WorldProperties>, index: number) => ({
+			id: String(entry.id ?? entry.properties?.name ?? index),
+			d: pathGenerator(entry) ?? ''
+		})
+	);
+
+	const statusStyles: Record<ClientStatus, Marker['style']> = {
+		online: {
+			dot: 'rgb(16 185 129)',
+			halo: 'rgba(16, 185, 129, 0.18)',
+			stroke: 'rgba(16, 185, 129, 0.55)'
+		},
+		idle: {
+			dot: 'rgb(56 189 248)',
+			halo: 'rgba(56, 189, 248, 0.22)',
+			stroke: 'rgba(56, 189, 248, 0.5)'
+		},
+		dormant: {
+			dot: 'rgb(245 158 11)',
+			halo: 'rgba(245, 158, 11, 0.22)',
+			stroke: 'rgba(245, 158, 11, 0.55)'
+		},
+		offline: {
+			dot: 'rgb(148 163 184)',
+			halo: 'rgba(148, 163, 184, 0.25)',
+			stroke: 'rgba(148, 163, 184, 0.45)'
+		}
+	};
+
+	$: markers = clients
+		.map((client) => {
+			const coordinates = projection([client.location.longitude, client.location.latitude]);
+			if (!coordinates) {
+				return null;
+			}
+			const [x, y] = coordinates;
+			return {
+				client,
+				x,
+				y,
+				style: statusStyles[client.status]
+			} satisfies Marker;
+		})
+		.filter((entry): entry is Marker => entry !== null);
+</script>
+
+<svg
+	viewBox={`0 0 ${width} ${height}`}
+	role="img"
+	aria-label="Client presence map"
+	class="h-[320px] w-full overflow-hidden rounded-xl border border-border/60 bg-gradient-to-br from-background via-background to-muted/30"
+>
+	<defs>
+		<radialGradient id="map-glow" cx="50%" cy="50%" r="75%">
+			<stop offset="0%" stop-color="rgb(15 23 42 / 0.1)" />
+			<stop offset="60%" stop-color="rgb(15 23 42 / 0.04)" />
+			<stop offset="100%" stop-color="rgb(15 23 42 / 0.01)" />
+		</radialGradient>
+	</defs>
+	<rect x="0" y="0" {width} {height} fill="url(#map-glow)" />
+
+	{#if graticulePath}
+		<path d={graticulePath} class="fill-none stroke-border/40 stroke-[0.4]" />
+	{/if}
+
+	{#each landPaths as land (land.id)}
+		{#if land.d}
+			<path
+				d={land.d}
+				class="fill-muted/70 stroke-border/50 stroke-[0.5] dark:fill-muted/40 dark:stroke-border/40"
+			/>
+		{/if}
+	{/each}
+
+	{#if markers.length === 0}
+		<foreignObject x="0" y="0" {width} {height}>
+			<div class="flex h-full items-center justify-center text-sm text-muted-foreground">
+				No clients available for this selection.
+			</div>
+		</foreignObject>
+	{/if}
+
+	{#each markers as marker (marker.client.id)}
+		<g
+			transform={`translate(${marker.x}, ${marker.y})`}
+			style={`opacity: ${
+				highlightCountry && marker.client.location.countryCode !== highlightCountry ? 0.3 : 1
+			};`}
+		>
+			<circle r="11" style={`fill: ${marker.style.halo};`} />
+			<circle
+				r="5"
+				style={`fill: ${marker.style.dot}; stroke: ${marker.style.stroke}; stroke-width: 1.5;`}
+			/>
+			<title>
+				{marker.client.codename} · {marker.client.location.city}, {marker.client.location.country}
+			</title>
+		</g>
+	{/each}
+</svg>

--- a/tenvy-server/src/lib/data/dashboard.ts
+++ b/tenvy-server/src/lib/data/dashboard.ts
@@ -1,0 +1,600 @@
+import { countryCodeToFlag } from '$lib/utils/location';
+import type { ClientStatus } from './clients';
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+export type DashboardClient = {
+	id: string;
+	codename: string;
+	status: ClientStatus;
+	connectedAt: string;
+	lastSeen: string;
+	metrics: {
+		latencyMs: number;
+	};
+	location: {
+		city: string;
+		country: string;
+		countryCode: string;
+		latitude: number;
+		longitude: number;
+	};
+};
+
+export type DashboardLogEntry = {
+	id: string;
+	clientId: string;
+	codename: string;
+	timestamp: string;
+	action: string;
+	description: string;
+	severity: 'info' | 'warning' | 'critical';
+	countryCode: string | null;
+	city?: string;
+};
+
+export type DashboardCountryStat = {
+	countryCode: string;
+	countryName: string;
+	flag: string;
+	count: number;
+	onlineCount: number;
+	percentage: number;
+};
+
+export type DashboardNewClientSnapshot = {
+	total: number;
+	deltaPercent: number | null;
+	series: { timestamp: string; count: number }[];
+};
+
+export type DashboardBandwidthSnapshot = {
+	totalMb: number;
+	totalGb: number;
+	deltaPercent: number | null;
+	capacityMb: number;
+	usagePercent: number;
+	peakMb: number;
+	series: { timestamp: string; inboundMb: number; outboundMb: number; totalMb: number }[];
+};
+
+export type DashboardLatencySnapshot = {
+	averageMs: number;
+	deltaMs: number;
+	series: { timestamp: string; latencyMs: number }[];
+};
+
+export type DashboardSnapshot = {
+	generatedAt: string;
+	totals: {
+		total: number;
+		connected: number;
+		offline: number;
+		online: number;
+		idle: number;
+		dormant: number;
+	};
+	newClients: {
+		today: DashboardNewClientSnapshot;
+		week: DashboardNewClientSnapshot;
+	};
+	bandwidth: DashboardBandwidthSnapshot;
+	latency: DashboardLatencySnapshot;
+	clients: DashboardClient[];
+	logs: DashboardLogEntry[];
+	countries: DashboardCountryStat[];
+};
+
+type ClientSeed = {
+	id: string;
+	codename: string;
+	status: ClientStatus;
+	location: DashboardClient['location'];
+	connectedHoursAgo: number;
+	lastSeenMinutesAgo: number;
+	latencyMs: number;
+};
+
+const clientSeeds: ClientSeed[] = [
+	{
+		id: 'tv-001',
+		codename: 'VELA',
+		status: 'online',
+		location: {
+			city: 'Lisbon',
+			country: 'Portugal',
+			countryCode: 'PT',
+			latitude: 38.7223,
+			longitude: -9.1393
+		},
+		connectedHoursAgo: 72,
+		lastSeenMinutesAgo: 2,
+		latencyMs: 142
+	},
+	{
+		id: 'tv-002',
+		codename: 'ORION',
+		status: 'idle',
+		location: {
+			city: 'Berlin',
+			country: 'Germany',
+			countryCode: 'DE',
+			latitude: 52.52,
+			longitude: 13.405
+		},
+		connectedHoursAgo: 12,
+		lastSeenMinutesAgo: 7,
+		latencyMs: 188
+	},
+	{
+		id: 'tv-003',
+		codename: 'HALO',
+		status: 'online',
+		location: {
+			city: 'Toronto',
+			country: 'Canada',
+			countryCode: 'CA',
+			latitude: 43.651,
+			longitude: -79.383
+		},
+		connectedHoursAgo: 4,
+		lastSeenMinutesAgo: 1,
+		latencyMs: 156
+	},
+	{
+		id: 'tv-004',
+		codename: 'LYRA',
+		status: 'dormant',
+		location: {
+			city: 'Austin',
+			country: 'United States',
+			countryCode: 'US',
+			latitude: 30.2672,
+			longitude: -97.7431
+		},
+		connectedHoursAgo: 220,
+		lastSeenMinutesAgo: 190,
+		latencyMs: 0
+	},
+	{
+		id: 'tv-005',
+		codename: 'NOVA',
+		status: 'online',
+		location: {
+			city: 'Reykjavik',
+			country: 'Iceland',
+			countryCode: 'IS',
+			latitude: 64.1466,
+			longitude: -21.9426
+		},
+		connectedHoursAgo: 18,
+		lastSeenMinutesAgo: 3,
+		latencyMs: 172
+	},
+	{
+		id: 'tv-006',
+		codename: 'ATLAS',
+		status: 'offline',
+		location: {
+			city: 'Singapore',
+			country: 'Singapore',
+			countryCode: 'SG',
+			latitude: 1.3521,
+			longitude: 103.8198
+		},
+		connectedHoursAgo: 340,
+		lastSeenMinutesAgo: 480,
+		latencyMs: 0
+	},
+	{
+		id: 'tv-007',
+		codename: 'ECHO',
+		status: 'idle',
+		location: {
+			city: 'Tokyo',
+			country: 'Japan',
+			countryCode: 'JP',
+			latitude: 35.6762,
+			longitude: 139.6503
+		},
+		connectedHoursAgo: 60,
+		lastSeenMinutesAgo: 12,
+		latencyMs: 214
+	},
+	{
+		id: 'tv-008',
+		codename: 'QUILL',
+		status: 'dormant',
+		location: {
+			city: 'Tallinn',
+			country: 'Estonia',
+			countryCode: 'EE',
+			latitude: 59.437,
+			longitude: 24.7536
+		},
+		connectedHoursAgo: 150,
+		lastSeenMinutesAgo: 160,
+		latencyMs: 0
+	},
+	{
+		id: 'tv-009',
+		codename: 'POLAR',
+		status: 'online',
+		location: {
+			city: 'Chicago',
+			country: 'United States',
+			countryCode: 'US',
+			latitude: 41.8781,
+			longitude: -87.6298
+		},
+		connectedHoursAgo: 6,
+		lastSeenMinutesAgo: 2,
+		latencyMs: 132
+	},
+	{
+		id: 'tv-010',
+		codename: 'MISTRAL',
+		status: 'online',
+		location: {
+			city: 'Paris',
+			country: 'France',
+			countryCode: 'FR',
+			latitude: 48.8566,
+			longitude: 2.3522
+		},
+		connectedHoursAgo: 30,
+		lastSeenMinutesAgo: 9,
+		latencyMs: 168
+	},
+	{
+		id: 'tv-011',
+		codename: 'SPECTRUM',
+		status: 'online',
+		location: {
+			city: 'Delhi',
+			country: 'India',
+			countryCode: 'IN',
+			latitude: 28.6139,
+			longitude: 77.209
+		},
+		connectedHoursAgo: 10,
+		lastSeenMinutesAgo: 4,
+		latencyMs: 226
+	},
+	{
+		id: 'tv-012',
+		codename: 'ZEPHYR',
+		status: 'offline',
+		location: {
+			city: 'Sydney',
+			country: 'Australia',
+			countryCode: 'AU',
+			latitude: -33.8688,
+			longitude: 151.2093
+		},
+		connectedHoursAgo: 400,
+		lastSeenMinutesAgo: 960,
+		latencyMs: 0
+	}
+];
+
+type NewClientTodaySeed = { hoursAgo: number; count: number };
+const newClientsTodaySeed: NewClientTodaySeed[] = [
+	{ hoursAgo: 24, count: 0 },
+	{ hoursAgo: 21, count: 1 },
+	{ hoursAgo: 18, count: 1 },
+	{ hoursAgo: 15, count: 0 },
+	{ hoursAgo: 12, count: 1 },
+	{ hoursAgo: 9, count: 0 },
+	{ hoursAgo: 6, count: 1 },
+	{ hoursAgo: 3, count: 1 },
+	{ hoursAgo: 0, count: 0 }
+];
+
+const previousDayNewClients = 3;
+
+type NewClientsWeekSeed = { daysAgo: number; count: number };
+const newClientsWeekSeed: NewClientsWeekSeed[] = [
+	{ daysAgo: 6, count: 1 },
+	{ daysAgo: 5, count: 1 },
+	{ daysAgo: 4, count: 2 },
+	{ daysAgo: 3, count: 1 },
+	{ daysAgo: 2, count: 2 },
+	{ daysAgo: 1, count: 1 },
+	{ daysAgo: 0, count: 1 }
+];
+
+const previousWeekNewClients = 7;
+
+type BandwidthSeed = { hoursAgo: number; inboundMb: number; outboundMb: number };
+const bandwidthSeed: BandwidthSeed[] = [
+	{ hoursAgo: 22, inboundMb: 820, outboundMb: 640 },
+	{ hoursAgo: 20, inboundMb: 780, outboundMb: 590 },
+	{ hoursAgo: 18, inboundMb: 910, outboundMb: 720 },
+	{ hoursAgo: 16, inboundMb: 970, outboundMb: 760 },
+	{ hoursAgo: 14, inboundMb: 1020, outboundMb: 800 },
+	{ hoursAgo: 12, inboundMb: 1150, outboundMb: 840 },
+	{ hoursAgo: 10, inboundMb: 1210, outboundMb: 890 },
+	{ hoursAgo: 8, inboundMb: 1280, outboundMb: 930 },
+	{ hoursAgo: 6, inboundMb: 1320, outboundMb: 960 },
+	{ hoursAgo: 4, inboundMb: 1380, outboundMb: 1010 },
+	{ hoursAgo: 2, inboundMb: 1470, outboundMb: 1080 },
+	{ hoursAgo: 0, inboundMb: 1520, outboundMb: 1120 }
+];
+
+const previousBandwidthTotalMb = 19840;
+const bandwidthCapacityMb = 48000;
+
+type LatencySeed = { minutesAgo: number; latencyMs: number };
+const latencySeed: LatencySeed[] = [
+	{ minutesAgo: 330, latencyMs: 248 },
+	{ minutesAgo: 300, latencyMs: 236 },
+	{ minutesAgo: 270, latencyMs: 228 },
+	{ minutesAgo: 240, latencyMs: 222 },
+	{ minutesAgo: 210, latencyMs: 214 },
+	{ minutesAgo: 180, latencyMs: 208 },
+	{ minutesAgo: 150, latencyMs: 202 },
+	{ minutesAgo: 120, latencyMs: 198 },
+	{ minutesAgo: 90, latencyMs: 194 },
+	{ minutesAgo: 60, latencyMs: 188 },
+	{ minutesAgo: 30, latencyMs: 182 },
+	{ minutesAgo: 0, latencyMs: 176 }
+];
+
+const previousLatencyAverage = 204;
+
+type LogSeed = {
+	id: string;
+	clientId: string;
+	minutesAgo: number;
+	action: string;
+	description: string;
+	severity: DashboardLogEntry['severity'];
+};
+
+const logSeeds: LogSeed[] = [
+	{
+		id: 'log-001',
+		clientId: 'tv-003',
+		minutesAgo: 6,
+		action: 'task:credential-harvest',
+		description: 'Credential sweep completed on finance hosts',
+		severity: 'info'
+	},
+	{
+		id: 'log-002',
+		clientId: 'tv-009',
+		minutesAgo: 14,
+		action: 'config:beacon-jitter',
+		description: 'Adjusted jitter window to 45-90 seconds',
+		severity: 'info'
+	},
+	{
+		id: 'log-003',
+		clientId: 'tv-011',
+		minutesAgo: 22,
+		action: 'alert:process-anomaly',
+		description: 'Suspicious credential manager fork detected',
+		severity: 'warning'
+	},
+	{
+		id: 'log-004',
+		clientId: 'tv-006',
+		minutesAgo: 41,
+		action: 'connection:lost',
+		description: 'Agent dropped from Singapore relay',
+		severity: 'critical'
+	},
+	{
+		id: 'log-005',
+		clientId: 'tv-010',
+		minutesAgo: 55,
+		action: 'plugin:deploy',
+		description: 'Deployed Sightline Recon module',
+		severity: 'info'
+	},
+	{
+		id: 'log-006',
+		clientId: 'tv-005',
+		minutesAgo: 70,
+		action: 'transfer:window-opened',
+		description: 'Exfiltration window negotiated (sftp)',
+		severity: 'warning'
+	},
+	{
+		id: 'log-007',
+		clientId: 'tv-001',
+		minutesAgo: 95,
+		action: 'notes:sync',
+		description: 'Operator shared note synced to workspace',
+		severity: 'info'
+	},
+	{
+		id: 'log-008',
+		clientId: 'tv-008',
+		minutesAgo: 120,
+		action: 'scheduler:update',
+		description: 'Dormant sleeper heartbeat scheduled for tonight',
+		severity: 'info'
+	}
+];
+
+function computeDeltaPercent(current: number, previous: number): number | null {
+	if (previous <= 0) {
+		return null;
+	}
+	const delta = ((current - previous) / previous) * 100;
+	return Number.isFinite(delta) ? delta : null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.min(Math.max(value, min), max);
+}
+
+export function buildDashboardSnapshot(): DashboardSnapshot {
+	const now = new Date();
+	const generatedAt = now.toISOString();
+
+	const clients: DashboardClient[] = clientSeeds.map((seed) => ({
+		id: seed.id,
+		codename: seed.codename,
+		status: seed.status,
+		connectedAt: new Date(now.getTime() - seed.connectedHoursAgo * HOUR).toISOString(),
+		lastSeen: new Date(now.getTime() - seed.lastSeenMinutesAgo * MINUTE).toISOString(),
+		metrics: {
+			latencyMs: seed.latencyMs
+		},
+		location: seed.location
+	}));
+
+	const totals = clients.reduce(
+		(acc, client) => {
+			acc.total += 1;
+			if (client.status === 'offline') {
+				acc.offline += 1;
+			} else {
+				acc.connected += 1;
+				if (client.status === 'online') {
+					acc.online += 1;
+				}
+				if (client.status === 'idle') {
+					acc.idle += 1;
+				}
+				if (client.status === 'dormant') {
+					acc.dormant += 1;
+				}
+			}
+			return acc;
+		},
+		{ total: 0, connected: 0, offline: 0, online: 0, idle: 0, dormant: 0 }
+	);
+
+	const todaySeries = newClientsTodaySeed
+		.map((point) => ({
+			timestamp: new Date(now.getTime() - point.hoursAgo * HOUR).toISOString(),
+			count: point.count
+		}))
+		.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+	const todayTotal = todaySeries.reduce((sum, point) => sum + point.count, 0);
+	const todayDeltaPercent = computeDeltaPercent(todayTotal, previousDayNewClients);
+
+	const weekSeries = newClientsWeekSeed
+		.map((point) => ({
+			timestamp: new Date(now.getTime() - point.daysAgo * DAY).toISOString(),
+			count: point.count
+		}))
+		.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+	const weekTotal = weekSeries.reduce((sum, point) => sum + point.count, 0);
+	const weekDeltaPercent = computeDeltaPercent(weekTotal, previousWeekNewClients);
+
+	const bandwidthSeries = bandwidthSeed
+		.map((point) => {
+			const timestamp = new Date(now.getTime() - point.hoursAgo * HOUR).toISOString();
+			const totalMb = point.inboundMb + point.outboundMb;
+			return {
+				timestamp,
+				inboundMb: point.inboundMb,
+				outboundMb: point.outboundMb,
+				totalMb
+			};
+		})
+		.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+	const totalBandwidthMb = bandwidthSeries.reduce((sum, point) => sum + point.totalMb, 0);
+	const totalBandwidthGb = totalBandwidthMb / 1024;
+	const bandwidthDeltaPercent = computeDeltaPercent(totalBandwidthMb, previousBandwidthTotalMb);
+	const peakMb = Math.max(...bandwidthSeries.map((point) => point.totalMb));
+	const usagePercent = clamp((totalBandwidthMb / bandwidthCapacityMb) * 100, 0, 100);
+
+	const latencySeries = latencySeed
+		.map((point) => ({
+			timestamp: new Date(now.getTime() - point.minutesAgo * MINUTE).toISOString(),
+			latencyMs: point.latencyMs
+		}))
+		.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+	const averageLatency =
+		latencySeries.reduce((sum, point) => sum + point.latencyMs, 0) /
+		Math.max(latencySeries.length, 1);
+	const latencyDeltaMs = Number((averageLatency - previousLatencyAverage).toFixed(1));
+
+	const logs: DashboardLogEntry[] = logSeeds
+		.map((seed) => {
+			const client = clients.find((entry) => entry.id === seed.clientId) ?? null;
+			return {
+				id: seed.id,
+				clientId: seed.clientId,
+				codename: client?.codename ?? seed.clientId,
+				timestamp: new Date(now.getTime() - seed.minutesAgo * MINUTE).toISOString(),
+				action: seed.action,
+				description: seed.description,
+				severity: seed.severity,
+				countryCode: client?.location.countryCode ?? null,
+				city: client?.location.city
+			} satisfies DashboardLogEntry;
+		})
+		.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+	const countryMap = new Map<string, DashboardCountryStat>();
+	for (const client of clients) {
+		const existing = countryMap.get(client.location.countryCode);
+		if (existing) {
+			existing.count += 1;
+			if (client.status !== 'offline') {
+				existing.onlineCount += 1;
+			}
+		} else {
+			countryMap.set(client.location.countryCode, {
+				countryCode: client.location.countryCode,
+				countryName: client.location.country,
+				flag: countryCodeToFlag(client.location.countryCode),
+				count: 1,
+				onlineCount: client.status === 'offline' ? 0 : 1,
+				percentage: 0
+			});
+		}
+	}
+
+	const countries = Array.from(countryMap.values())
+		.map((entry) => ({
+			...entry,
+			percentage: Number(((entry.count / totals.total) * 100).toFixed(1))
+		}))
+		.sort((a, b) => b.count - a.count);
+
+	return {
+		generatedAt,
+		totals,
+		newClients: {
+			today: {
+				total: todayTotal,
+				deltaPercent: todayDeltaPercent,
+				series: todaySeries
+			},
+			week: {
+				total: weekTotal,
+				deltaPercent: weekDeltaPercent,
+				series: weekSeries
+			}
+		},
+		bandwidth: {
+			totalMb: Number(totalBandwidthMb.toFixed(0)),
+			totalGb: Number(totalBandwidthGb.toFixed(2)),
+			deltaPercent: bandwidthDeltaPercent,
+			capacityMb: bandwidthCapacityMb,
+			usagePercent: Number(usagePercent.toFixed(1)),
+			peakMb: peakMb,
+			series: bandwidthSeries
+		},
+		latency: {
+			averageMs: Number(averageLatency.toFixed(1)),
+			deltaMs: latencyDeltaMs,
+			series: latencySeries
+		},
+		clients,
+		logs,
+		countries
+	} satisfies DashboardSnapshot;
+}

--- a/tenvy-server/src/routes/(app)/dashboard/+page.server.ts
+++ b/tenvy-server/src/routes/(app)/dashboard/+page.server.ts
@@ -1,0 +1,6 @@
+import type { PageServerLoad } from './$types';
+import { buildDashboardSnapshot } from '$lib/data/dashboard';
+
+export const load: PageServerLoad = async () => {
+	return buildDashboardSnapshot();
+};

--- a/tenvy-server/src/routes/(app)/dashboard/+page.svelte
+++ b/tenvy-server/src/routes/(app)/dashboard/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { cn } from '$lib/utils.js';
 	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
 	import {
 		Card,
 		CardContent,
@@ -8,280 +9,611 @@
 		CardHeader,
 		CardTitle
 	} from '$lib/components/ui/card/index.js';
-	import type { IconComponent } from '$lib/types/navigation.js';
+	import { Progress } from '$lib/components/ui/progress/index.js';
+	import {
+		ChartContainer,
+		ChartTooltip,
+		type ChartConfig
+	} from '$lib/components/ui/chart/index.js';
+	import { LineChart } from 'layerchart';
+	import ClientPresenceMap from '$lib/components/dashboard/client-presence-map.svelte';
+	import { countryCodeToFlag } from '$lib/utils/location';
+	import { derived, writable } from 'svelte/store';
+	import {
+		Activity,
+		ArrowDownRight,
+		ArrowUpRight,
+		Gauge,
+		Globe2,
+		UserPlus,
+		Users
+	} from '@lucide/svelte';
+	import type {
+		DashboardClient,
+		DashboardCountryStat,
+		DashboardLogEntry
+	} from '$lib/data/dashboard';
+	import type { PageData } from './$types';
 
-	import { Activity, TriangleAlert, CircleCheck, PlugZap, Terminal, Users } from '@lucide/svelte';
-	import { Switch } from '$lib/components/ui/switch/index.js';
+	const integerFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
+	const gbFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 });
+	const percentageFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 1 });
+	const timeFormatter = new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit' });
+	const dayFormatter = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+	const relativeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+	const latencyFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 1 });
 
-	type Stat = {
-		title: string;
-		value: string;
-		delta?: string;
-		icon: IconComponent;
-		iconClass?: string;
+	let { data } = $props<{ data: PageData }>();
+
+	const newClientRange = writable<'today' | 'week'>('today');
+	const activeView = writable<'logs' | 'map'>('logs');
+	const selectedCountry = writable<string | null>(null);
+
+	type TrendIcon = typeof ArrowUpRight | typeof ArrowDownRight;
+	type TrendTone = 'positive' | 'negative' | 'neutral';
+	type TrendDescriptor = { text: string; tone: TrendTone; icon: TrendIcon | null };
+
+	const generatedAt = new Date(data.generatedAt);
+
+	const countryNameMap = new Map<string, string>(
+		data.countries.map(
+			(entry: DashboardCountryStat) => [entry.countryCode, entry.countryName] as const
+		)
+	);
+
+	const newClientSnapshot = derived(
+		newClientRange,
+		($range): (typeof data.newClients)[keyof typeof data.newClients] => data.newClients[$range]
+	);
+	const newClientDelta = derived(
+		newClientSnapshot,
+		($snapshot): TrendDescriptor => describePercentDelta($snapshot.deltaPercent)
+	);
+	const filteredLogs = derived(selectedCountry, ($selectedCountry): DashboardLogEntry[] =>
+		$selectedCountry
+			? data.logs.filter((entry: DashboardLogEntry) => entry.countryCode === $selectedCountry)
+			: data.logs
+	);
+	const filteredClients = derived(selectedCountry, ($selectedCountry): DashboardClient[] =>
+		$selectedCountry
+			? data.clients.filter(
+					(entry: DashboardClient) => entry.location.countryCode === $selectedCountry
+				)
+			: data.clients
+	);
+	const countryStats: DashboardCountryStat[] = data.countries;
+	type SelectedCountrySummary = { flag: string; name: string; total: number };
+	const selectedCountrySummary = derived(
+		[selectedCountry, filteredClients],
+		([$selectedCountry, $filteredClients]): SelectedCountrySummary | null => {
+			if (!$selectedCountry) {
+				return null;
+			}
+			const name = countryNameMap.get($selectedCountry) ?? $selectedCountry;
+			return {
+				flag: resolveFlag($selectedCountry),
+				name,
+				total: $filteredClients.length
+			};
+		}
+	);
+	const bandwidthDelta = describePercentDelta(data.bandwidth.deltaPercent);
+	const latencyDelta = describeLatencyDelta(data.latency.deltaMs);
+
+	const severityVariant: Record<
+		DashboardLogEntry['severity'],
+		'secondary' | 'outline' | 'destructive'
+	> = {
+		info: 'secondary',
+		warning: 'outline',
+		critical: 'destructive'
 	};
 
-	const stats: Stat[] = [
+	const severityTone: Record<DashboardLogEntry['severity'], string> = {
+		info: 'text-sky-500',
+		warning: 'text-amber-500',
+		critical: 'text-destructive'
+	};
+
+	const newClientsChartConfig = {
+		count: {
+			label: 'New clients',
+			theme: {
+				light: 'var(--chart-1)',
+				dark: 'var(--chart-1)'
+			}
+		}
+	} satisfies ChartConfig;
+
+	const newClientsSeries = [
 		{
-			title: 'Active clients',
-			value: '18',
-			delta: '+3.2% vs last hour',
-			icon: Users,
-			iconClass: 'text-emerald-500'
-		},
-		{
-			title: 'Pending tasks',
-			value: '42',
-			delta: '6 scheduled for execution',
-			icon: Terminal,
-			iconClass: 'text-amber-500'
-		},
-		{
-			title: 'Plugin status',
-			value: '27 online',
-			delta: '4 modules awaiting review',
-			icon: PlugZap,
-			iconClass: 'text-purple-500'
-		},
-		{
-			title: 'Alerts',
-			value: '5 open',
-			delta: 'Updated moments ago',
-			icon: TriangleAlert,
-			iconClass: 'text-red-500'
+			key: 'count',
+			label: newClientsChartConfig.count.label,
+			value: (point: (typeof data.newClients.today.series)[number]) => point.count,
+			color: 'var(--chart-1)'
 		}
 	];
 
-	type LogEntry = {
-		source: string;
-		message: string;
-		time: string;
-		level: 'info' | 'warning' | 'critical';
-		icon: IconComponent;
-		accentClass: string;
-	};
+	const bandwidthChartConfig = {
+		total: {
+			label: 'Total transfer (MB)',
+			theme: {
+				light: 'var(--chart-2)',
+				dark: 'var(--chart-2)'
+			}
+		}
+	} satisfies ChartConfig;
 
-	const logEntries: LogEntry[] = [
+	const bandwidthSeries = [
 		{
-			source: 'vela/core',
-			message: 'Beacon accepted, stage negotiation complete.',
-			time: '00:02:14',
-			level: 'info',
-			icon: Activity,
-			accentClass: 'bg-emerald-500/15 text-emerald-500'
-		},
-		{
-			source: 'aurora/tasker',
-			message: 'Workflow "Aurora Sweep" completed across 3 hosts.',
-			time: '00:14:08',
-			level: 'info',
-			icon: CircleCheck,
-			accentClass: 'bg-blue-500/15 text-blue-500'
-		},
-		{
-			source: 'credentials/cache',
-			message: 'New credential bundle awaiting analyst review.',
-			time: '00:27:46',
-			level: 'warning',
-			icon: PlugZap,
-			accentClass: 'bg-purple-500/15 text-purple-500'
-		},
-		{
-			source: 'guardian/watch',
-			message: 'Safeguard override requested for lateral move.',
-			time: '00:41:59',
-			level: 'critical',
-			icon: TriangleAlert,
-			accentClass: 'bg-red-500/15 text-red-500'
+			key: 'totalMb',
+			label: bandwidthChartConfig.total.label,
+			value: (point: (typeof data.bandwidth.series)[number]) => point.totalMb,
+			color: 'var(--chart-2)'
 		}
 	];
 
-	type CommandEntry = {
-		kind: 'command' | 'output' | 'system' | 'error';
-		prompt?: string;
-		text: string;
-	};
+	const latencyChartConfig = {
+		latency: {
+			label: 'Average latency (ms)',
+			theme: {
+				light: 'var(--chart-3)',
+				dark: 'var(--chart-3)'
+			}
+		}
+	} satisfies ChartConfig;
 
-	const commandStream: CommandEntry[] = [
+	const latencySeries = [
 		{
-			kind: 'system',
-			text: '[channel] connected to agent VELA :: latency 142ms'
-		},
-		{
-			kind: 'command',
-			prompt: 'vela@controller:~$',
-			text: 'status --summary'
-		},
-		{
-			kind: 'output',
-			text: 'active clients: 18  |  pending tasks: 42  |  safeguards: 2 overrides pending'
-		},
-		{
-			kind: 'command',
-			prompt: 'vela@controller:~$',
-			text: 'tail --follow=/var/log/vela/broker.log --lines=4'
-		},
-		{
-			kind: 'output',
-			text: ':: broker :: queue synced :: 14 new events buffered'
-		},
-		{
-			kind: 'error',
-			text: 'warning: safeguard escalation required for host-239'
-		},
-		{
-			kind: 'command',
-			prompt: 'vela@controller:~$',
-			text: 'acknowledge --ticket=9124'
-		},
-		{
-			kind: 'system',
-			text: '[channel] awaiting operator input…'
+			key: 'latencyMs',
+			label: latencyChartConfig.latency.label,
+			value: (point: (typeof data.latency.series)[number]) => point.latencyMs,
+			color: 'var(--chart-3)'
 		}
 	];
 
-	let showCommand = false;
+	function describePercentDelta(delta: number | null): TrendDescriptor {
+		if (delta === null) {
+			return { text: 'No prior comparison', tone: 'neutral', icon: null };
+		}
+		if (Math.abs(delta) < 0.05) {
+			return { text: 'Stable vs prior period', tone: 'neutral', icon: null };
+		}
+		const tone: TrendTone = delta > 0 ? 'positive' : 'negative';
+		const icon: TrendIcon = delta > 0 ? ArrowUpRight : ArrowDownRight;
+		const formatted = `${delta > 0 ? '+' : '−'}${percentageFormatter.format(Math.abs(delta))}%`;
+		return { text: `${formatted} vs prior period`, tone, icon };
+	}
+
+	function describeLatencyDelta(delta: number): TrendDescriptor {
+		if (Math.abs(delta) < 0.1) {
+			return { text: 'Stable vs last window', tone: 'neutral', icon: null };
+		}
+		const tone: TrendTone = delta < 0 ? 'positive' : 'negative';
+		const icon: TrendIcon = delta < 0 ? ArrowDownRight : ArrowUpRight;
+		const formatted = `${delta > 0 ? '+' : '−'}${latencyFormatter.format(Math.abs(delta))} ms`;
+		return { text: `${formatted} vs last window`, tone, icon };
+	}
+
+	function formatRelative(timestamp: string): string {
+		const difference = new Date(timestamp).getTime() - generatedAt.getTime();
+		const abs = Math.abs(difference);
+		if (abs < 60_000) {
+			return 'moments ago';
+		}
+		if (abs < 3_600_000) {
+			return relativeFormatter.format(Math.round(difference / 60_000), 'minute');
+		}
+		if (abs < 86_400_000) {
+			return relativeFormatter.format(Math.round(difference / 3_600_000), 'hour');
+		}
+		return relativeFormatter.format(Math.round(difference / 86_400_000), 'day');
+	}
+
+	function formatLogTime(timestamp: string): string {
+		return timeFormatter.format(new Date(timestamp));
+	}
+
+	function toggleCountry(code: string) {
+		selectedCountry.update((current) => (current === code ? null : code));
+	}
+
+	function resolveFlag(code: string | null): string {
+		return code ? countryCodeToFlag(code) : '🌐';
+	}
+
+	const connectedCaption = `${data.totals.connected} active links`;
+	const offlineCaption = `${data.totals.offline} offline`;
 </script>
 
 <section class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-	{#each stats as stat}
-		<Card class="border-border/60">
-			<CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
-				<CardTitle class="text-sm font-medium">{stat.title}</CardTitle>
-				<stat.icon class={cn('h-4 w-4 text-muted-foreground', stat.iconClass)} />
-			</CardHeader>
-			<CardContent class="space-y-1">
-				<div class="text-2xl font-semibold">{stat.value}</div>
-				{#if stat.delta}
-					<p class="text-xs text-muted-foreground">{stat.delta}</p>
-				{/if}
-			</CardContent>
-		</Card>
-	{/each}
+	<Card class="border-border/60">
+		<CardHeader class="flex flex-col gap-3">
+			<div class="flex items-center justify-between gap-3">
+				<CardTitle class="text-sm font-semibold">Total clients</CardTitle>
+				<span
+					class="flex h-9 w-9 items-center justify-center rounded-full border border-border/60 bg-muted/40"
+				>
+					<Users class="h-4 w-4 text-muted-foreground" />
+				</span>
+			</div>
+			<CardDescription>Live controller footprint across every uplink.</CardDescription>
+		</CardHeader>
+		<CardContent class="space-y-2">
+			<div class="text-3xl font-semibold tracking-tight">
+				{integerFormatter.format(data.totals.total)}
+			</div>
+			<p class="text-xs text-muted-foreground">
+				🟢 {connectedCaption} · 🔴 {offlineCaption}
+			</p>
+			<p class="text-xs text-muted-foreground">
+				Idle + dormant sleepers: {integerFormatter.format(data.totals.idle + data.totals.dormant)}
+			</p>
+		</CardContent>
+	</Card>
+
+	<Card class="border-border/60">
+		<CardHeader class="flex flex-col gap-3">
+			<div class="flex items-center justify-between gap-3">
+				<CardTitle class="text-sm font-semibold">New clients</CardTitle>
+				<span
+					class="flex h-9 w-9 items-center justify-center rounded-full border border-border/60 bg-muted/40"
+				>
+					<UserPlus class="h-4 w-4 text-muted-foreground" />
+				</span>
+			</div>
+			<CardDescription>Enrollment momentum for operators.</CardDescription>
+		</CardHeader>
+		<CardContent class="space-y-4">
+			<div class="flex flex-wrap items-center justify-between gap-3">
+				<div>
+					<div class="text-3xl font-semibold tracking-tight">
+						{integerFormatter.format($newClientSnapshot.total)}
+					</div>
+					{#if $newClientDelta.text}
+						<div
+							class={cn(
+								'mt-1 flex items-center gap-1 text-xs',
+								$newClientDelta.tone === 'positive'
+									? 'text-emerald-500'
+									: $newClientDelta.tone === 'negative'
+										? 'text-rose-500'
+										: 'text-muted-foreground'
+							)}
+						>
+							{#if $newClientDelta.icon}
+								{@const Icon = $newClientDelta.icon}
+								<Icon class="h-3.5 w-3.5" />
+							{/if}
+							<span>{$newClientDelta.text}</span>
+						</div>
+					{/if}
+				</div>
+				<div class="flex items-center gap-1 rounded-md border border-border/60 bg-muted/40 p-1">
+					<Button
+						type="button"
+						variant={$newClientRange === 'today' ? 'secondary' : 'ghost'}
+						size="sm"
+						class="px-3 text-xs"
+						onclick={() => newClientRange.set('today')}
+					>
+						Today
+					</Button>
+					<Button
+						type="button"
+						variant={$newClientRange === 'week' ? 'secondary' : 'ghost'}
+						size="sm"
+						class="px-3 text-xs"
+						onclick={() => newClientRange.set('week')}
+					>
+						This week
+					</Button>
+				</div>
+			</div>
+			<ChartContainer config={newClientsChartConfig} class="h-28 w-full">
+				<LineChart
+					data={$newClientSnapshot.series}
+					x={(point) => new Date(point.timestamp)}
+					series={newClientsSeries}
+					props={{
+						xAxis: {
+							format: (value) =>
+								value instanceof Date
+									? $newClientRange === 'today'
+										? timeFormatter.format(value)
+										: dayFormatter.format(value)
+									: ''
+						},
+						yAxis: {
+							format: (value) => `${integerFormatter.format(Number(value ?? 0))}`
+						}
+					}}
+				>
+					{#snippet tooltip()}
+						<ChartTooltip indicator="line" />
+					{/snippet}
+				</LineChart>
+			</ChartContainer>
+		</CardContent>
+	</Card>
+
+	<Card class="border-border/60">
+		<CardHeader class="flex flex-col gap-3">
+			<div class="flex items-center justify-between gap-3">
+				<CardTitle class="text-sm font-semibold">Bandwidth usage</CardTitle>
+				<span
+					class="flex h-9 w-9 items-center justify-center rounded-full border border-border/60 bg-muted/40"
+				>
+					<Activity class="h-4 w-4 text-muted-foreground" />
+				</span>
+			</div>
+			<CardDescription>Aggregate transfer over the last 24 hours.</CardDescription>
+		</CardHeader>
+		<CardContent class="space-y-4">
+			<div>
+				<div class="text-3xl font-semibold tracking-tight">
+					{gbFormatter.format(data.bandwidth.totalGb)}
+					<span class="text-base font-normal text-muted-foreground">GB</span>
+				</div>
+				<div
+					class={cn(
+						'mt-1 flex items-center gap-1 text-xs',
+						bandwidthDelta.tone === 'positive'
+							? 'text-emerald-500'
+							: bandwidthDelta.tone === 'negative'
+								? 'text-rose-500'
+								: 'text-muted-foreground'
+					)}
+				>
+					{#if bandwidthDelta.icon}
+						{@const Icon = bandwidthDelta.icon}
+						<Icon class="h-3.5 w-3.5" />
+					{/if}
+					<span>{bandwidthDelta.text}</span>
+				</div>
+			</div>
+			<div class="space-y-2">
+				<div class="flex items-center justify-between text-xs text-muted-foreground">
+					<span>Capacity {gbFormatter.format(data.bandwidth.capacityMb / 1024)} GB</span>
+					<span>{percentageFormatter.format(data.bandwidth.usagePercent)}% utilised</span>
+				</div>
+				<Progress value={data.bandwidth.usagePercent} />
+			</div>
+			<ChartContainer config={bandwidthChartConfig} class="h-24 w-full">
+				<LineChart
+					data={data.bandwidth.series}
+					x={(point) => new Date(point.timestamp)}
+					series={bandwidthSeries}
+					props={{
+						xAxis: {
+							format: (value) => (value instanceof Date ? timeFormatter.format(value) : '')
+						},
+						yAxis: {
+							format: (value) => `${integerFormatter.format(Number(value ?? 0))} MB`
+						}
+					}}
+				>
+					{#snippet tooltip()}
+						<ChartTooltip indicator="line" />
+					{/snippet}
+				</LineChart>
+			</ChartContainer>
+		</CardContent>
+	</Card>
+
+	<Card class="border-border/60">
+		<CardHeader class="flex flex-col gap-3">
+			<div class="flex items-center justify-between gap-3">
+				<CardTitle class="text-sm font-semibold">C2 server latency</CardTitle>
+				<span
+					class="flex h-9 w-9 items-center justify-center rounded-full border border-border/60 bg-muted/40"
+				>
+					<Gauge class="h-4 w-4 text-muted-foreground" />
+				</span>
+			</div>
+			<CardDescription>Heartbeat round-trip monitoring.</CardDescription>
+		</CardHeader>
+		<CardContent class="space-y-4">
+			<div>
+				<div class="text-3xl font-semibold tracking-tight">
+					{latencyFormatter.format(data.latency.averageMs)}
+					<span class="text-base font-normal text-muted-foreground">ms</span>
+				</div>
+				<div
+					class={cn(
+						'mt-1 flex items-center gap-1 text-xs',
+						latencyDelta.tone === 'positive'
+							? 'text-emerald-500'
+							: latencyDelta.tone === 'negative'
+								? 'text-rose-500'
+								: 'text-muted-foreground'
+					)}
+				>
+					{#if latencyDelta.icon}
+						{@const Icon = latencyDelta.icon}
+						<Icon class="h-3.5 w-3.5" />
+					{/if}
+					<span>{latencyDelta.text}</span>
+				</div>
+			</div>
+			<ChartContainer config={latencyChartConfig} class="h-24 w-full">
+				<LineChart
+					data={data.latency.series}
+					x={(point) => new Date(point.timestamp)}
+					series={latencySeries}
+					props={{
+						xAxis: {
+							format: (value) => (value instanceof Date ? timeFormatter.format(value) : '')
+						},
+						yAxis: {
+							format: (value) => `${latencyFormatter.format(Number(value ?? 0))} ms`
+						}
+					}}
+				>
+					{#snippet tooltip()}
+						<ChartTooltip indicator="line" />
+					{/snippet}
+				</LineChart>
+			</ChartContainer>
+		</CardContent>
+	</Card>
 </section>
 
 <section class="grid gap-6 lg:grid-cols-7">
-	<Card class="lg:col-span-4">
-		<CardHeader class="space-y-3">
-			<div class="flex items-center gap-2 text-[0.7rem] font-semibold tracking-[0.08em] uppercase">
-				<span
-					class={cn('transition-colors', showCommand ? 'text-muted-foreground/70' : 'text-primary')}
-				>
-					Logs
-				</span>
-				<Switch
-					bind:checked={showCommand}
-					aria-label="Toggle between log stream and command console"
-				/>
-				<span
-					class={cn('transition-colors', showCommand ? 'text-primary' : 'text-muted-foreground/70')}
-				>
-					Command
-				</span>
+	<Card class="border-border/60 lg:col-span-5">
+		<CardHeader class="flex flex-col gap-3">
+			<div class="flex flex-wrap items-center justify-between gap-3">
+				<div class="space-y-1">
+					<CardTitle>Operations stream</CardTitle>
+					<CardDescription>
+						Inspect live log traffic or map uplink distribution in real time.
+					</CardDescription>
+				</div>
+				<div class="flex items-center gap-1 rounded-md border border-border/60 bg-muted/40 p-1">
+					<Button
+						type="button"
+						variant={$activeView === 'logs' ? 'secondary' : 'ghost'}
+						size="sm"
+						class="px-3 text-xs"
+						onclick={() => activeView.set('logs')}
+					>
+						Logs
+					</Button>
+					<Button
+						type="button"
+						variant={$activeView === 'map' ? 'secondary' : 'ghost'}
+						size="sm"
+						class="px-3 text-xs"
+						onclick={() => activeView.set('map')}
+					>
+						Map
+					</Button>
+				</div>
 			</div>
-			<div class="space-y-1">
-				<CardTitle>Operations console</CardTitle>
-				<CardDescription>
-					Monitor live log ingestion or drop into the embedded command interface.
-				</CardDescription>
-			</div>
+			{#if $selectedCountrySummary}
+				<Badge variant="outline" class="w-fit gap-2 text-xs uppercase">
+					<span>{$selectedCountrySummary.flag}</span>
+					<span>{$selectedCountrySummary.name}</span>
+					<span class="text-muted-foreground">
+						· {integerFormatter.format($selectedCountrySummary.total)}
+						{$selectedCountrySummary.total === 1 ? ' client' : ' clients'}
+					</span>
+				</Badge>
+			{/if}
 		</CardHeader>
 		<CardContent class="space-y-4">
-			{#if !showCommand}
+			{#if $activeView === 'logs'}
 				<div class="space-y-3">
-					{#each logEntries as entry}
-						<div class="flex items-start gap-4 rounded-lg border border-border/60 p-4">
-							<div
-								class={cn(
-									'mt-1 flex h-9 w-9 items-center justify-center rounded-md',
-									entry.accentClass
-								)}
-							>
-								<entry.icon class="h-4 w-4" />
-							</div>
-							<div class="flex-1 space-y-1">
-								<p class="font-mono text-xs tracking-[0.08em] text-muted-foreground uppercase">
-									{entry.source}
-								</p>
-								<p class="text-sm leading-tight font-medium">{entry.message}</p>
-							</div>
-							<div class="flex flex-col items-end gap-2 text-xs text-muted-foreground">
-								<span>{entry.time}</span>
-								<Badge
-									variant={entry.level === 'critical'
-										? 'destructive'
-										: entry.level === 'warning'
-											? 'outline'
-											: 'secondary'}
+					{#if $filteredLogs.length === 0}
+						<div
+							class="rounded-lg border border-dashed border-border/60 p-6 text-center text-sm text-muted-foreground"
+						>
+							No events matched this country filter.
+						</div>
+					{/if}
+					{#each $filteredLogs as entry (entry.id)}
+						<div
+							class="flex flex-col gap-4 rounded-lg border border-border/60 p-4 md:flex-row md:items-center md:justify-between"
+						>
+							<div class="flex items-start gap-3">
+								<span
+									class="flex h-10 w-10 items-center justify-center rounded-md border border-border/60 bg-muted/40"
 								>
-									{entry.level}
+									<Globe2 class="h-4 w-4 text-muted-foreground" />
+								</span>
+								<div class="space-y-1">
+									<div class="flex items-center gap-2 text-sm font-semibold">
+										<span>{entry.codename}</span>
+										<span class="text-xs text-muted-foreground">
+											{resolveFlag(entry.countryCode ?? null)}
+										</span>
+									</div>
+									<p
+										class="font-mono text-[0.65rem] tracking-[0.08em] text-muted-foreground uppercase"
+									>
+										{entry.action}
+									</p>
+									<p class="text-sm text-muted-foreground">{entry.description}</p>
+								</div>
+							</div>
+							<div class="flex flex-col items-start gap-2 md:items-end">
+								<div class="flex items-center gap-2 text-xs text-muted-foreground">
+									<span>{formatLogTime(entry.timestamp)}</span>
+									<span aria-hidden="true">•</span>
+									<span>{formatRelative(entry.timestamp)}</span>
+								</div>
+								<Badge
+									variant={severityVariant[entry.severity]}
+									class={cn('tracking-wide uppercase', severityTone[entry.severity])}
+								>
+									{entry.severity}
 								</Badge>
 							</div>
 						</div>
 					{/each}
 				</div>
 			{:else}
-				<div
-					class="space-y-3 rounded-lg border border-border/60 bg-background/95 p-4 font-mono text-xs"
-				>
-					{#each commandStream as line}
-						<div
-							class={cn(
-								'flex flex-wrap gap-x-2 gap-y-1',
-								line.kind === 'command' && 'text-emerald-400',
-								line.kind === 'system' && 'text-sky-400/90',
-								line.kind === 'error' && 'text-red-400',
-								line.kind === 'output' && 'text-muted-foreground'
-							)}
-						>
-							{#if line.prompt}
-								<span class="select-none">{line.prompt}</span>
-							{/if}
-							<span class="whitespace-pre-wrap">{line.text}</span>
-						</div>
-					{/each}
-					<div class="flex items-center gap-2 text-emerald-400">
-						<span class="select-none">vela@controller:~$</span>
-						<span class="animate-pulse text-muted-foreground/60">█</span>
-					</div>
-				</div>
+				<ClientPresenceMap clients={$filteredClients} highlightCountry={$selectedCountry} />
 			{/if}
 		</CardContent>
 	</Card>
 
-	<Card class="lg:col-span-3">
-		<CardHeader>
-			<CardTitle>Operational health</CardTitle>
-			<CardDescription>Signals from infrastructure, telemetry, and safeguards.</CardDescription>
+	<Card class="border-border/60 lg:col-span-2">
+		<CardHeader class="flex flex-col gap-2">
+			<CardTitle>Country distribution</CardTitle>
+			<CardDescription>Click to focus the map and event feed.</CardDescription>
+			<div class="flex flex-wrap items-center gap-2">
+				<Badge variant="secondary" class="font-mono text-[0.65rem]">
+					{integerFormatter.format(data.clients.length)} clients tracked
+				</Badge>
+				<Button
+					type="button"
+					variant="ghost"
+					size="sm"
+					class="h-7 px-2 text-xs"
+					onclick={() => selectedCountry.set(null)}
+					disabled={!$selectedCountry}
+				>
+					Reset
+				</Button>
+			</div>
 		</CardHeader>
-		<CardContent class="space-y-4">
-			<div class="rounded-lg border border-border/60 p-4">
-				<div class="flex items-center justify-between">
-					<div>
-						<p class="text-sm leading-tight font-semibold">Connectivity</p>
-						<p class="text-xs text-muted-foreground">All relay nodes responding</p>
+		<CardContent class="space-y-3">
+			{#each countryStats as country (country.countryCode)}
+				<button
+					type="button"
+					class={cn(
+						'w-full rounded-lg border px-3 py-2 text-left transition-colors',
+						$selectedCountry === country.countryCode
+							? 'border-primary/70 bg-primary/10'
+							: 'border-border/60 hover:border-primary/50 hover:bg-primary/5'
+					)}
+					onclick={() => toggleCountry(country.countryCode)}
+				>
+					<div class="flex items-center justify-between gap-3">
+						<div class="flex items-center gap-3">
+							<span class="text-lg leading-none">{country.flag}</span>
+							<div class="space-y-0.5">
+								<p class="text-sm font-semibold text-foreground">{country.countryName}</p>
+								<p class="text-xs text-muted-foreground">
+									{integerFormatter.format(country.count)} clients · {integerFormatter.format(
+										country.onlineCount
+									)} active
+								</p>
+							</div>
+						</div>
+						<span class="text-sm font-semibold text-muted-foreground">
+							{percentageFormatter.format(country.percentage)}%
+						</span>
 					</div>
-					<Badge variant="secondary" class="bg-emerald-500/15 text-emerald-600">Stable</Badge>
-				</div>
-			</div>
-			<div class="rounded-lg border border-border/60 p-4">
-				<div class="flex items-center justify-between">
-					<div>
-						<p class="text-sm leading-tight font-semibold">Command queue</p>
-						<p class="text-xs text-muted-foreground">Next dispatch in 38 seconds</p>
+					<div class="mt-3 h-2 w-full overflow-hidden rounded-full bg-muted/50">
+						<div
+							class="h-full rounded-full bg-primary/80"
+							style={`width: ${Math.min(country.percentage, 100)}%;`}
+						></div>
 					</div>
-					<Badge variant="outline" class="border-amber-500/40 text-amber-500">Balanced</Badge>
-				</div>
-			</div>
-			<div class="rounded-lg border border-border/60 p-4">
-				<div class="flex items-center justify-between">
-					<div>
-						<p class="text-sm leading-tight font-semibold">Safeguards</p>
-						<p class="text-xs text-muted-foreground">2 overrides pending approval</p>
-					</div>
-					<Badge variant="outline" class="border-red-500/40 text-red-500">Review</Badge>
-				</div>
-			</div>
+				</button>
+			{/each}
 		</CardContent>
 	</Card>
 </section>


### PR DESCRIPTION
## Summary
- replace the dashboard page with data-driven stat cards, charts, map/log toggle, and country filtering tied to real stores
- add a synthesized dashboard snapshot loader and helper module to serve clients, logs, metrics, and distribution data
- introduce a reusable client presence map component powered by d3-geo/topojson and add the necessary type packages

## Testing
- bunx eslint src/lib/components/dashboard/client-presence-map.svelte 'src/routes/(app)/dashboard/+page.svelte' src/lib/data/dashboard.ts 'src/routes/(app)/dashboard/+page.server.ts'
- bun check


------
https://chatgpt.com/codex/tasks/task_e_68ee364b04ac832b8d10802fbf8a0ae6