### PR TITLE
Use baked server URL for runtime options

### DIFF
--- a/tenvy-client/cmd/config.go
+++ b/tenvy-client/cmd/config.go
@@ -27,7 +27,7 @@ var (
 )
 
 func loadRuntimeOptions(logger *log.Logger) (agent.RuntimeOptions, error) {
-	serverURL := strings.TrimRight(getEnv("TENVY_SERVER_URL", defaultServerURL()), "/")
+	serverURL := strings.TrimRight(defaultServerURL(), "/")
 	if serverURL == "" {
 		return agent.RuntimeOptions{}, errors.New("server url must be provided")
 	}
@@ -127,13 +127,6 @@ func parsePositiveDurationSeconds(raw string) time.Duration {
 		return 0
 	}
 	return time.Duration(value) * time.Second
-}
-
-func getEnv(key, fallbackValue string) string {
-	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
-		return value
-	}
-	return fallbackValue
 }
 
 func fallback(value, fallbackValue string) string {


### PR DESCRIPTION
## Summary
- stop reading TENVY_SERVER_URL and always rely on the baked default URL when loading runtime options
- remove the unused getEnv helper from the client configuration

## Testing
- go build -o tenvy ./cmd

------
https://chatgpt.com/codex/tasks/task_e_68f3df633ca0832b95c5c752a5195074