### PR TITLE
Revert lint relaxation and fix targeted issues

### DIFF
--- a/tenvy-server/src/global.d.ts
+++ b/tenvy-server/src/global.d.ts
@@ -1,13 +1,13 @@
 declare module '@simplewebauthn/server' {
-	export const generateRegistrationOptions: (...args: any[]) => Promise<any>;
-	export const verifyRegistrationResponse: (...args: any[]) => Promise<any>;
-	export const generateAuthenticationOptions: (...args: any[]) => Promise<any>;
-	export const verifyAuthenticationResponse: (...args: any[]) => Promise<any>;
+        export const generateRegistrationOptions: (...args: unknown[]) => Promise<unknown>;
+        export const verifyRegistrationResponse: (...args: unknown[]) => Promise<unknown>;
+        export const generateAuthenticationOptions: (...args: unknown[]) => Promise<unknown>;
+        export const verifyAuthenticationResponse: (...args: unknown[]) => Promise<unknown>;
 }
 
 declare module '@simplewebauthn/browser' {
-	export const startRegistration: (...args: any[]) => Promise<any>;
-	export const startAuthentication: (...args: any[]) => Promise<any>;
+        export const startRegistration: (...args: unknown[]) => Promise<unknown>;
+        export const startAuthentication: (...args: unknown[]) => Promise<unknown>;
 }
 
 declare module '$lib/paraglide/server' {
@@ -22,6 +22,6 @@ declare module '$lib/paraglide/runtime' {
 }
 
 declare module 'systeminformation' {
-	const value: any;
-	export default value;
+        const value: unknown;
+        export default value;
 }

--- a/tenvy-server/src/lib/components/client-context-menu.svelte
+++ b/tenvy-server/src/lib/components/client-context-menu.svelte
@@ -8,7 +8,8 @@
 		ContextMenuSubContent,
 		ContextMenuSubTrigger
 	} from '$lib/components/ui/context-menu/index.js';
-	import { goto, invalidateAll } from '$app/navigation';
+        import { goto, invalidateAll } from '$app/navigation';
+        import { resolve } from '$app/paths';
 	import { browser } from '$app/environment';
 	import type { Client } from '$lib/data/clients';
 	import ClientToolDialog from '$lib/components/client-tool-dialog.svelte';
@@ -182,10 +183,10 @@
 
 		if (!browser) return;
 
-		if (target === '_self') {
-			goto(url);
-			return;
-		}
+                if (target === '_self') {
+                        goto(resolve(url));
+                        return;
+                }
 
 		window.open(url, target, 'noopener,noreferrer');
 	}

--- a/tenvy-server/src/lib/components/client-tool-dialog.svelte
+++ b/tenvy-server/src/lib/components/client-tool-dialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
-	import { goto } from '$app/navigation';
+        import { goto } from '$app/navigation';
+        import { resolve } from '$app/paths';
 	import { createEventDispatcher, onMount } from 'svelte';
 	import * as Dialog from '$lib/components/ui/dialog/index.js';
 	import MovableWindow from '$lib/components/ui/movablewindow/MovableWindow.svelte';
@@ -160,8 +161,8 @@
 	async function openWorkspace() {
 		if (!browser) return;
 		requestClose();
-		await goto(workspaceUrl);
-	}
+                await goto(resolve(workspaceUrl));
+        }
 
 	const selectClasses =
 		'flex h-9 w-full min-w-0 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs ring-offset-background transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:bg-input/30';

--- a/tenvy-server/src/lib/components/ui/button/button.svelte
+++ b/tenvy-server/src/lib/components/ui/button/button.svelte
@@ -40,41 +40,57 @@
 </script>
 
 <script lang="ts">
-	let {
-		class: className,
-		variant = 'default',
-		size = 'default',
-		ref = $bindable(null),
-		href = undefined,
-		type = 'button',
-		disabled,
-		children,
-		...restProps
-	}: ButtonProps = $props();
+        import { resolve } from '$app/paths';
+
+        let {
+                class: className,
+                variant = 'default',
+                size = 'default',
+                ref = $bindable(null),
+                href = undefined,
+                type = 'button',
+                disabled,
+                children,
+                ...restProps
+        }: ButtonProps = $props();
+
 </script>
 
 {#if href}
-	<a
-		bind:this={ref}
-		data-slot="button"
-		class={cn(buttonVariants({ variant, size }), className)}
-		href={disabled ? undefined : href}
-		aria-disabled={disabled}
-		role={disabled ? 'link' : undefined}
-		tabindex={disabled ? -1 : undefined}
-		{...restProps}
-	>
-		{@render children?.()}
-	</a>
+        {@const computedHref = typeof href === 'string' ? href : href.toString()}
+        {#if disabled}
+                <a
+                        bind:this={ref}
+                        data-slot="button"
+                        class={cn(buttonVariants({ variant, size }), className)}
+                        aria-disabled={true}
+                        role="link"
+                        tabindex={-1}
+                        {...restProps}
+                >
+                        {@render children?.()}
+                </a>
+        {:else}
+                <a
+                        bind:this={ref}
+                        data-slot="button"
+                        class={cn(buttonVariants({ variant, size }), className)}
+                        href={resolve(computedHref)}
+                        aria-disabled={false}
+                        {...restProps}
+                >
+                        {@render children?.()}
+                </a>
+        {/if}
 {:else}
-	<button
-		bind:this={ref}
-		data-slot="button"
-		class={cn(buttonVariants({ variant, size }), className)}
-		{type}
-		{disabled}
-		{...restProps}
-	>
-		{@render children?.()}
-	</button>
+        <button
+                bind:this={ref}
+                data-slot="button"
+                class={cn(buttonVariants({ variant, size }), className)}
+                {type}
+                {disabled}
+                {...restProps}
+        >
+                {@render children?.()}
+        </button>
 {/if}

--- a/tenvy-server/src/lib/components/ui/chart/chart-tooltip.svelte
+++ b/tenvy-server/src/lib/components/ui/chart/chart-tooltip.svelte
@@ -6,10 +6,9 @@
 	import { browser } from '$app/environment';
 	import type { Snippet } from 'svelte';
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	function defaultFormatter(value: any, _payload: TooltipPayload[]) {
-		return `${value}`;
-	}
+        function defaultFormatter(value: unknown) {
+                return `${value}`;
+        }
 
 	let {
 		ref = $bindable(null),
@@ -33,8 +32,8 @@
 		labelKey?: string;
 		hideIndicator?: boolean;
 		labelClassName?: string;
-		labelFormatter?: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-		((value: any, payload: TooltipPayload[]) => string | number | Snippet) | null;
+                labelFormatter?:
+                        ((value: unknown, payload: TooltipPayload[]) => string | number | Snippet) | null;
 		formatter?: Snippet<
 			[
 				{

--- a/tenvy-server/src/routes/login/+page.svelte
+++ b/tenvy-server/src/routes/login/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
+        import { goto } from '$app/navigation';
+        import { resolve } from '$app/paths';
 	import { startAuthentication } from '@simplewebauthn/browser';
 	import { AlertCircle, KeyRound, LogIn } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
@@ -49,7 +50,7 @@
 				throw new Error(message ?? 'Passkey verification failed.');
 			}
 
-			await goto('/dashboard');
+                        await goto(resolve('/dashboard'));
 		} catch (error) {
 			errorMessage =
 				error instanceof Error ? error.message : 'Unable to authenticate with passkey.';

--- a/tenvy-server/src/routes/redeem/+page.svelte
+++ b/tenvy-server/src/routes/redeem/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
+        import { goto } from '$app/navigation';
+        import { resolve } from '$app/paths';
 	import { startRegistration } from '@simplewebauthn/browser';
 	import { AlertCircle, Check, KeyRound, Shield } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
@@ -92,8 +93,8 @@
 	}
 
 	async function finishOnboarding() {
-		await goto('/dashboard');
-	}
+                await goto(resolve('/dashboard'));
+        }
 </script>
 
 <svelte:head>
@@ -195,13 +196,13 @@
 							<h2 class="text-sm font-medium tracking-wide text-muted-foreground uppercase">
 								One-time recovery codes
 							</h2>
-							<div class="grid gap-2 md:grid-cols-2">
-								{#each recoveryCodes as code}
-									<div
-										class="rounded-md border border-dashed border-emerald-400/50 bg-emerald-400/10 px-3 py-2 font-mono text-sm tracking-widest text-emerald-400"
-									>
-										{code}
-									</div>
+                                                        <div class="grid gap-2 md:grid-cols-2">
+                                                                {#each recoveryCodes as code, index (code ?? index)}
+                                                                        <div
+                                                                                class="rounded-md border border-dashed border-emerald-400/50 bg-emerald-400/10 px-3 py-2 font-mono text-sm tracking-widest text-emerald-400"
+                                                                        >
+                                                                                {code}
+                                                                        </div>
 								{/each}
 							</div>
 							<p class="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- restore the previous ESLint configuration instead of downgrading rule severities
- update global type declarations and chart tooltip helpers to avoid `any` usage
- resolve navigation warnings by using SvelteKit's `resolve()` for goto/link targets and add missing each block keys

## Testing
- bunx eslint src/global.d.ts src/lib/components/client-context-menu.svelte src/lib/components/client-tool-dialog.svelte src/lib/components/ui/button/button.svelte src/lib/components/ui/chart/chart-tooltip.svelte src/routes/login/+page.svelte src/routes/redeem/+page.svelte

------
https://chatgpt.com/codex/tasks/task_e_68f280a38e54832b90ffbc0a57c4768d