### PR TITLE
Fix systeminformation stub regression

### DIFF
--- a/tenvy-server/src/global.d.ts
+++ b/tenvy-server/src/global.d.ts
@@ -22,6 +22,6 @@ declare module '$lib/paraglide/runtime' {
 }
 
 declare module 'systeminformation' {
-        const value: unknown;
+        const value: any;
         export default value;
 }


### PR DESCRIPTION
## Summary
- revert the global systeminformation module stub to `any` so existing code can access its members

## Testing
- bun check *(fails: existing type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f3976fd18c832b8bef13d6ade3f77e