### PR TITLE
Fix settings sidebar snippet for svelte check

### DIFF
--- a/tenvy-server/src/lib/server/rat/remote-desktop.ts
+++ b/tenvy-server/src/lib/server/rat/remote-desktop.ts
@@ -789,27 +789,29 @@ export class RemoteDesktopManager {
 		}
 	}
 
-    private replaceTransportHandle(
-        record: RemoteDesktopSessionRecord,
-        handle: RemoteDesktopTransportHandle | null
+        private replaceTransportHandle(
+                record: RemoteDesktopSessionRecord,
+                handle: RemoteDesktopTransportHandle | null
         ) {
-        if (!record) {
-			return;
-		}
-		const previous = record.transportHandle;
-		record.transportHandle = handle ?? null;
-		if (previous && previous !== handle) {
-			try {
-				previous.close();
-			} catch (err) {
-				console.error('Failed to close remote desktop transport', err);
+                if (!record) {
+                        return;
+                }
+
+                const previous = record.transportHandle;
+                record.transportHandle = handle ?? null;
+
+                if (previous && previous !== handle) {
+                        try {
+                                previous.close();
+                        } catch (err) {
+                                console.error('Failed to close remote desktop transport', err);
+                        }
                 }
         }
-	}
 
-    private reserveInputSequence(
-        record: RemoteDesktopSessionRecord,
-        hint?: number
+        private reserveInputSequence(
+                record: RemoteDesktopSessionRecord,
+                hint?: number
         ): number | null {
                 const current = record.inputSequence ?? 0;
                 if (typeof hint === 'number' && Number.isFinite(hint)) {
@@ -824,7 +826,6 @@ export class RemoteDesktopManager {
                 record.inputSequence = next;
                 return next;
         }
-	}
 
 	private async establishWebRTCTransport(
 		agentId: string,

--- a/tenvy-server/src/routes/(app)/+layout.svelte
+++ b/tenvy-server/src/routes/(app)/+layout.svelte
@@ -424,6 +424,23 @@
 	}
 </script>
 
+{#snippet SettingsLink({ props }: SidebarMenuButtonChildContext)}
+        {@const { class: existingClass } = props as { class?: string }}
+        {@const className = cn('cursor-pointer', existingClass)}
+        <a
+                {...props}
+                class={className}
+                href="/settings"
+                data-sveltekit-preload-data="hover"
+                aria-current={(layoutData as LayoutData).activeNav === 'settings' ? 'page' : undefined}
+        >
+                <Settings />
+                <div class="flex min-w-0 flex-col gap-0.5 text-left">
+                        <span class="truncate text-sm font-medium">Settings</span>
+                </div>
+        </a>
+{/snippet}
+
 <SidebarProvider>
 	<Sidebar collapsible="icon">
 		<SidebarHeader class="border-b border-sidebar-border px-2 pt-3 pb-4">
@@ -471,27 +488,11 @@
 						{/if}
 					</SidebarMenuItem>
 				{/each}
-				{#snippet SettingsLink({ props }: SidebarMenuButtonChildContext)}
-					{@const { class: existingClass } = props as { class?: string }}
-					{@const className = cn('cursor-pointer', existingClass)}
-					<a
-						{...props}
-						class={className}
-						href="/settings"
-						data-sveltekit-preload-data="hover"
-						aria-current={(layoutData as LayoutData).activeNav === 'settings' ? 'page' : undefined}
-					>
-						<Settings />
-						<div class="flex min-w-0 flex-col gap-0.5 text-left">
-							<span class="truncate text-sm font-medium">Settings</span>
-						</div>
-					</a>
-				{/snippet}
-				<SidebarMenuItem class="hidden cursor-pointer group-data-[state=collapsed]:block">
-					<SidebarMenuButton
-						isActive={(layoutData as LayoutData).activeNav === 'settings'}
-						tooltipContent="Settings"
-						child={SettingsLink}
+                                <SidebarMenuItem class="hidden cursor-pointer group-data-[state=collapsed]:block">
+                                        <SidebarMenuButton
+                                                isActive={(layoutData as LayoutData).activeNav === 'settings'}
+                                                tooltipContent="Settings"
+                                                child={SettingsLink}
 					/>
 				</SidebarMenuItem>
 			</SidebarMenu>


### PR DESCRIPTION
## Summary
- define the `SettingsLink` sidebar snippet at the top level so Svelte no longer misinterprets it as a prop
- continue reusing the snippet for the collapsed settings button while keeping the aria-current state intact

## Testing
- bun check

------
https://chatgpt.com/codex/tasks/task_e_68f24242d21c832bb91258ff04dc9789