### PR TITLE
Refactor remote desktop input handling and metrics layout

### DIFF
--- a/shared/types/messages.ts
+++ b/shared/types/messages.ts
@@ -1,6 +1,9 @@
 import type { AgentConfig } from "./config";
 import type { AgentMetrics, AgentStatus } from "./agent";
-import type { RemoteDesktopCommandPayload } from "./remote-desktop";
+import type {
+  RemoteDesktopCommandPayload,
+  RemoteDesktopInputBurst,
+} from "./remote-desktop";
 import type { AudioControlCommandPayload } from "./audio";
 import type { ClipboardCommandPayload } from "./clipboard";
 import type { RecoveryCommandPayload } from "./recovery";
@@ -121,3 +124,12 @@ export interface AgentCommandEnvelope {
   type: "command";
   command: Command;
 }
+
+export interface AgentRemoteDesktopInputEnvelope {
+  type: "remote-desktop-input";
+  input: RemoteDesktopInputBurst;
+}
+
+export type AgentEnvelope =
+  | AgentCommandEnvelope
+  | AgentRemoteDesktopInputEnvelope;

--- a/shared/types/remote-desktop.ts
+++ b/shared/types/remote-desktop.ts
@@ -108,6 +108,12 @@ export interface RemoteDesktopCommandPayload {
   events?: RemoteDesktopInputEvent[];
 }
 
+export interface RemoteDesktopInputBurst {
+  sessionId: string;
+  events: RemoteDesktopInputEvent[];
+  sequence?: number;
+}
+
 export interface RemoteDesktopFrameMetrics {
   fps?: number;
   bandwidthKbps?: number;
@@ -164,6 +170,8 @@ export interface RemoteDesktopFramePacket {
   deltas?: RemoteDesktopDeltaRect[];
   clip?: RemoteDesktopVideoClip;
   encoder?: RemoteDesktopEncoder;
+  encoderHardware?: string;
+  intraRefresh?: boolean;
   monitors?: RemoteDesktopMonitor[];
   cursor?: RemoteDesktopCursorState;
   metrics?: RemoteDesktopFrameMetrics;
@@ -188,6 +196,7 @@ export interface RemoteDesktopSessionState {
   negotiatedTransport?: RemoteDesktopTransport;
   negotiatedCodec?: RemoteDesktopEncoder;
   intraRefresh?: boolean;
+  encoderHardware?: string;
   monitors: RemoteDesktopMonitor[];
   metrics?: RemoteDesktopFrameMetrics;
 }

--- a/tenvy-client/internal/modules/control/remotedesktop/types.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/types.go
@@ -167,20 +167,22 @@ type RemoteDesktopDeltaRect struct {
 }
 
 type RemoteDesktopFramePacket struct {
-	SessionID string                     `json:"sessionId"`
-	Sequence  uint64                     `json:"sequence"`
-	Timestamp string                     `json:"timestamp"`
-	Width     int                        `json:"width"`
-	Height    int                        `json:"height"`
-	KeyFrame  bool                       `json:"keyFrame"`
-	Encoding  string                     `json:"encoding"`
-	Transport RemoteDesktopTransport     `json:"transport,omitempty"`
-	Image     string                     `json:"image,omitempty"`
-	Deltas    []RemoteDesktopDeltaRect   `json:"deltas,omitempty"`
-	Clip      *RemoteDesktopVideoClip    `json:"clip,omitempty"`
-	Encoder   RemoteDesktopEncoder       `json:"encoder,omitempty"`
-	Monitors  []RemoteDesktopMonitorInfo `json:"monitors,omitempty"`
-	Metrics   *RemoteDesktopFrameMetrics `json:"metrics,omitempty"`
+	SessionID       string                     `json:"sessionId"`
+	Sequence        uint64                     `json:"sequence"`
+	Timestamp       string                     `json:"timestamp"`
+	Width           int                        `json:"width"`
+	Height          int                        `json:"height"`
+	KeyFrame        bool                       `json:"keyFrame"`
+	Encoding        string                     `json:"encoding"`
+	Transport       RemoteDesktopTransport     `json:"transport,omitempty"`
+	Image           string                     `json:"image,omitempty"`
+	Deltas          []RemoteDesktopDeltaRect   `json:"deltas,omitempty"`
+	Clip            *RemoteDesktopVideoClip    `json:"clip,omitempty"`
+	Encoder         RemoteDesktopEncoder       `json:"encoder,omitempty"`
+	EncoderHardware string                     `json:"encoderHardware,omitempty"`
+	IntraRefresh    bool                       `json:"intraRefresh,omitempty"`
+	Monitors        []RemoteDesktopMonitorInfo `json:"monitors,omitempty"`
+	Metrics         *RemoteDesktopFrameMetrics `json:"metrics,omitempty"`
 }
 
 type RemoteDesktopTransportCapability struct {
@@ -236,6 +238,7 @@ type RemoteDesktopSession struct {
 	NegotiatedCodec    RemoteDesktopEncoder
 	Transport          RemoteDesktopTransport
 	IntraRefresh       bool
+	EncoderHardware    string
 	Width              int
 	Height             int
 	TileSize           int

--- a/tenvy-client/internal/modules/control/remotedesktop/video_encoder.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/video_encoder.go
@@ -35,6 +35,7 @@ type clipEncodeOptions struct {
 	ForceKey      bool
 	TargetBitrate int
 	FrameInterval time.Duration
+	IntraRefresh  bool
 }
 
 type clipEncodeResult struct {
@@ -215,6 +216,9 @@ func (e *ffmpegClipEncoder) encodeWithCandidate(
 
 	if len(candidate.extraArgs) > 0 {
 		args = append(args, candidate.extraArgs...)
+	}
+	if opts.IntraRefresh {
+		args = append(args, "-intra-refresh", "1")
 	}
 
 	container := strings.TrimSpace(e.container)

--- a/tenvy-client/internal/protocol/types.go
+++ b/tenvy-client/internal/protocol/types.go
@@ -32,8 +32,9 @@ type Command struct {
 }
 
 type CommandEnvelope struct {
-	Type    string   `json:"type"`
-	Command *Command `json:"command,omitempty"`
+	Type    string                   `json:"type"`
+	Command *Command                 `json:"command,omitempty"`
+	Input   *RemoteDesktopInputBurst `json:"input,omitempty"`
 }
 
 type CommandResult struct {
@@ -42,6 +43,43 @@ type CommandResult struct {
 	Output      string `json:"output,omitempty"`
 	Error       string `json:"error,omitempty"`
 	CompletedAt string `json:"completedAt"`
+}
+
+type RemoteDesktopInputType string
+
+const (
+	RemoteDesktopInputMouseMove   RemoteDesktopInputType = "mouse-move"
+	RemoteDesktopInputMouseButton RemoteDesktopInputType = "mouse-button"
+	RemoteDesktopInputMouseScroll RemoteDesktopInputType = "mouse-scroll"
+	RemoteDesktopInputKey         RemoteDesktopInputType = "key"
+)
+
+type RemoteDesktopInputEvent struct {
+	Type       RemoteDesktopInputType `json:"type"`
+	CapturedAt int64                  `json:"capturedAt"`
+	X          float64                `json:"x,omitempty"`
+	Y          float64                `json:"y,omitempty"`
+	Normalized bool                   `json:"normalized,omitempty"`
+	Monitor    *int                   `json:"monitor,omitempty"`
+	Button     string                 `json:"button,omitempty"`
+	Pressed    bool                   `json:"pressed,omitempty"`
+	DeltaX     float64                `json:"deltaX,omitempty"`
+	DeltaY     float64                `json:"deltaY,omitempty"`
+	DeltaMode  int                    `json:"deltaMode,omitempty"`
+	Key        string                 `json:"key,omitempty"`
+	Code       string                 `json:"code,omitempty"`
+	KeyCode    int                    `json:"keyCode,omitempty"`
+	Repeat     bool                   `json:"repeat,omitempty"`
+	AltKey     bool                   `json:"altKey,omitempty"`
+	CtrlKey    bool                   `json:"ctrlKey,omitempty"`
+	ShiftKey   bool                   `json:"shiftKey,omitempty"`
+	MetaKey    bool                   `json:"metaKey,omitempty"`
+}
+
+type RemoteDesktopInputBurst struct {
+	SessionID string                    `json:"sessionId"`
+	Sequence  int64                     `json:"sequence,omitempty"`
+	Events    []RemoteDesktopInputEvent `json:"events"`
 }
 
 type AgentMetadata struct {

--- a/tenvy-server/src/lib/server/rat/remote-desktop.ts
+++ b/tenvy-server/src/lib/server/rat/remote-desktop.ts
@@ -1,17 +1,20 @@
 import { randomUUID } from 'crypto';
 import type {
-	RemoteDesktopEncoder,
-	RemoteDesktopFrameMetrics,
-	RemoteDesktopFramePacket,
-	RemoteDesktopMonitor,
-	RemoteDesktopSessionNegotiationRequest,
-	RemoteDesktopSessionNegotiationResponse,
-	RemoteDesktopSessionState,
-	RemoteDesktopSettings,
-	RemoteDesktopSettingsPatch,
-	RemoteDesktopTransport,
-	RemoteDesktopTransportCapability
+        RemoteDesktopEncoder,
+        RemoteDesktopFrameMetrics,
+        RemoteDesktopFramePacket,
+        RemoteDesktopInputBurst,
+        RemoteDesktopInputEvent,
+        RemoteDesktopMonitor,
+        RemoteDesktopSessionNegotiationRequest,
+        RemoteDesktopSessionNegotiationResponse,
+        RemoteDesktopSessionState,
+        RemoteDesktopSettings,
+        RemoteDesktopSettingsPatch,
+        RemoteDesktopTransport,
+        RemoteDesktopTransportCapability
 } from '$lib/types/remote-desktop';
+import { registry } from './store';
 
 const encoder = new TextEncoder();
 const HEARTBEAT_INTERVAL_MS = 15_000;
@@ -53,22 +56,24 @@ class RemoteDesktopError extends Error {
 }
 
 interface RemoteDesktopSessionRecord {
-	id: string;
-	agentId: string;
-	active: boolean;
-	createdAt: Date;
-	lastUpdatedAt?: Date;
-	lastSequence?: number;
-	settings: RemoteDesktopSettings;
-	activeEncoder?: RemoteDesktopEncoder;
-	negotiatedCodec?: RemoteDesktopEncoder;
-	transport?: RemoteDesktopTransport;
-	intraRefresh?: boolean;
-	monitors: RemoteDesktopMonitor[];
-	metrics?: RemoteDesktopFrameMetrics;
-	history: RemoteDesktopFramePacket[];
-	hasKeyFrame: boolean;
-	transportHandle?: RemoteDesktopTransportHandle | null;
+        id: string;
+        agentId: string;
+        active: boolean;
+        createdAt: Date;
+        lastUpdatedAt?: Date;
+        lastSequence?: number;
+        settings: RemoteDesktopSettings;
+        activeEncoder?: RemoteDesktopEncoder;
+        negotiatedCodec?: RemoteDesktopEncoder;
+        transport?: RemoteDesktopTransport;
+        intraRefresh?: boolean;
+        encoderHardware?: string;
+        monitors: RemoteDesktopMonitor[];
+        metrics?: RemoteDesktopFrameMetrics;
+        history: RemoteDesktopFramePacket[];
+        hasKeyFrame: boolean;
+        transportHandle?: RemoteDesktopTransportHandle | null;
+        inputSequence: number;
 }
 
 interface RemoteDesktopSubscriber {
@@ -136,12 +141,18 @@ function validateFramePacket(frame: RemoteDesktopFramePacket) {
 	if (!isFiniteNumber(frame.sequence)) {
 		throw new RemoteDesktopError('Invalid frame sequence number', 400);
 	}
-	if (typeof frame.encoding !== 'string' || frame.encoding.length === 0) {
-		throw new RemoteDesktopError('Frame encoding is required', 400);
-	}
-	if (typeof frame.timestamp !== 'string' || frame.timestamp.length === 0) {
-		throw new RemoteDesktopError('Frame timestamp is required', 400);
-	}
+        if (typeof frame.encoding !== 'string' || frame.encoding.length === 0) {
+                throw new RemoteDesktopError('Frame encoding is required', 400);
+        }
+        if (typeof frame.timestamp !== 'string' || frame.timestamp.length === 0) {
+                throw new RemoteDesktopError('Frame timestamp is required', 400);
+        }
+        if (frame.encoderHardware !== undefined && typeof frame.encoderHardware !== 'string') {
+                throw new RemoteDesktopError('Encoder hardware label must be a string', 400);
+        }
+        if (frame.intraRefresh !== undefined && typeof frame.intraRefresh !== 'boolean') {
+                throw new RemoteDesktopError('Intra-refresh flag must be boolean', 400);
+        }
 
 	if (frame.image) {
 		validateBase64Payload(frame.image, 'Frame');
@@ -411,14 +422,15 @@ function toSessionState(record: RemoteDesktopSessionRecord): RemoteDesktopSessio
 		createdAt: record.createdAt.toISOString(),
 		lastUpdatedAt: record.lastUpdatedAt?.toISOString(),
 		lastSequence: record.lastSequence,
-		settings: cloneSettings(record.settings),
-		activeEncoder: record.activeEncoder,
-		negotiatedTransport: record.transport,
-		negotiatedCodec: record.negotiatedCodec,
-		intraRefresh: record.intraRefresh,
-		monitors: cloneMonitors(record.monitors),
-		metrics: record.metrics ? { ...record.metrics } : undefined
-	};
+                settings: cloneSettings(record.settings),
+                activeEncoder: record.activeEncoder,
+                negotiatedTransport: record.transport,
+                negotiatedCodec: record.negotiatedCodec,
+                intraRefresh: record.intraRefresh,
+                encoderHardware: record.encoderHardware,
+                monitors: cloneMonitors(record.monitors),
+                metrics: record.metrics ? { ...record.metrics } : undefined
+        };
 }
 
 export class RemoteDesktopManager {
@@ -432,18 +444,19 @@ export class RemoteDesktopManager {
 		}
 
 		const resolved = resolveSettings(settings);
-		const record: RemoteDesktopSessionRecord = {
-			id: randomUUID(),
-			agentId,
-			active: true,
-			createdAt: new Date(),
-			settings: resolved,
-			activeEncoder: resolved.encoder,
-			monitors: cloneMonitors(defaultMonitors),
-			history: [],
-			hasKeyFrame: false,
-			transportHandle: null
-		};
+                const record: RemoteDesktopSessionRecord = {
+                        id: randomUUID(),
+                        agentId,
+                        active: true,
+                        createdAt: new Date(),
+                        settings: resolved,
+                        activeEncoder: resolved.encoder,
+                        monitors: cloneMonitors(defaultMonitors),
+                        history: [],
+                        hasKeyFrame: false,
+                        transportHandle: null,
+                        inputSequence: 0
+                };
 
 		this.sessions.set(agentId, record);
 		this.broadcastSession(agentId);
@@ -462,11 +475,11 @@ export class RemoteDesktopManager {
 		return toSessionState(record);
 	}
 
-	updateSettings(agentId: string, updates: RemoteDesktopSettingsPatch) {
-		const record = this.sessions.get(agentId);
-		if (!record || !record.active) {
-			throw new RemoteDesktopError('No active remote desktop session', 404);
-		}
+        updateSettings(agentId: string, updates: RemoteDesktopSettingsPatch) {
+                const record = this.sessions.get(agentId);
+                if (!record || !record.active) {
+                        throw new RemoteDesktopError('No active remote desktop session', 404);
+                }
 		applySettings(record.settings, updates);
 		if (updates.encoder) {
 			record.activeEncoder = updates.encoder;
@@ -477,8 +490,57 @@ export class RemoteDesktopManager {
 				Math.min(record.settings.monitor, record.monitors.length - 1)
 			);
 		}
-		this.broadcastSession(agentId);
-	}
+                this.broadcastSession(agentId);
+        }
+
+        dispatchInput(
+                agentId: string,
+                sessionId: string,
+                events: RemoteDesktopInputEvent[],
+                options: { sequence?: number } = {}
+        ): { delivered: boolean; sequence: number | null } {
+                const record = this.sessions.get(agentId);
+                if (!record || !record.active) {
+                        throw new RemoteDesktopError('No active remote desktop session', 404);
+                }
+                if (record.id !== sessionId) {
+                        throw new RemoteDesktopError('Session identifier mismatch', 409);
+                }
+                if (!Array.isArray(events) || events.length === 0) {
+                        return { delivered: false, sequence: null };
+                }
+
+                const sequence = this.reserveInputSequence(record, options.sequence);
+                if (sequence === null) {
+                        return { delivered: false, sequence: null };
+                }
+
+                const burst: RemoteDesktopInputBurst = { sessionId, events, sequence };
+
+                let delivered = false;
+                try {
+                        delivered = registry.sendRemoteDesktopInput(agentId, burst);
+                } catch (err) {
+                        console.error('Failed to deliver remote desktop input burst', err);
+                }
+
+                if (!delivered) {
+                        try {
+                                registry.queueCommand(agentId, {
+                                        name: 'remote-desktop',
+                                        payload: {
+                                                action: 'input',
+                                                sessionId,
+                                                events
+                                        }
+                                });
+                        } catch (err) {
+                                console.error('Failed to enqueue remote desktop input fallback command', err);
+                        }
+                }
+
+                return { delivered, sequence };
+        }
 
 	async negotiateTransport(
 		agentId: string,
@@ -574,13 +636,14 @@ export class RemoteDesktopManager {
 		const record = this.sessions.get(agentId);
 		if (!record) {
 			return;
-		}
-		record.active = false;
-		this.replaceTransportHandle(record, null);
-		record.lastUpdatedAt = new Date();
-		this.broadcastSession(agentId);
-		this.broadcast(agentId, 'end', { reason: 'closed' });
-	}
+                }
+                record.active = false;
+                this.replaceTransportHandle(record, null);
+                record.lastUpdatedAt = new Date();
+                record.inputSequence = 0;
+                this.broadcastSession(agentId);
+                this.broadcast(agentId, 'end', { reason: 'closed' });
+        }
 
 	ingestFrame(agentId: string, frame: RemoteDesktopFramePacket) {
 		const record = this.sessions.get(agentId);
@@ -593,47 +656,60 @@ export class RemoteDesktopManager {
 
 		validateFramePacket(frame);
 
-		let transportChanged = false;
-		if (frame.transport && transports.has(frame.transport)) {
-			if (record.transport !== frame.transport) {
-				record.transport = frame.transport;
-				transportChanged = true;
-			}
-		}
+                let sessionChanged = false;
+                if (frame.transport && transports.has(frame.transport)) {
+                        if (record.transport !== frame.transport) {
+                                record.transport = frame.transport;
+                                sessionChanged = true;
+                        }
+                }
 
-		record.lastSequence = frame.sequence;
-		record.lastUpdatedAt = new Date();
-		if (frame.metrics) {
-			record.metrics = { ...frame.metrics };
-		}
+                record.lastSequence = frame.sequence;
+                record.lastUpdatedAt = new Date();
+                if (frame.metrics) {
+                        record.metrics = { ...frame.metrics };
+                }
 
-		if (frame.encoder && encoders.has(frame.encoder)) {
-			record.activeEncoder = frame.encoder;
-		}
+                if (frame.encoder && encoders.has(frame.encoder)) {
+                        record.activeEncoder = frame.encoder;
+                }
 
-		if (frame.monitors && frame.monitors.length > 0) {
-			const next = cloneMonitors(frame.monitors);
-			if (!monitorsEqual(record.monitors, next)) {
-				record.monitors = next;
+                if (typeof frame.intraRefresh === 'boolean' && frame.intraRefresh !== record.intraRefresh) {
+                        record.intraRefresh = frame.intraRefresh;
+                        sessionChanged = true;
+                }
+
+                if (typeof frame.encoderHardware === 'string' && frame.encoderHardware.trim() !== '') {
+                        const normalizedHardware = frame.encoderHardware.trim();
+                        if (record.encoderHardware !== normalizedHardware) {
+                                record.encoderHardware = normalizedHardware;
+                                sessionChanged = true;
+                        }
+                }
+
+                if (frame.monitors && frame.monitors.length > 0) {
+                        const next = cloneMonitors(frame.monitors);
+                        if (!monitorsEqual(record.monitors, next)) {
+                                record.monitors = next;
 				if (record.settings.monitor >= record.monitors.length) {
 					record.settings.monitor = Math.max(
 						0,
 						Math.min(record.settings.monitor, record.monitors.length - 1)
 					);
 				}
-				this.broadcastSession(agentId);
-				transportChanged = false;
-			}
-		}
+                                this.broadcastSession(agentId);
+                                sessionChanged = false;
+                        }
+                }
 
-		appendFrameHistory(record, cloneFrame(frame));
+                appendFrameHistory(record, cloneFrame(frame));
 
-		if (transportChanged) {
-			this.broadcastSession(agentId);
-		}
+                if (sessionChanged) {
+                        this.broadcastSession(agentId);
+                }
 
-		this.broadcast(agentId, 'frame', { frame });
-	}
+                this.broadcast(agentId, 'frame', { frame });
+        }
 
 	subscribe(agentId: string, sessionId?: string): ReadableStream<Uint8Array> {
 		let subscriber: RemoteDesktopSubscriber | null = null;
@@ -727,11 +803,11 @@ export class RemoteDesktopManager {
 		}
 	}
 
-	private replaceTransportHandle(
-		record: RemoteDesktopSessionRecord,
-		handle: RemoteDesktopTransportHandle | null
-	) {
-		if (!record) {
+        private replaceTransportHandle(
+                record: RemoteDesktopSessionRecord,
+                handle: RemoteDesktopTransportHandle | null
+        ) {
+                if (!record) {
 			return;
 		}
 		const previous = record.transportHandle;
@@ -741,8 +817,26 @@ export class RemoteDesktopManager {
 				previous.close();
 			} catch (err) {
 				console.error('Failed to close remote desktop transport', err);
-			}
-		}
+                }
+        }
+
+        private reserveInputSequence(
+                record: RemoteDesktopSessionRecord,
+                hint?: number
+        ): number | null {
+                const current = record.inputSequence ?? 0;
+                if (typeof hint === 'number' && Number.isFinite(hint)) {
+                        const normalized = Math.trunc(hint);
+                        if (normalized <= current) {
+                                return null;
+                        }
+                        record.inputSequence = normalized;
+                        return normalized;
+                }
+                const next = current + 1;
+                record.inputSequence = next;
+                return next;
+        }
 	}
 
 	private async establishWebRTCTransport(

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/modules/control/remote-desktop/SessionMetricsGrid.svelte
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/modules/control/remote-desktop/SessionMetricsGrid.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+        import { formatLatency, formatMetric, formatResolution } from './formatters';
+
+        export let fps: number | null;
+        export let bandwidth: number | null;
+        export let clipQuality: number | null;
+        export let streamWidth: number | null;
+        export let streamHeight: number | null;
+        export let latencyMs: number | null;
+</script>
+
+<div class="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-5">
+        <div class="rounded-lg border border-border/60 bg-background/60 p-3">
+                <p class="text-xs text-muted-foreground uppercase">FPS</p>
+                <p class="text-sm font-semibold text-foreground">{formatMetric(fps, 'fps')}</p>
+        </div>
+        <div class="rounded-lg border border-border/60 bg-background/60 p-3">
+                <p class="text-xs text-muted-foreground uppercase">Bandwidth</p>
+                <p class="text-sm font-semibold text-foreground">{formatMetric(bandwidth, 'kbps')}</p>
+        </div>
+        <div class="rounded-lg border border-border/60 bg-background/60 p-3">
+                <p class="text-xs text-muted-foreground">JPEG quality</p>
+                <p class="text-sm font-semibold text-foreground">
+                        {clipQuality === null || Number.isNaN(clipQuality) ? '--' : `Q${Math.round(clipQuality)}`}
+                </p>
+        </div>
+        <div class="rounded-lg border border-border/60 bg-background/60 p-3">
+                <p class="text-xs text-muted-foreground">Resolution</p>
+                <p class="text-sm font-semibold text-foreground">{formatResolution(streamWidth, streamHeight)}</p>
+        </div>
+        <div class="rounded-lg border border-border/60 bg-background/60 p-3">
+                <p class="text-xs text-muted-foreground">Latency</p>
+                <p class="text-sm font-semibold text-foreground">{formatLatency(latencyMs)}</p>
+        </div>
+</div>

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/modules/control/remote-desktop/formatters.ts
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/modules/control/remote-desktop/formatters.ts
@@ -1,0 +1,39 @@
+export function formatMetric(value: number | null, suffix: string, digits = 1) {
+        if (value === null || Number.isNaN(value)) {
+                return `-- ${suffix}`;
+        }
+        return `${value.toFixed(digits)} ${suffix}`;
+}
+
+export function formatPercent(value: number | null) {
+        if (value === null || Number.isNaN(value)) {
+                return '-- %';
+        }
+        return `${Math.round(value)}%`;
+}
+
+export function formatResolution(width: number | null, height: number | null) {
+        if (width === null || height === null || Number.isNaN(width) || Number.isNaN(height)) {
+                return '--';
+        }
+        return `${width}×${height}`;
+}
+
+export function formatLatency(value: number | null) {
+        if (value === null || Number.isNaN(value)) {
+                return '-- ms';
+        }
+        if (value >= 1000) {
+                return `${(value / 1000).toFixed(1)} s`;
+        }
+        return `${Math.round(value)} ms`;
+}
+
+export function formatTimestamp(value: string | null | undefined) {
+        if (!value) return '—';
+        const parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) {
+                return value;
+        }
+        return parsed.toLocaleTimeString();
+}

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/modules/control/remote-desktop/input-channel.ts
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/modules/control/remote-desktop/input-channel.ts
@@ -1,0 +1,188 @@
+import { browser } from '$app/environment';
+import type { RemoteDesktopInputEvent } from '$lib/types/remote-desktop';
+
+export interface InputChannelOptions {
+        dispatch: (events: RemoteDesktopInputEvent[]) => Promise<boolean>;
+        historyWindowMs?: number;
+        onDispatchFailure?: (events: RemoteDesktopInputEvent[]) => void;
+        onDispatchError?: (error: unknown, events: RemoteDesktopInputEvent[]) => void;
+        raf?: typeof requestAnimationFrame;
+        cancelRaf?: typeof cancelAnimationFrame;
+}
+
+export interface InputChannel {
+        captureTimestamp(): number;
+        normalize(event: RemoteDesktopInputEvent): void;
+        enqueue(event: RemoteDesktopInputEvent): void;
+        enqueueBatch(events: RemoteDesktopInputEvent[]): void;
+        clear(): void;
+        resolveLatency(presentationMs: number): number | null;
+        computeLatency(timestamp?: string | null): number | null;
+}
+
+const DEFAULT_HISTORY_WINDOW_MS = 4_000;
+
+export function createInputChannel(options: InputChannelOptions): InputChannel {
+        const queue: RemoteDesktopInputEvent[] = [];
+        const history: number[] = [];
+        const historyWindowMs = options.historyWindowMs ?? DEFAULT_HISTORY_WINDOW_MS;
+
+        let flushHandle: number | null = null;
+        let sending = false;
+
+        const raf = options.raf ?? (browser && typeof requestAnimationFrame === 'function' ? requestAnimationFrame : undefined);
+        const cancelRaf = options.cancelRaf ?? (browser && typeof cancelAnimationFrame === 'function' ? cancelAnimationFrame : undefined);
+
+        const captureTimestamp = () => {
+                if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+                        return Math.round(performance.timeOrigin + performance.now());
+                }
+                return Date.now();
+        };
+
+        const trimHistory = (cutoff: number) => {
+                if (history.length === 0) {
+                        return;
+                }
+                let removeCount = 0;
+                for (const value of history) {
+                        if (value < cutoff) {
+                                removeCount += 1;
+                                continue;
+                        }
+                        break;
+                }
+                if (removeCount > 0) {
+                        history.splice(0, removeCount);
+                }
+        };
+
+        const recordTimestamp = (timestamp: number) => {
+                if (!Number.isFinite(timestamp)) {
+                        return;
+                }
+                history.push(timestamp);
+                trimHistory(timestamp - historyWindowMs);
+        };
+
+        const normalize = (event: RemoteDesktopInputEvent) => {
+                if (typeof event.capturedAt !== 'number' || !Number.isFinite(event.capturedAt)) {
+                        event.capturedAt = captureTimestamp();
+                        return;
+                }
+                event.capturedAt = Math.trunc(event.capturedAt);
+        };
+
+        const resolveLatency = (presentationMs: number) => {
+                if (!Number.isFinite(presentationMs)) {
+                        return null;
+                }
+                let anchor: number | null = null;
+                for (let index = history.length - 1; index >= 0; index -= 1) {
+                        const value = history[index];
+                        if (value <= presentationMs) {
+                                anchor = value;
+                                break;
+                        }
+                }
+                trimHistory(presentationMs - historyWindowMs);
+                if (anchor === null) {
+                        const delta = Date.now() - presentationMs;
+                        return delta < 0 ? 0 : delta;
+                }
+                const delta = presentationMs - anchor;
+                return delta < 0 ? 0 : delta;
+        };
+
+        const computeLatency = (timestamp?: string | null) => {
+                if (!timestamp) {
+                        return null;
+                }
+                const parsed = Date.parse(timestamp);
+                if (Number.isNaN(parsed)) {
+                        return null;
+                }
+                return resolveLatency(parsed);
+        };
+
+        const scheduleFlush = () => {
+                if (!browser || queue.length === 0 || typeof raf !== 'function') {
+                        return;
+                }
+                if (flushHandle !== null) {
+                        return;
+                }
+                flushHandle = raf(() => {
+                        flushHandle = null;
+                        void flush();
+                });
+        };
+
+        const flush = async () => {
+                if (sending || queue.length === 0) {
+                        return;
+                }
+                sending = true;
+                const events = queue.splice(0, queue.length);
+                try {
+                        const success = await options.dispatch(events);
+                        if (!success) {
+                                queue.unshift(...events);
+                                options.onDispatchFailure?.(events);
+                        }
+                } catch (error) {
+                        queue.unshift(...events);
+                        options.onDispatchError?.(error, events);
+                } finally {
+                        sending = false;
+                        if (queue.length > 0) {
+                                scheduleFlush();
+                        }
+                }
+        };
+
+        const enqueue = (event: RemoteDesktopInputEvent) => {
+                if (!browser) {
+                        return;
+                }
+                normalize(event);
+                if (typeof event.capturedAt === 'number') {
+                        recordTimestamp(event.capturedAt);
+                }
+                queue.push(event);
+                scheduleFlush();
+        };
+
+        const enqueueBatch = (events: RemoteDesktopInputEvent[]) => {
+                if (!browser || events.length === 0) {
+                        return;
+                }
+                for (const event of events) {
+                        normalize(event);
+                        if (typeof event.capturedAt === 'number') {
+                                recordTimestamp(event.capturedAt);
+                        }
+                        queue.push(event);
+                }
+                scheduleFlush();
+        };
+
+        const clear = () => {
+                queue.length = 0;
+                history.length = 0;
+                if (browser && flushHandle !== null && typeof cancelRaf === 'function') {
+                        cancelRaf(flushHandle);
+                        flushHandle = null;
+                }
+        };
+
+        return {
+                captureTimestamp,
+                normalize,
+                enqueue,
+                enqueueBatch,
+                clear,
+                resolveLatency,
+                computeLatency
+        };
+}


### PR DESCRIPTION
## Summary
- encapsulate browser-side remote desktop input queuing and latency tracking in a reusable input channel helper
- extract metric formatting utilities and a dedicated SessionMetricsGrid component to shrink +page.svelte and improve separation of concerns
- update the remote desktop page to use the shared helpers, clear input state on disconnect, and compute latency via the channel

## Testing
- `bun format` *(fails: Script not found "format")*
- `bun lint` *(fails: Script not found "lint")*
- `bun check` *(fails: Script not found "check")*
- `go test ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68f22b273884832b9fa15d4b92875187