### PR TITLE
Fix remote desktop workspace session initialization race

### DIFF
--- a/tenvy-server/src/lib/components/workspace/tools/remote-desktop/remote-desktop-workspace.svelte
+++ b/tenvy-server/src/lib/components/workspace/tools/remote-desktop/remote-desktop-workspace.svelte
@@ -157,19 +157,22 @@
 
         async function refreshSession() {
                 if (!browser || !client) {
-                        return;
+                        return session;
                 }
                 try {
                         const response = await fetch(`/api/agents/${client.id}/remote-desktop/session`);
                         if (!response.ok) {
-                                return;
+                                return session;
                         }
                         const payload = (await response.json()) as {
                                 session?: RemoteDesktopSessionState | null;
                         };
-                        session = payload.session ?? null;
+                        const nextSession = payload.session ?? null;
+                        session = nextSession;
+                        return nextSession;
                 } catch (err) {
                         console.warn('Failed to refresh remote desktop session state', err);
+                        return session;
                 }
         }
 
@@ -998,12 +1001,12 @@
                 let destroyed = false;
 
                 const initialize = async () => {
-                        await refreshSession();
+                        const currentSession = await refreshSession();
                         if (destroyed) {
                                 return;
                         }
-                        if (sessionActive && sessionId) {
-                                connectStream(sessionId);
+                        if (currentSession?.active && currentSession.sessionId) {
+                                connectStream(currentSession.sessionId);
                         } else {
                                 maybeStartSession();
                         }


### PR DESCRIPTION
## Summary
- return the refreshed remote desktop session state so initialization can read the latest data immediately
- base the initial connection logic on the freshly fetched session to avoid starting duplicate sessions

## Testing
- not run (existing TypeScript issues in bun check noted in original PR)

------
https://chatgpt.com/codex/tasks/task_e_68f49583cdb0832b8ece65e3e237ad29