### PR TITLE
Sort command history by completion time

### DIFF
--- a/tenvy-server/src/lib/server/rat/store.test.ts
+++ b/tenvy-server/src/lib/server/rat/store.test.ts
@@ -140,17 +140,20 @@ describe('AgentRegistry persistence hygiene', () => {
 			results: [...duplicateResults, ...extraResults]
 		});
 
-		registry.updateAgentTags(registration.agentId, ['primary']);
+                registry.updateAgentTags(registration.agentId, ['primary']);
 
-		const snapshot = registry.getAgent(registration.agentId);
-		expect(snapshot.recentResults).toHaveLength(MAX_RECENT_RESULTS);
-		const uniqueIds = new Set(snapshot.recentResults.map((result) => result.commandId));
-		expect(uniqueIds.size).toBe(snapshot.recentResults.length);
+                const snapshot = registry.getAgent(registration.agentId);
+                expect(snapshot.recentResults).toHaveLength(MAX_RECENT_RESULTS);
+                const uniqueIds = new Set(snapshot.recentResults.map((result) => result.commandId));
+                expect(uniqueIds.size).toBe(snapshot.recentResults.length);
+                const completedAt = snapshot.recentResults.map((result) => Date.parse(result.completedAt));
+                const sortedCompletedAt = [...completedAt].sort((a, b) => b - a);
+                expect(completedAt).toEqual(sortedCompletedAt);
 
-		snapshot.metadata.hostname = 'mutated-host';
-		snapshot.metadata.tags?.push('mutated');
-		if (snapshot.recentResults.length > 0) {
-			snapshot.recentResults[0]!.commandId = 'mutated';
+                snapshot.metadata.hostname = 'mutated-host';
+                snapshot.metadata.tags?.push('mutated');
+                if (snapshot.recentResults.length > 0) {
+                        snapshot.recentResults[0]!.commandId = 'mutated';
 		}
 
 		const nextSnapshot = registry.getAgent(registration.agentId);


### PR DESCRIPTION
## Summary
- rewrite the registry command result merge to keep the newest completions and drop stale duplicates
- verify command history ordering through an updated persistence hygiene test

## Testing
- bun test *(fails: Playwright and browser-mode suites require tools that are unavailable in the container; Vitest unit suites covering the registry succeed)*

------
https://chatgpt.com/codex/tasks/task_e_68f3af437d8c832b880edc4c4fb822ba