### PR TITLE
Harden remote desktop input worker shutdown

### DIFF
--- a/tenvy-client/internal/agent/agent.go
+++ b/tenvy-client/internal/agent/agent.go
@@ -12,26 +12,29 @@ import (
 )
 
 type Agent struct {
-	id                      string
-	key                     string
-	baseURL                 string
-	client                  *http.Client
-	config                  protocol.AgentConfig
-	logger                  *log.Logger
-	resultMu                sync.Mutex
-	pendingResults          []protocol.CommandResult
-	startTime               time.Time
-	metadata                protocol.AgentMetadata
-	sharedSecret            string
-	preferences             BuildPreferences
-	notes                   *notes.Manager
-	buildVersion            string
-	timing                  TimingOverride
-	modules                 *moduleRegistry
-	commands                *commandRouter
-	connectionFlag          atomic.Uint32
-	remoteDesktopInputOnce  sync.Once
-	remoteDesktopInputQueue chan remoteDesktopInputTask
+	id                           string
+	key                          string
+	baseURL                      string
+	client                       *http.Client
+	config                       protocol.AgentConfig
+	logger                       *log.Logger
+	resultMu                     sync.Mutex
+	pendingResults               []protocol.CommandResult
+	startTime                    time.Time
+	metadata                     protocol.AgentMetadata
+	sharedSecret                 string
+	preferences                  BuildPreferences
+	notes                        *notes.Manager
+	buildVersion                 string
+	timing                       TimingOverride
+	modules                      *moduleRegistry
+	commands                     *commandRouter
+	connectionFlag               atomic.Uint32
+	remoteDesktopInputOnce       sync.Once
+	remoteDesktopInputSignalOnce sync.Once
+	remoteDesktopInputQueue      chan remoteDesktopInputTask
+	remoteDesktopInputStopCh     chan struct{}
+	remoteDesktopInputStopped    atomic.Bool
 }
 
 func (a *Agent) AgentID() string {

--- a/tenvy-client/internal/agent/lifecycle.go
+++ b/tenvy-client/internal/agent/lifecycle.go
@@ -327,6 +327,7 @@ func (a *Agent) userAgent() string {
 }
 
 func (a *Agent) shutdown(ctx context.Context) {
+	a.stopRemoteDesktopInputWorker()
 	if a.modules != nil {
 		a.modules.Shutdown(ctx)
 	}


### PR DESCRIPTION
## Summary
- guard remote desktop input handling once the agent has started shutting down so bursts are dropped safely
- manage the worker queue with a dedicated stop signal instead of closing the work channel to avoid panic races
- extend the unit tests to cover shutdown signalling, post-stop behaviour, and stopping before the worker is started

## Testing
- go test ./internal/agent -run TestStopRemoteDesktopInputWorker -count=1 *(hangs while downloading/building dependencies, run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68f37757d638832bbbb11cc42ec0c134