### PR TITLE
Measure controller RTT ping on clients page

### DIFF
--- a/tenvy-server/src/routes/api/ping/+server.ts
+++ b/tenvy-server/src/routes/api/ping/+server.ts
@@ -1,0 +1,10 @@
+import type { RequestHandler } from './$types';
+
+const headers = {
+	'Cache-Control': 'no-store, no-cache, must-revalidate'
+};
+
+export const GET: RequestHandler = () =>
+	new Response('pong', {
+		headers
+	});


### PR DESCRIPTION
## Summary
- add a lightweight `/api/ping` endpoint to measure controller responsiveness
- update the clients table to poll the ping endpoint every 15s and surface the measured RTT

## Testing
- bun lint *(fails: existing Prettier formatting issues in unrelated files)*
- bun check *(fails: pre-existing type error in src/routes/(app)/+layout.svelte about SettingsLink)*

------
https://chatgpt.com/codex/tasks/task_e_68f0a4bc4ecc832ba84948c6baec8da5