### PR TITLE
Improve agent remote desktop input handling and registry queue limits

### DIFF
--- a/tenvy-client/internal/agent/agent.go
+++ b/tenvy-client/internal/agent/agent.go
@@ -12,24 +12,26 @@ import (
 )
 
 type Agent struct {
-	id             string
-	key            string
-	baseURL        string
-	client         *http.Client
-	config         protocol.AgentConfig
-	logger         *log.Logger
-	resultMu       sync.Mutex
-	pendingResults []protocol.CommandResult
-	startTime      time.Time
-	metadata       protocol.AgentMetadata
-	sharedSecret   string
-	preferences    BuildPreferences
-	notes          *notes.Manager
-	buildVersion   string
-	timing         TimingOverride
-	modules        *moduleRegistry
-	commands       *commandRouter
-	connectionFlag atomic.Uint32
+	id                      string
+	key                     string
+	baseURL                 string
+	client                  *http.Client
+	config                  protocol.AgentConfig
+	logger                  *log.Logger
+	resultMu                sync.Mutex
+	pendingResults          []protocol.CommandResult
+	startTime               time.Time
+	metadata                protocol.AgentMetadata
+	sharedSecret            string
+	preferences             BuildPreferences
+	notes                   *notes.Manager
+	buildVersion            string
+	timing                  TimingOverride
+	modules                 *moduleRegistry
+	commands                *commandRouter
+	connectionFlag          atomic.Uint32
+	remoteDesktopInputOnce  sync.Once
+	remoteDesktopInputQueue chan remoteDesktopInputTask
 }
 
 func (a *Agent) AgentID() string {

--- a/tenvy-client/internal/agent/lifecycle.go
+++ b/tenvy-client/internal/agent/lifecycle.go
@@ -202,7 +202,7 @@ func (a *Agent) reRegister(ctx context.Context) error {
 		return ctx.Err()
 	}
 
-	metadata := CollectMetadata(a.buildVersion)
+	metadata := CollectMetadataWithClient(a.buildVersion, a.client)
 	registration, err := registerAgentWithRetry(ctx, a.logger, a.client, a.baseURL, a.sharedSecret, metadata, a.maxBackoff())
 	if err != nil {
 		return err

--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -49,7 +49,7 @@ func Run(ctx context.Context, opts RuntimeOptions) error {
 
 	metadata := opts.Metadata
 	if strings.TrimSpace(metadata.Hostname) == "" {
-		metadata = CollectMetadata(opts.BuildVersion)
+		metadata = CollectMetadataWithClient(opts.BuildVersion, opts.HTTPClient)
 	}
 
 	client := opts.HTTPClient


### PR DESCRIPTION
## Summary
- serialize remote desktop input bursts through a bounded worker on the Go agent to preserve order and surface backpressure
- reuse the runtime HTTP client for metadata collection, caching public IP lookups behind a client-aware helper to avoid repeated external calls
- cap the controller registry's pending command queue, trim oversized snapshots, log drops, persist compact JSON, and cover the new behavior with tests

## Testing
- bun test *(fails: Playwright suite requires browser runtime; clipboard/file-manager specs expect vi.useFakeTimers)*

------
https://chatgpt.com/codex/tasks/task_e_68f2612382d0832bab2f87c9da96c0f4