### PR TITLE
Improve file manager caching and add coverage

### DIFF
--- a/tenvy-server/src/lib/server/rat/file-manager.test.ts
+++ b/tenvy-server/src/lib/server/rat/file-manager.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, beforeEach, vi, afterEach } from 'vitest';
+import { FileManagerStore, FileManagerError } from './file-manager';
+import type { DirectoryListing } from '$lib/types/file-manager';
+
+const baseDirectory = (path: string): DirectoryListing => ({
+	type: 'directory',
+	root: '/',
+	path,
+	parent: path === '/' ? null : '/',
+	entries: []
+});
+
+describe('FileManagerStore', () => {
+	beforeEach(() => {
+		vi.useRealTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('prunes stale directory listings after expiration', () => {
+		vi.useFakeTimers();
+		const store = new FileManagerStore({ expirationMs: 1_000, pruneIntervalMs: 0 });
+		const agentId = 'agent-1';
+		const listing = baseDirectory('/tmp');
+
+		vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+		store.ingestResource(agentId, listing);
+		expect(store.getResource(agentId, listing.path)).toMatchObject({ path: listing.path });
+
+		vi.setSystemTime(new Date('2024-01-01T00:00:02Z'));
+		expect(() => store.getResource(agentId, listing.path)).toThrow(FileManagerError);
+		expect(() => store.getResource(agentId)).toThrow(FileManagerError);
+	});
+
+	it('falls back to the next available directory when the default is removed', () => {
+		const store = new FileManagerStore({ expirationMs: -1 });
+		const agentId = 'agent-2';
+		const first = baseDirectory('/var');
+		const second = baseDirectory('/home');
+
+		store.ingestResource(agentId, first);
+		store.ingestResource(agentId, second);
+
+		store.removeResource(agentId, second.path);
+
+		const resource = store.getResource(agentId);
+		expect(resource).toMatchObject({ path: first.path });
+	});
+});

--- a/tenvy-server/src/lib/server/rat/file-manager.ts
+++ b/tenvy-server/src/lib/server/rat/file-manager.ts
@@ -161,6 +161,18 @@ export class FileManagerError extends Error {
 	}
 }
 
+interface FileManagerStoreOptions {
+	/**
+	 * Milliseconds a resource remains cached before being pruned.
+	 * Set to a negative value to disable pruning.
+	 */
+	expirationMs?: number;
+	/**
+	 * Minimum interval between pruning attempts per agent.
+	 */
+	pruneIntervalMs?: number;
+}
+
 export class FileManagerStore {
 	private directories = new Map<string, Map<string, ResourceRecord<DirectoryListing>>>();
 
@@ -169,6 +181,17 @@ export class FileManagerStore {
 	private roots = new Map<string, string>();
 
 	private defaults = new Map<string, string>();
+
+	private lastPruned = new Map<string, number>();
+
+	private readonly expirationMs: number;
+
+	private readonly pruneIntervalMs: number;
+
+	constructor(options: FileManagerStoreOptions = {}) {
+		this.expirationMs = options.expirationMs ?? 5 * 60_000;
+		this.pruneIntervalMs = options.pruneIntervalMs ?? 30_000;
+	}
 
 	ingestResource(agentId: string, resource: unknown): FileManagerResource {
 		ensureAgent(agentId);
@@ -200,6 +223,9 @@ export class FileManagerStore {
 
 	getResource(agentId: string, path?: string | null): FileManagerResource {
 		ensureAgent(agentId);
+
+		const now = Date.now();
+		this.pruneAgent(agentId, now);
 
 		const normalized =
 			typeof path === 'string' && path.trim().length > 0 ? normalizePath(path) : undefined;
@@ -238,6 +264,7 @@ export class FileManagerStore {
 		this.files.delete(agentId);
 		this.defaults.delete(agentId);
 		this.roots.delete(agentId);
+		this.lastPruned.delete(agentId);
 	}
 
 	removeResource(agentId: string, path: string): void {
@@ -246,19 +273,21 @@ export class FileManagerStore {
 			throw new FileManagerError('Path is required for removal', 400);
 		}
 		const normalized = normalizePath(path);
-		this.directories.get(agentId)?.delete(normalized);
-		this.files.get(agentId)?.delete(normalized);
-		const fallback = this.defaults.get(agentId);
-		if (fallback === normalized) {
-			this.defaults.delete(agentId);
-		}
+		const directories = this.directories.get(agentId);
+		const files = this.files.get(agentId);
+		directories?.delete(normalized);
+		files?.delete(normalized);
+		this.updateDefaultDirectory(agentId, directories);
+		this.cleanupAgentMaps(agentId, directories, files);
 	}
 
 	private storeDirectory(agentId: string, listing: DirectoryListing): DirectoryListing {
+		const now = Date.now();
+		this.pruneAgent(agentId, now, true);
 		const directories =
 			this.directories.get(agentId) ?? new Map<string, ResourceRecord<DirectoryListing>>();
 		const cloned = cloneDirectory(listing);
-		directories.set(cloned.path, { value: cloned, storedAt: new Date() });
+		directories.set(cloned.path, { value: cloned, storedAt: new Date(now) });
 		this.directories.set(agentId, directories);
 		this.roots.set(agentId, cloned.root);
 		this.defaults.set(agentId, cloned.path);
@@ -266,14 +295,103 @@ export class FileManagerStore {
 	}
 
 	private storeFile(agentId: string, resource: FileContent): FileContent {
+		const now = Date.now();
+		this.pruneAgent(agentId, now, true);
 		const files = this.files.get(agentId) ?? new Map<string, ResourceRecord<FileContent>>();
 		const cloned = cloneFile(resource);
-		files.set(cloned.path, { value: cloned, storedAt: new Date() });
+		files.set(cloned.path, { value: cloned, storedAt: new Date(now) });
 		this.files.set(agentId, files);
 		if (!this.roots.has(agentId)) {
 			this.roots.set(agentId, cloned.root);
 		}
 		return cloneFile(cloned);
+	}
+
+	private pruneAgent(agentId: string, now: number, force = false): void {
+		if (this.expirationMs < 0) {
+			return;
+		}
+
+		const last = this.lastPruned.get(agentId);
+		if (!force && last !== undefined && now - last < this.pruneIntervalMs) {
+			return;
+		}
+
+		const cutoff = now - this.expirationMs;
+		const directories = this.directories.get(agentId);
+		const files = this.files.get(agentId);
+
+                const pruneMap = <T extends FileManagerResource>(
+                        map: Map<string, ResourceRecord<T>> | undefined
+                ) => {
+			if (!map) {
+				return undefined;
+			}
+			for (const [key, record] of map) {
+				if (record.storedAt.getTime() <= cutoff) {
+					map.delete(key);
+				}
+			}
+			return map.size > 0 ? map : undefined;
+		};
+
+		const prunedDirectories = pruneMap(directories);
+		const prunedFiles = pruneMap(files);
+
+		if (prunedDirectories === undefined) {
+			this.directories.delete(agentId);
+		}
+		if (prunedFiles === undefined) {
+			this.files.delete(agentId);
+		}
+
+		const activeDirectories =
+			prunedDirectories ?? (directories && directories.size > 0 ? directories : undefined);
+		const activeFiles = prunedFiles ?? (files && files.size > 0 ? files : undefined);
+
+		this.updateDefaultDirectory(agentId, activeDirectories);
+		this.cleanupAgentMaps(agentId, activeDirectories, activeFiles);
+
+		if (!this.directories.has(agentId) && !this.files.has(agentId)) {
+			this.lastPruned.delete(agentId);
+		} else {
+			this.lastPruned.set(agentId, now);
+		}
+	}
+
+	private updateDefaultDirectory(
+		agentId: string,
+		directories: Map<string, ResourceRecord<DirectoryListing>> | undefined
+	): void {
+		const currentDefault = this.defaults.get(agentId);
+		if (!directories || directories.size === 0) {
+			this.defaults.delete(agentId);
+			return;
+		}
+
+		if (!currentDefault || !directories.has(currentDefault)) {
+			const first = directories.keys().next().value as string | undefined;
+			if (first) {
+				this.defaults.set(agentId, first);
+			}
+		}
+	}
+
+	private cleanupAgentMaps(
+		agentId: string,
+		directories: Map<string, ResourceRecord<DirectoryListing>> | undefined,
+		files: Map<string, ResourceRecord<FileContent>> | undefined
+	): void {
+		const hasDirectories = directories !== undefined && directories.size > 0;
+		const hasFiles = files !== undefined && files.size > 0;
+
+		if (!hasDirectories && !hasFiles) {
+			this.directories.delete(agentId);
+			this.files.delete(agentId);
+			this.roots.delete(agentId);
+			this.defaults.delete(agentId);
+			this.lastPruned.delete(agentId);
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- introduce configurable cache expiration for file manager resources and prune stale entries
- ensure default directories are kept in sync when entries are removed or expire
- add targeted unit coverage for cache eviction and default fallback behaviour

## Testing
- bun test:unit -- --run src/lib/server/rat/file-manager.test.ts
- bun lint (fails: repository contains existing Prettier violations outside the change scope)
- bun check (fails: pre-existing svelte-check error in routes/(app)/+layout.svelte)


------
https://chatgpt.com/codex/tasks/task_e_68f1e2c94210832b8df6a3b08eec1c4c