### PR TITLE
Add Linux and macOS remote desktop input synthesis

### DIFF
--- a/tenvy-client/internal/modules/control/remotedesktop/input_darwin.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/input_darwin.go
@@ -1,0 +1,418 @@
+//go:build darwin
+
+package remotedesktop
+
+/*
+#cgo CFLAGS: -x objective-c -fmodules -fobjc-arc
+#cgo LDFLAGS: -framework ApplicationServices -framework CoreGraphics
+#include <ApplicationServices/ApplicationServices.h>
+#include <CoreGraphics/CoreGraphics.h>
+#include <math.h>
+#include <stdbool.h>
+
+static CGPoint rd_current_position(void) {
+        CGEventRef event = CGEventCreate(NULL);
+        CGPoint location = CGEventGetLocation(event);
+        CFRelease(event);
+        return location;
+}
+
+static void rd_move_mouse(CGFloat x, CGFloat y) {
+        CGWarpMouseCursorPosition(CGPointMake(x, y));
+        CGAssociateMouseAndMouseCursorPosition(true);
+}
+
+static void rd_mouse_button(int button, bool down) {
+        CGPoint location = rd_current_position();
+        CGMouseButton cgButton = kCGMouseButtonLeft;
+        CGEventType typeDown = kCGEventLeftMouseDown;
+        CGEventType typeUp = kCGEventLeftMouseUp;
+        switch (button) {
+        case 0:
+                cgButton = kCGMouseButtonLeft;
+                typeDown = kCGEventLeftMouseDown;
+                typeUp = kCGEventLeftMouseUp;
+                break;
+        case 1:
+                cgButton = kCGMouseButtonRight;
+                typeDown = kCGEventRightMouseDown;
+                typeUp = kCGEventRightMouseUp;
+                break;
+        case 2:
+                cgButton = kCGMouseButtonCenter;
+                typeDown = kCGEventOtherMouseDown;
+                typeUp = kCGEventOtherMouseUp;
+                break;
+        default:
+                return;
+        }
+        CGEventType type = down ? typeDown : typeUp;
+        CGEventRef event = CGEventCreateMouseEvent(NULL, type, location, cgButton);
+        CGEventPost(kCGHIDEventTap, event);
+        CFRelease(event);
+}
+
+static void rd_scroll(double dx, double dy, int mode) {
+        CGScrollEventUnit unit = kCGScrollEventUnitLine;
+        double scale = 1.0;
+        if (mode == 0) {
+                unit = kCGScrollEventUnitPixel;
+                scale = 1.0;
+        } else if (mode == 2) {
+                scale = 3.0;
+        }
+        double xAmount = dx * scale;
+        double yAmount = dy * scale;
+        int32_t yValue = (int32_t)lround(-yAmount);
+        int32_t xValue = (int32_t)lround(xAmount);
+        CGEventRef event = CGEventCreateScrollWheelEvent(NULL, unit, 2, yValue, xValue);
+        CGEventPost(kCGHIDEventTap, event);
+        CFRelease(event);
+}
+
+static void rd_key_event(CGKeyCode code, bool down) {
+        CGEventRef event = CGEventCreateKeyboardEvent(NULL, code, down);
+        CGEventPost(kCGHIDEventTap, event);
+        CFRelease(event);
+}
+
+static void rd_unicode_event(uint32_t rune, bool down) {
+        UniChar chars[2];
+        size_t length = 0;
+        if (rune <= 0xFFFF) {
+                chars[0] = (UniChar)rune;
+                length = 1;
+        } else {
+                uint32_t value = rune - 0x10000;
+                chars[0] = (UniChar)((value >> 10) + 0xD800);
+                chars[1] = (UniChar)((value & 0x3FF) + 0xDC00);
+                length = 2;
+        }
+        CGEventRef event = CGEventCreateKeyboardEvent(NULL, (CGKeyCode)0, down);
+        CGEventKeyboardSetUnicodeString(event, length, chars);
+        CGEventPost(kCGHIDEventTap, event);
+        CFRelease(event);
+}
+
+static void rd_main_display_bounds(double *x, double *y, double *w, double *h) {
+        CGRect bounds = CGDisplayBounds(CGMainDisplayID());
+        if (x) *x = bounds.origin.x;
+        if (y) *y = bounds.origin.y;
+        if (w) *w = bounds.size.width;
+        if (h) *h = bounds.size.height;
+}
+*/
+import "C"
+
+import (
+	"image"
+	"strings"
+	"sync"
+	"unicode"
+)
+
+type macInput struct {
+	mu       sync.Mutex
+	fallback remoteMonitor
+}
+
+var (
+	macOnce     sync.Once
+	macInstance *macInput
+)
+
+func processRemoteInput(monitors []remoteMonitor, settings RemoteDesktopSettings, events []RemoteDesktopInputEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	input := macInputInstance()
+	fallback := selectMonitorForInputDarwin(monitors, settings.Monitor, input.fallback)
+
+	input.mu.Lock()
+	defer input.mu.Unlock()
+
+	for _, event := range events {
+		switch event.Type {
+		case RemoteInputMouseMove:
+			target := monitorFromEventDarwin(monitors, fallback, event.Monitor)
+			if err := input.movePointer(event, target); err != nil {
+				return err
+			}
+		case RemoteInputMouseButton:
+			if err := input.sendMouseButton(event.Button, event.Pressed); err != nil {
+				return err
+			}
+		case RemoteInputMouseScroll:
+			input.sendMouseScroll(event)
+		case RemoteInputKey:
+			if err := input.sendKeyEvent(event); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func macInputInstance() *macInput {
+	macOnce.Do(func() {
+		macInstance = &macInput{fallback: detectMacFallbackMonitor()}
+	})
+	return macInstance
+}
+
+func detectMacFallbackMonitor() remoteMonitor {
+	var x, y, w, h C.double
+	C.rd_main_display_bounds(&x, &y, &w, &h)
+	rect := image.Rect(int(x), int(y), int(x+w), int(y+h))
+	info := RemoteDesktopMonitorInfo{Width: rect.Dx(), Height: rect.Dy()}
+	return remoteMonitor{info: info, bounds: rect}
+}
+
+func selectMonitorForInputDarwin(monitors []remoteMonitor, index int, fallback remoteMonitor) remoteMonitor {
+	if len(monitors) == 0 {
+		return fallback
+	}
+	if index < 0 || index >= len(monitors) {
+		index = 0
+	}
+	return monitors[index]
+}
+
+func monitorFromEventDarwin(monitors []remoteMonitor, fallback remoteMonitor, override *int) remoteMonitor {
+	if override != nil {
+		idx := *override
+		if idx >= 0 && idx < len(monitors) {
+			return monitors[idx]
+		}
+	}
+	return fallback
+}
+
+func (m *macInput) movePointer(event RemoteDesktopInputEvent, monitor remoteMonitor) error {
+	x, y := resolvePointerPosition(event, monitor)
+	C.rd_move_mouse(C.CGFloat(x), C.CGFloat(y))
+	return nil
+}
+
+func (m *macInput) sendMouseButton(button RemoteDesktopMouseButton, pressed bool) error {
+	var code C.int
+	switch button {
+	case RemoteMouseButtonLeft:
+		code = 0
+	case RemoteMouseButtonRight:
+		code = 1
+	case RemoteMouseButtonMiddle:
+		code = 2
+	default:
+		return nil
+	}
+	down := C.bool(0)
+	if pressed {
+		down = C.bool(1)
+	}
+	C.rd_mouse_button(code, down)
+	return nil
+}
+
+func (m *macInput) sendMouseScroll(event RemoteDesktopInputEvent) {
+	C.rd_scroll(C.double(event.DeltaX), C.double(event.DeltaY), C.int(event.DeltaMode))
+}
+
+func (m *macInput) sendKeyEvent(event RemoteDesktopInputEvent) error {
+	if code, ok := macKeyCodeForEvent(event); ok {
+		down := C.bool(0)
+		if event.Pressed {
+			down = C.bool(1)
+		}
+		C.rd_key_event(C.CGKeyCode(code), down)
+		return nil
+	}
+	if len(event.Key) == 1 {
+		r := []rune(event.Key)[0]
+		down := C.bool(0)
+		if event.Pressed {
+			down = C.bool(1)
+		}
+		C.rd_unicode_event(C.uint(r), down)
+		return nil
+	}
+	return nil
+}
+
+func macKeyCodeForEvent(event RemoteDesktopInputEvent) (uint16, bool) {
+	if code, ok := macKeyCodeByCode[event.Code]; ok {
+		return code, true
+	}
+	if code, ok := macKeyCodeByKey[event.Key]; ok {
+		return code, true
+	}
+	if strings.HasPrefix(event.Code, "Key") && len(event.Code) == 4 {
+		if code, ok := macRuneKeyCode(rune(event.Code[3])); ok {
+			return code, true
+		}
+	}
+	if strings.HasPrefix(event.Code, "Digit") && len(event.Code) == 6 {
+		if code, ok := macRuneKeyCode(rune(event.Code[5])); ok {
+			return code, true
+		}
+	}
+	if strings.HasPrefix(event.Code, "Numpad") {
+		if code, ok := macKeyCodeByCode[event.Code]; ok {
+			return code, true
+		}
+	}
+	if len(event.Key) == 1 {
+		if code, ok := macRuneKeyCode([]rune(event.Key)[0]); ok {
+			return code, true
+		}
+	}
+	return 0, false
+}
+
+func macRuneKeyCode(r rune) (uint16, bool) {
+	if code, ok := macCharacterKeyCodes[r]; ok {
+		return code, true
+	}
+	upper := unicode.ToUpper(r)
+	if code, ok := macCharacterKeyCodes[upper]; ok {
+		return code, true
+	}
+	return 0, false
+}
+
+var macCharacterKeyCodes = map[rune]uint16{
+	'A':  0x00,
+	'S':  0x01,
+	'D':  0x02,
+	'F':  0x03,
+	'H':  0x04,
+	'G':  0x05,
+	'Z':  0x06,
+	'X':  0x07,
+	'C':  0x08,
+	'V':  0x09,
+	'B':  0x0B,
+	'Q':  0x0C,
+	'W':  0x0D,
+	'E':  0x0E,
+	'R':  0x0F,
+	'Y':  0x10,
+	'T':  0x11,
+	'1':  0x12,
+	'2':  0x13,
+	'3':  0x14,
+	'4':  0x15,
+	'6':  0x16,
+	'5':  0x17,
+	'=':  0x18,
+	'9':  0x19,
+	'7':  0x1A,
+	'-':  0x1B,
+	'8':  0x1C,
+	'0':  0x1D,
+	']':  0x1E,
+	'O':  0x1F,
+	'U':  0x20,
+	'[':  0x21,
+	'I':  0x22,
+	'P':  0x23,
+	'L':  0x25,
+	'J':  0x26,
+	'\'': 0x27,
+	'K':  0x28,
+	';':  0x29,
+	'\\': 0x2A,
+	',':  0x2B,
+	'/':  0x2C,
+	'N':  0x2D,
+	'M':  0x2E,
+	'.':  0x2F,
+	'`':  0x32,
+	' ':  0x31,
+}
+
+var macKeyCodeByKey = map[string]uint16{
+	"Backspace":    0x33,
+	"Delete":       0x75,
+	"Enter":        0x24,
+	"Return":       0x24,
+	"Tab":          0x30,
+	"Escape":       0x35,
+	"Space":        0x31,
+	" ":            0x31,
+	"ArrowUp":      0x7e,
+	"ArrowDown":    0x7d,
+	"ArrowLeft":    0x7b,
+	"ArrowRight":   0x7c,
+	"Home":         0x73,
+	"End":          0x77,
+	"PageUp":       0x74,
+	"PageDown":     0x79,
+	"Insert":       0x72,
+	"CapsLock":     0x39,
+	"Shift":        0x38,
+	"ShiftLeft":    0x38,
+	"ShiftRight":   0x3c,
+	"Control":      0x3b,
+	"ControlLeft":  0x3b,
+	"ControlRight": 0x3e,
+	"Alt":          0x3a,
+	"AltLeft":      0x3a,
+	"AltRight":     0x3d,
+	"Meta":         0x37,
+	"MetaLeft":     0x37,
+	"MetaRight":    0x36,
+	"ContextMenu":  0x6e,
+	"F1":           0x7a,
+	"F2":           0x78,
+	"F3":           0x63,
+	"F4":           0x76,
+	"F5":           0x60,
+	"F6":           0x61,
+	"F7":           0x62,
+	"F8":           0x64,
+	"F9":           0x65,
+	"F10":          0x6d,
+	"F11":          0x67,
+	"F12":          0x6f,
+}
+
+var macKeyCodeByCode = map[string]uint16{
+	"Backspace":      0x33,
+	"Delete":         0x75,
+	"Enter":          0x24,
+	"NumpadEnter":    0x4c,
+	"NumpadDivide":   0x4b,
+	"NumpadMultiply": 0x43,
+	"NumpadSubtract": 0x4e,
+	"NumpadAdd":      0x45,
+	"NumpadDecimal":  0x41,
+	"NumpadEqual":    0x51,
+	"Numpad0":        0x52,
+	"Numpad1":        0x53,
+	"Numpad2":        0x54,
+	"Numpad3":        0x55,
+	"Numpad4":        0x56,
+	"Numpad5":        0x57,
+	"Numpad6":        0x58,
+	"Numpad7":        0x59,
+	"Numpad8":        0x5b,
+	"Numpad9":        0x5c,
+	"ArrowUp":        0x7e,
+	"ArrowDown":      0x7d,
+	"ArrowLeft":      0x7b,
+	"ArrowRight":     0x7c,
+	"Escape":         0x35,
+	"Tab":            0x30,
+	"Space":          0x31,
+	"CapsLock":       0x39,
+	"ShiftLeft":      0x38,
+	"ShiftRight":     0x3c,
+	"ControlLeft":    0x3b,
+	"ControlRight":   0x3e,
+	"AltLeft":        0x3a,
+	"AltRight":       0x3d,
+	"MetaLeft":       0x37,
+	"MetaRight":      0x36,
+}

--- a/tenvy-client/internal/modules/control/remotedesktop/input_linux.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/input_linux.go
@@ -1,0 +1,458 @@
+//go:build linux
+
+package remotedesktop
+
+import (
+	"errors"
+	"fmt"
+	"image"
+	"math"
+	"os"
+	"strings"
+	"sync"
+	"unicode"
+
+	"github.com/jezek/xgb"
+	"github.com/jezek/xgb/xproto"
+	"github.com/jezek/xgb/xtest"
+)
+
+type x11Input struct {
+	conn       *xgb.Conn
+	root       xproto.Window
+	screenRect image.Rectangle
+	minKeycode xproto.Keycode
+	maxKeycode xproto.Keycode
+
+	keymapOnce sync.Once
+	keymapErr  error
+	keycodes   map[xproto.Keysym]xproto.Keycode
+	mu         sync.Mutex
+}
+
+var (
+	x11InputOnce sync.Once
+	x11Instance  *x11Input
+	x11InitErr   error
+)
+
+const (
+	x11MinCoordinate = -32768
+	x11MaxCoordinate = 32767
+)
+
+func processRemoteInput(monitors []remoteMonitor, settings RemoteDesktopSettings, events []RemoteDesktopInputEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	input, err := getX11Input()
+	if err != nil {
+		return err
+	}
+
+	fallback := selectMonitorForInputLinux(monitors, settings.Monitor, input.defaultMonitor())
+
+	input.mu.Lock()
+	defer input.mu.Unlock()
+
+	for _, event := range events {
+		switch event.Type {
+		case RemoteInputMouseMove:
+			target := monitorFromEventLinux(monitors, fallback, event.Monitor)
+			if err := input.movePointer(event, target); err != nil {
+				return err
+			}
+		case RemoteInputMouseButton:
+			if err := input.sendMouseButton(event.Button, event.Pressed); err != nil {
+				return err
+			}
+		case RemoteInputMouseScroll:
+			if err := input.sendMouseScroll(event); err != nil {
+				return err
+			}
+		case RemoteInputKey:
+			if err := input.sendKeyEvent(event); err != nil {
+				return err
+			}
+		}
+	}
+
+	input.conn.Sync()
+	return nil
+}
+
+func getX11Input() (*x11Input, error) {
+	x11InputOnce.Do(func() {
+		inst, err := newX11Input()
+		if err != nil {
+			x11InitErr = err
+			return
+		}
+		x11Instance = inst
+	})
+	return x11Instance, x11InitErr
+}
+
+func newX11Input() (*x11Input, error) {
+	display := os.Getenv("DISPLAY")
+	if display == "" {
+		if os.Getenv("WAYLAND_DISPLAY") != "" {
+			return nil, errors.New("wayland session detected but X11 DISPLAY is not available")
+		}
+		return nil, errors.New("X11 DISPLAY environment variable is not set")
+	}
+
+	conn, err := xgb.NewConnDisplay(display)
+	if err != nil {
+		return nil, err
+	}
+	if err := xtest.Init(conn); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	setup := xproto.Setup(conn)
+	if setup == nil {
+		conn.Close()
+		return nil, errors.New("failed to query X11 setup")
+	}
+	screen := setup.DefaultScreen(conn)
+	if screen == nil {
+		conn.Close()
+		return nil, errors.New("failed to resolve X11 default screen")
+	}
+	rect := image.Rect(0, 0, int(screen.WidthInPixels), int(screen.HeightInPixels))
+
+	return &x11Input{
+		conn:       conn,
+		root:       screen.Root,
+		screenRect: rect,
+		minKeycode: setup.MinKeycode,
+		maxKeycode: setup.MaxKeycode,
+		keycodes:   make(map[xproto.Keysym]xproto.Keycode),
+	}, nil
+}
+
+func (x *x11Input) defaultMonitor() remoteMonitor {
+	info := RemoteDesktopMonitorInfo{Width: x.screenRect.Dx(), Height: x.screenRect.Dy()}
+	return remoteMonitor{info: info, bounds: x.screenRect}
+}
+
+func selectMonitorForInputLinux(monitors []remoteMonitor, index int, fallback remoteMonitor) remoteMonitor {
+	if len(monitors) == 0 {
+		return fallback
+	}
+	if index < 0 || index >= len(monitors) {
+		index = 0
+	}
+	return monitors[index]
+}
+
+func monitorFromEventLinux(monitors []remoteMonitor, fallback remoteMonitor, override *int) remoteMonitor {
+	if override != nil {
+		idx := *override
+		if idx >= 0 && idx < len(monitors) {
+			return monitors[idx]
+		}
+	}
+	return fallback
+}
+
+func (x *x11Input) movePointer(event RemoteDesktopInputEvent, monitor remoteMonitor) error {
+	targetX, targetY := resolvePointerPosition(event, monitor)
+	point := image.Point{X: clampToInt(targetX), Y: clampToInt(targetY)}
+	return xproto.WarpPointerChecked(x.conn, xproto.WindowNone, x.root, 0, 0, 0, 0, int16(point.X), int16(point.Y)).Check()
+}
+
+func (x *x11Input) sendMouseButton(button RemoteDesktopMouseButton, pressed bool) error {
+	var detail byte
+	switch button {
+	case RemoteMouseButtonLeft:
+		detail = 1
+	case RemoteMouseButtonMiddle:
+		detail = 2
+	case RemoteMouseButtonRight:
+		detail = 3
+	default:
+		return nil
+	}
+	eventType := byte(xproto.ButtonPress)
+	if !pressed {
+		eventType = byte(xproto.ButtonRelease)
+	}
+	return xtest.FakeInputChecked(x.conn, eventType, detail, 0, xproto.WindowNone, 0, 0, 0).Check()
+}
+
+func (x *x11Input) sendMouseScroll(event RemoteDesktopInputEvent) error {
+	vertical := scrollSteps(event.DeltaY, event.DeltaMode)
+	horizontal := scrollSteps(event.DeltaX, event.DeltaMode)
+
+	for vertical > 0 {
+		if err := x.clickScrollButton(5); err != nil {
+			return err
+		}
+		vertical--
+	}
+	for vertical < 0 {
+		if err := x.clickScrollButton(4); err != nil {
+			return err
+		}
+		vertical++
+	}
+	for horizontal > 0 {
+		if err := x.clickScrollButton(7); err != nil {
+			return err
+		}
+		horizontal--
+	}
+	for horizontal < 0 {
+		if err := x.clickScrollButton(6); err != nil {
+			return err
+		}
+		horizontal++
+	}
+	return nil
+}
+
+func (x *x11Input) clickScrollButton(detail byte) error {
+	if err := xtest.FakeInputChecked(x.conn, byte(xproto.ButtonPress), detail, 0, xproto.WindowNone, 0, 0, 0).Check(); err != nil {
+		return err
+	}
+	return xtest.FakeInputChecked(x.conn, byte(xproto.ButtonRelease), detail, 0, xproto.WindowNone, 0, 0, 0).Check()
+}
+
+func scrollSteps(delta float64, mode int) int {
+	if delta == 0 {
+		return 0
+	}
+	scale := 1.0
+	switch mode {
+	case 0: // pixel
+		scale = 1.0 / 32.0
+	case 1: // line
+		scale = 1.0
+	case 2: // page
+		scale = 4.0
+	}
+	amount := int(math.Round(delta * scale))
+	if amount == 0 {
+		if delta > 0 {
+			amount = 1
+		} else {
+			amount = -1
+		}
+	}
+	return amount
+}
+
+func (x *x11Input) sendKeyEvent(event RemoteDesktopInputEvent) error {
+	keysym, ok := resolveX11Keysym(event)
+	if !ok {
+		return errors.New("unsupported key event")
+	}
+	keycode, err := x.keycodeForKeysym(keysym)
+	if err != nil {
+		return err
+	}
+	eventType := byte(xproto.KeyPress)
+	if !event.Pressed {
+		eventType = byte(xproto.KeyRelease)
+	}
+	return xtest.FakeInputChecked(x.conn, eventType, byte(keycode), 0, xproto.WindowNone, 0, 0, 0).Check()
+}
+
+func (x *x11Input) keycodeForKeysym(sym xproto.Keysym) (xproto.Keycode, error) {
+	if sym == 0 {
+		return 0, errors.New("invalid keysym")
+	}
+	x.keymapOnce.Do(func() {
+		x.keymapErr = x.populateKeymap()
+	})
+	if x.keymapErr != nil {
+		return 0, x.keymapErr
+	}
+	if code, ok := x.keycodes[sym]; ok {
+		return code, nil
+	}
+	if sym >= 'A' && sym <= 'Z' {
+		if code, ok := x.keycodes[sym+32]; ok {
+			return code, nil
+		}
+	}
+	if sym >= 'a' && sym <= 'z' {
+		if code, ok := x.keycodes[sym-32]; ok {
+			return code, nil
+		}
+	}
+	return 0, errors.New("keysym not mapped")
+}
+
+func (x *x11Input) populateKeymap() error {
+	count := int(x.maxKeycode) - int(x.minKeycode) + 1
+	cookie := xproto.GetKeyboardMapping(x.conn, x.minKeycode, byte(count))
+	reply, err := cookie.Reply()
+	if err != nil {
+		return err
+	}
+	perKeycode := int(reply.KeysymsPerKeycode)
+	if perKeycode <= 0 {
+		return errors.New("invalid X11 keyboard mapping")
+	}
+	for i := 0; i < count; i++ {
+		keycode := xproto.Keycode(int(x.minKeycode) + i)
+		for j := 0; j < perKeycode; j++ {
+			sym := reply.Keysyms[i*perKeycode+j]
+			if sym == 0 {
+				continue
+			}
+			if _, exists := x.keycodes[sym]; !exists {
+				x.keycodes[sym] = keycode
+			}
+		}
+	}
+	return nil
+}
+
+func clampToInt(value float64) int {
+	rounded := int(math.Round(value))
+	if rounded < x11MinCoordinate {
+		return x11MinCoordinate
+	}
+	if rounded > x11MaxCoordinate {
+		return x11MaxCoordinate
+	}
+	return rounded
+}
+
+func resolveX11Keysym(event RemoteDesktopInputEvent) (xproto.Keysym, bool) {
+	if sym, ok := keysymForCode(event.Code); ok {
+		return sym, true
+	}
+	if sym, ok := keysymForKey(event.Key); ok {
+		return sym, true
+	}
+	if len(event.Key) == 1 {
+		r := []rune(event.Key)[0]
+		if !event.ShiftKey {
+			r = unicode.ToLower(r)
+		}
+		return xproto.Keysym(r), true
+	}
+	if event.KeyCode > 0 && event.KeyCode < 65535 {
+		return xproto.Keysym(event.KeyCode), true
+	}
+	return 0, false
+}
+
+func keysymForCode(code string) (xproto.Keysym, bool) {
+	if code == "" {
+		return 0, false
+	}
+	if sym, ok := x11KeycodeMap[code]; ok {
+		return sym, true
+	}
+	if strings.HasPrefix(code, "Key") && len(code) == 4 {
+		r := rune(code[3])
+		return xproto.Keysym(unicode.ToLower(r)), true
+	}
+	if strings.HasPrefix(code, "Digit") && len(code) == 6 {
+		r := rune(code[5])
+		if r >= '0' && r <= '9' {
+			return xproto.Keysym(r), true
+		}
+	}
+	if strings.HasPrefix(code, "Numpad") && len(code) > 6 {
+		if sym, ok := x11KeycodeMap[code]; ok {
+			return sym, true
+		}
+	}
+	return 0, false
+}
+
+func keysymForKey(key string) (xproto.Keysym, bool) {
+	if key == "" {
+		return 0, false
+	}
+	if sym, ok := x11KeynameMap[key]; ok {
+		return sym, true
+	}
+	if len(key) == 1 {
+		r := []rune(key)[0]
+		return xproto.Keysym(r), true
+	}
+	return 0, false
+}
+
+var x11KeycodeMap = map[string]xproto.Keysym{
+	"Backspace":      0xff08,
+	"Tab":            0xff09,
+	"Enter":          0xff0d,
+	"Escape":         0xff1b,
+	"Space":          0x0020,
+	"ArrowUp":        0xff52,
+	"ArrowDown":      0xff54,
+	"ArrowLeft":      0xff51,
+	"ArrowRight":     0xff53,
+	"Delete":         0xffff,
+	"Home":           0xff50,
+	"End":            0xff57,
+	"PageUp":         0xff55,
+	"PageDown":       0xff56,
+	"Insert":         0xff63,
+	"CapsLock":       0xffe5,
+	"ShiftLeft":      0xffe1,
+	"ShiftRight":     0xffe2,
+	"ControlLeft":    0xffe3,
+	"ControlRight":   0xffe4,
+	"AltLeft":        0xffe9,
+	"AltRight":       0xffea,
+	"MetaLeft":       0xffe7,
+	"MetaRight":      0xffe8,
+	"ContextMenu":    0xff67,
+	"PrintScreen":    0xff61,
+	"ScrollLock":     0xff14,
+	"Pause":          0xff13,
+	"NumpadMultiply": 0xffaa,
+	"NumpadAdd":      0xffab,
+	"NumpadSubtract": 0xffad,
+	"NumpadDecimal":  0xffae,
+	"NumpadDivide":   0xffaf,
+	"NumpadEnter":    0xff8d,
+}
+
+var x11KeynameMap = map[string]xproto.Keysym{
+	"Backspace":   0xff08,
+	"Tab":         0xff09,
+	"Enter":       0xff0d,
+	"Escape":      0xff1b,
+	" ":           0x0020,
+	"ArrowUp":     0xff52,
+	"ArrowDown":   0xff54,
+	"ArrowLeft":   0xff51,
+	"ArrowRight":  0xff53,
+	"Delete":      0xffff,
+	"Home":        0xff50,
+	"End":         0xff57,
+	"PageUp":      0xff55,
+	"PageDown":    0xff56,
+	"Insert":      0xff63,
+	"CapsLock":    0xffe5,
+	"Shift":       0xffe1,
+	"Control":     0xffe3,
+	"Alt":         0xffe9,
+	"Meta":        0xffe7,
+	"ContextMenu": 0xff67,
+	"PrintScreen": 0xff61,
+	"ScrollLock":  0xff14,
+	"Pause":       0xff13,
+}
+
+func init() {
+	for i := 1; i <= 12; i++ {
+		sym := xproto.Keysym(0xffbd + i)
+		code := fmt.Sprintf("F%d", i)
+		x11KeycodeMap[code] = sym
+		x11KeynameMap[code] = sym
+	}
+}

--- a/tenvy-client/internal/modules/control/remotedesktop/input_stub.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/input_stub.go
@@ -1,7 +1,12 @@
-//go:build !windows
+//go:build !windows && !linux && !darwin
 
 package remotedesktop
 
+import "errors"
+
 func processRemoteInput(monitors []remoteMonitor, settings RemoteDesktopSettings, events []RemoteDesktopInputEvent) error {
-	return nil
+	if len(events) == 0 {
+		return nil
+	}
+	return errors.New("remote desktop input is not implemented for this platform")
 }

--- a/tenvy-client/internal/modules/control/remotedesktop/input_unix_common.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/input_unix_common.go
@@ -1,0 +1,34 @@
+//go:build linux || darwin
+
+package remotedesktop
+
+import "image"
+
+func resolvePointerPosition(event RemoteDesktopInputEvent, monitor remoteMonitor) (float64, float64) {
+	bounds := monitor.bounds
+	width := bounds.Dx()
+	height := bounds.Dy()
+	if width <= 0 || height <= 0 {
+		width = maxInt(monitor.info.Width, 1)
+		height = maxInt(monitor.info.Height, 1)
+		bounds = image.Rect(bounds.Min.X, bounds.Min.Y, bounds.Min.X+width, bounds.Min.Y+height)
+	}
+	normX := event.X
+	normY := event.Y
+	if event.Normalized {
+		normX = clampFloat(normX, 0, 1)
+		normY = clampFloat(normY, 0, 1)
+	} else {
+		normX = clampFloat(normX/float64(maxInt(monitor.info.Width-1, 1)), 0, 1)
+		normY = clampFloat(normY/float64(maxInt(monitor.info.Height-1, 1)), 0, 1)
+	}
+	targetX := float64(bounds.Min.X)
+	targetY := float64(bounds.Min.Y)
+	if width > 1 {
+		targetX += normX * float64(width-1)
+	}
+	if height > 1 {
+		targetY += normY * float64(height-1)
+	}
+	return targetX, targetY
+}


### PR DESCRIPTION
## Summary
- add an X11-backed remote input pipeline on Linux using XTest for mouse and keyboard events
- integrate Quartz CGEvent-based handlers on macOS to translate remote desktop input to native events
- share pointer normalization helpers for Unix targets and retain an explicit stub for unsupported platforms

## Testing
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68f504e30b68832b9b52d049e9ad1d7e