### PR TITLE
Add ephemeral session token handshake for agents

### DIFF
--- a/shared/constants/protocol.ts
+++ b/shared/constants/protocol.ts
@@ -1,2 +1,3 @@
 export const COMMAND_STREAM_SUBPROTOCOL = "tenvy.agent.v1";
 export const COMMAND_STREAM_MAX_MESSAGE_BYTES = 1_048_576; // 1 MiB
+export const AGENT_SESSION_TOKEN_HEADER = 'x-agent-session-token';

--- a/tenvy-server/src/routes/api/agents/[id]/session-token/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/session-token/+server.ts
@@ -1,0 +1,33 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { registry, RegistryError } from '$lib/server/rat/store';
+
+function extractBearerToken(headerValue: string | null): string | null {
+        if (!headerValue) {
+                return null;
+        }
+        const match = /^Bearer\s+(?<token>.+)$/i.exec(headerValue.trim());
+        return match?.groups?.token?.trim() ?? null;
+}
+
+export const POST: RequestHandler = async ({ params, request }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        const key = extractBearerToken(request.headers.get('authorization'));
+        if (!key) {
+                throw error(401, 'Missing agent key');
+        }
+
+        try {
+                const response = registry.issueSessionToken(id, key);
+                return json(response);
+        } catch (err) {
+                if (err instanceof RegistryError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to issue session token');
+        }
+};


### PR DESCRIPTION
## Summary
- add a session token issuance endpoint and shared header constant for agent connections
- validate, rotate, and persist session tokens when attaching live sessions while enforcing secure transports
- require the Go agent to obtain per-connection session tokens over HTTPS before dialing WSS and update the related tests

## Testing
- bun test src/lib/server/rat/session.test.ts src/lib/server/rat/store.test.ts
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f51cc8a4b0832baf74db7c315bbfe6