### PR TITLE
Optimize remote desktop monitor sync and frame cloning

### DIFF
--- a/tenvy-server/src/lib/server/rat/remote-desktop.ts
+++ b/tenvy-server/src/lib/server/rat/remote-desktop.ts
@@ -115,7 +115,28 @@ function monitorsEqual(a: readonly RemoteDesktopMonitor[], b: readonly RemoteDes
 }
 
 function cloneFrame(frame: RemoteDesktopFramePacket): RemoteDesktopFramePacket {
-	return structuredClone(frame);
+	const cloned: RemoteDesktopFramePacket = { ...frame };
+
+	if (Array.isArray(frame.deltas)) {
+		cloned.deltas = frame.deltas.map((delta) => ({ ...delta }));
+	}
+
+	if (frame.clip) {
+		cloned.clip = {
+			durationMs: frame.clip.durationMs,
+			frames: frame.clip.frames.map((clipFrame) => ({ ...clipFrame }))
+		};
+	}
+
+	if (Array.isArray(frame.monitors)) {
+		cloned.monitors = cloneMonitors(frame.monitors);
+	}
+
+	if (frame.metrics) {
+		cloned.metrics = { ...frame.metrics };
+	}
+
+	return cloned;
 }
 
 function isFiniteNumber(value: unknown): value is number {


### PR DESCRIPTION
## Summary
- clear the remote desktop monitor dirty flag after a successful video frame so metadata is not resent every clip
- make the metrics helper tolerate optional extras used by the stream code
- replace structuredClone in the remote desktop history cache with a cheap manual clone to cut CPU and GC pressure

## Testing
- go test ./... (in tenvy-client)


------
https://chatgpt.com/codex/tasks/task_e_68f248f5fef4832ba79dc627d4aeb565