### PR TITLE
Fix remote desktop encoding failures on odd monitor sizes

### DIFF
--- a/tenvy-client/internal/modules/control/remotedesktop/quality.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/quality.go
@@ -188,6 +188,13 @@ func alignEven(value int) int {
 	return value
 }
 
+func alignEvenDown(value int) int {
+	if value%2 != 0 {
+		value--
+	}
+	return value
+}
+
 func clipQualityBaseline(preset RemoteDesktopQuality) int {
 	switch preset {
 	case RemoteQualityHigh:


### PR DESCRIPTION
## Summary
- clamp base and native monitor dimensions to even values so the encoder always sees 4:2:0 friendly sizes
- normalize adaptive scaling updates to keep the negotiated width and height even while honoring the configured bounds

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f157aef77c832baacb62140d27ef4b