### PR TITLE
Add cross-platform startup registration

### DIFF
--- a/tenvy-client/internal/agent/preferences_darwin_test.go
+++ b/tenvy-client/internal/agent/preferences_darwin_test.go
@@ -1,0 +1,39 @@
+//go:build darwin
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegisterStartupPreferenceDarwin(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	target := filepath.Join(tmp, "Applications", "tenvy")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("prepare target dir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	if err := configureStartupPreference(target); err != nil {
+		t.Fatalf("configure startup: %v", err)
+	}
+
+	plistPath := filepath.Join(tmp, macLaunchAgentsDir, macPlistName)
+	if _, err := os.Stat(plistPath); err != nil {
+		t.Fatalf("stat plist: %v", err)
+	}
+
+	if err := unregisterStartup(); err != nil {
+		t.Fatalf("unregister startup: %v", err)
+	}
+
+	if _, err := os.Stat(plistPath); !os.IsNotExist(err) {
+		t.Fatalf("plist still present after unregister: %v", err)
+	}
+}

--- a/tenvy-client/internal/agent/preferences_linux_test.go
+++ b/tenvy-client/internal/agent/preferences_linux_test.go
@@ -1,0 +1,90 @@
+//go:build linux
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestConfigureStartupPreferenceLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux specific test")
+	}
+
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	target := filepath.Join(tmp, "bin", "tenvy-agent")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("prepare target dir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("binary"), 0o755); err != nil {
+		t.Fatalf("write target binary: %v", err)
+	}
+
+	if err := configureStartupPreference(target); err != nil {
+		t.Fatalf("configure startup: %v", err)
+	}
+
+	entryPath := filepath.Join(tmp, ".config", "tenvy", "startup-target.txt")
+	data, err := os.ReadFile(entryPath)
+	if err != nil {
+		t.Fatalf("read startup entry: %v", err)
+	}
+	if string(data) != target+"\n" {
+		t.Fatalf("unexpected startup entry contents: %q", string(data))
+	}
+
+	systemdDir := filepath.Join(tmp, ".config", "systemd", "user")
+	servicePath := filepath.Join(systemdDir, linuxServiceName)
+	unit, err := os.ReadFile(servicePath)
+	if err != nil {
+		t.Fatalf("read systemd unit: %v", err)
+	}
+	if !strings.Contains(string(unit), target) {
+		t.Fatalf("systemd unit missing target: %s", string(unit))
+	}
+
+	wantsLink := filepath.Join(systemdDir, linuxServiceTarget, linuxServiceName)
+	info, err := os.Lstat(wantsLink)
+	if err != nil {
+		t.Fatalf("lstat wants link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("expected symlink at %s", wantsLink)
+	}
+	linkDest, err := os.Readlink(wantsLink)
+	if err != nil {
+		t.Fatalf("read symlink: %v", err)
+	}
+	if linkDest != servicePath {
+		t.Fatalf("unexpected symlink destination: %s", linkDest)
+	}
+
+	cronPath := filepath.Join(tmp, ".config", "cron", "tenvy-agent.cron")
+	cronData, err := os.ReadFile(cronPath)
+	if err != nil {
+		t.Fatalf("read cron entry: %v", err)
+	}
+	if string(cronData) != "@reboot "+target+"\n" {
+		t.Fatalf("unexpected cron contents: %q", string(cronData))
+	}
+
+	if err := unregisterStartup(); err != nil {
+		t.Fatalf("unregister startup: %v", err)
+	}
+
+	if _, err := os.Stat(servicePath); !os.IsNotExist(err) {
+		t.Fatalf("systemd unit still present after unregister: %v", err)
+	}
+	if _, err := os.Lstat(wantsLink); !os.IsNotExist(err) {
+		t.Fatalf("wants link still present after unregister: %v", err)
+	}
+	if _, err := os.Stat(cronPath); !os.IsNotExist(err) {
+		t.Fatalf("cron entry still present after unregister: %v", err)
+	}
+}

--- a/tenvy-client/internal/agent/preferences_windows_test.go
+++ b/tenvy-client/internal/agent/preferences_windows_test.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegisterStartupPreferenceWindows(t *testing.T) {
+	tmp := t.TempDir()
+	runFile := filepath.Join(tmp, "run.txt")
+	t.Setenv("TENVY_WINDOWS_RUN_FILE", runFile)
+
+	target := `C:\\Program Files\\Tenvy\\tenvy.exe`
+	if err := registerStartup(target); err != nil {
+		t.Fatalf("register startup: %v", err)
+	}
+
+	data, err := os.ReadFile(runFile)
+	if err != nil {
+		t.Fatalf("read redirected run file: %v", err)
+	}
+	if string(data) != target {
+		t.Fatalf("unexpected run file contents: %q", string(data))
+	}
+
+	if err := unregisterStartup(); err != nil {
+		t.Fatalf("unregister startup: %v", err)
+	}
+
+	if _, err := os.Stat(runFile); !os.IsNotExist(err) {
+		t.Fatalf("run file still present after unregister: %v", err)
+	}
+}

--- a/tenvy-client/internal/agent/startup_darwin.go
+++ b/tenvy-client/internal/agent/startup_darwin.go
@@ -1,0 +1,63 @@
+//go:build darwin
+
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	macLaunchAgentsDir = "Library/LaunchAgents"
+	macPlistName       = "com.tenvy.agent.plist"
+)
+
+func registerStartup(target string) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	launchDir := filepath.Join(homeDir, macLaunchAgentsDir)
+	if err := os.MkdirAll(launchDir, 0o755); err != nil {
+		return fmt.Errorf("create LaunchAgents directory: %w", err)
+	}
+
+	plistPath := filepath.Join(launchDir, macPlistName)
+	plist := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.tenvy.agent</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>%s</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+`, target)
+
+	if err := os.WriteFile(plistPath, []byte(plist), 0o644); err != nil {
+		return fmt.Errorf("write LaunchAgent plist: %w", err)
+	}
+
+	return nil
+}
+
+func unregisterStartup() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	plistPath := filepath.Join(homeDir, macLaunchAgentsDir, macPlistName)
+	if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove LaunchAgent plist: %w", err)
+	}
+
+	return nil
+}

--- a/tenvy-client/internal/agent/startup_linux.go
+++ b/tenvy-client/internal/agent/startup_linux.go
@@ -1,0 +1,102 @@
+//go:build linux
+
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	linuxSystemdDir    = ".config/systemd/user"
+	linuxServiceName   = "tenvy-agent.service"
+	linuxServiceTarget = "default.target.wants"
+)
+
+func registerStartup(target string) error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	systemdDir := filepath.Join(homeDir, linuxSystemdDir)
+	if err := os.MkdirAll(systemdDir, 0o755); err != nil {
+		return fmt.Errorf("create systemd directory: %w", err)
+	}
+
+	servicePath := filepath.Join(systemdDir, linuxServiceName)
+	unit := fmt.Sprintf(`[Unit]
+Description=Tenvy Agent
+After=network.target
+
+[Service]
+Type=simple
+ExecStart="%s"
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+`, target)
+
+	if err := os.WriteFile(servicePath, []byte(unit), 0o644); err != nil {
+		return fmt.Errorf("write systemd unit: %w", err)
+	}
+
+	wantsDir := filepath.Join(systemdDir, linuxServiceTarget)
+	if err := os.MkdirAll(wantsDir, 0o755); err != nil {
+		return fmt.Errorf("create wants directory: %w", err)
+	}
+
+	linkPath := filepath.Join(wantsDir, linuxServiceName)
+	if err := os.Remove(linkPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("replace wants symlink: %w", err)
+	}
+
+	if err := os.Symlink(servicePath, linkPath); err != nil {
+		if !errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("link systemd unit: %w", err)
+		}
+	}
+
+	cronDir := filepath.Join(homeDir, ".config", "cron")
+	if err := os.MkdirAll(cronDir, 0o755); err != nil {
+		return fmt.Errorf("create cron directory: %w", err)
+	}
+
+	cronPath := filepath.Join(cronDir, "tenvy-agent.cron")
+	cronEntry := fmt.Sprintf("@reboot %s\n", target)
+	if err := os.WriteFile(cronPath, []byte(cronEntry), 0o644); err != nil {
+		return fmt.Errorf("write cron entry: %w", err)
+	}
+
+	return nil
+}
+
+func unregisterStartup() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+
+	systemdDir := filepath.Join(homeDir, linuxSystemdDir)
+	servicePath := filepath.Join(systemdDir, linuxServiceName)
+	wantsDir := filepath.Join(systemdDir, linuxServiceTarget)
+	linkPath := filepath.Join(wantsDir, linuxServiceName)
+
+	if err := os.Remove(linkPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove wants symlink: %w", err)
+	}
+
+	if err := os.Remove(servicePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove systemd unit: %w", err)
+	}
+
+	cronPath := filepath.Join(homeDir, ".config", "cron", "tenvy-agent.cron")
+	if err := os.Remove(cronPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove cron entry: %w", err)
+	}
+
+	return nil
+}

--- a/tenvy-client/internal/agent/startup_unsupported.go
+++ b/tenvy-client/internal/agent/startup_unsupported.go
@@ -1,0 +1,16 @@
+//go:build !linux && !darwin && !windows
+
+package agent
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func registerStartup(target string) error {
+	return fmt.Errorf("startup registration not supported on %s", runtime.GOOS)
+}
+
+func unregisterStartup() error {
+	return nil
+}

--- a/tenvy-client/internal/agent/startup_windows.go
+++ b/tenvy-client/internal/agent/startup_windows.go
@@ -1,0 +1,61 @@
+//go:build windows
+
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+const (
+	windowsRunKey   = `Software\Microsoft\Windows\CurrentVersion\Run`
+	windowsRunValue = "TenvyAgent"
+)
+
+func registerStartup(target string) error {
+	if redirect := os.Getenv("TENVY_WINDOWS_RUN_FILE"); redirect != "" {
+		return os.WriteFile(redirect, []byte(target), 0o644)
+	}
+
+	key, _, err := registry.CreateKey(registry.CURRENT_USER, windowsRunKey, registry.SET_VALUE)
+	if err != nil {
+		return fmt.Errorf("open run key: %w", err)
+	}
+	defer key.Close()
+
+	if err := key.SetStringValue(windowsRunValue, fmt.Sprintf("\"%s\"", target)); err != nil {
+		return fmt.Errorf("set run value: %w", err)
+	}
+
+	return nil
+}
+
+func unregisterStartup() error {
+	if redirect := os.Getenv("TENVY_WINDOWS_RUN_FILE"); redirect != "" {
+		if err := os.Remove(redirect); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove redirected run file: %w", err)
+		}
+		return nil
+	}
+
+	key, err := registry.OpenKey(registry.CURRENT_USER, windowsRunKey, registry.SET_VALUE)
+	if err != nil {
+		if errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
+			return nil
+		}
+		return fmt.Errorf("open run key: %w", err)
+	}
+	defer key.Close()
+
+	if err := key.DeleteValue(windowsRunValue); err != nil {
+		if !errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
+			return fmt.Errorf("delete run value: %w", err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- reuse the resolved installation target when enabling startup preferences
- add OS-specific startup registration helpers for Windows, macOS, and Linux with fallbacks
- add unit tests validating autorun registration and cleanup behaviour per platform

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f504d32984832bb75b9cfacdbfa4e4