### PR TITLE
feat: persist registry via database and live events

### DIFF
--- a/tenvy-server/src/routes/(app)/clients/+page.svelte
+++ b/tenvy-server/src/routes/(app)/clients/+page.svelte
@@ -92,6 +92,11 @@
 		clientsTable.setAgents(data.agents ?? []);
 	});
 
+	if (browser) {
+		const disconnectEvents = clientsTable.connectToEvents();
+		onDestroy(disconnectEvents);
+	}
+
 	const perPageOptions = [10, 25, 50];
 
 	let toolDialog = $state<{ agentId: string; toolId: DialogToolId } | null>(null);

--- a/tenvy-server/src/routes/api/agents/events/+server.ts
+++ b/tenvy-server/src/routes/api/agents/events/+server.ts
@@ -1,0 +1,81 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { registry, type RegistryBroadcast } from '$lib/server/rat/store';
+
+const encoder = new TextEncoder();
+const HEARTBEAT_INTERVAL_MS = 15_000;
+const HEARTBEAT = encoder.encode('event: heartbeat\ndata: {}\n\n');
+const RETRY = encoder.encode('retry: 5000\n\n');
+
+function serializeEvent(event: RegistryBroadcast): Uint8Array {
+	const payload = JSON.stringify(event);
+	return encoder.encode(`event: ${event.type}\ndata: ${payload}\n\n`);
+}
+
+export const GET: RequestHandler = ({ request }) => {
+	if (request.headers.get('accept')?.includes('text/event-stream') === false) {
+		return json({ error: 'SSE required' }, { status: 406 });
+	}
+
+	const signal = request.signal;
+	let cleanup: (() => void) | null = null;
+
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			let closed = false;
+			controller.enqueue(RETRY);
+
+			const send = (event: RegistryBroadcast) => {
+				if (closed) {
+					return;
+				}
+				controller.enqueue(serializeEvent(event));
+			};
+
+			const unsubscribe = registry.subscribe(send);
+			send({ type: 'agents:snapshot', agents: registry.listAgents() });
+
+			const heartbeat = setInterval(() => {
+				if (closed) {
+					return;
+				}
+				controller.enqueue(HEARTBEAT);
+			}, HEARTBEAT_INTERVAL_MS);
+
+			const abort = () => {
+				if (closed) {
+					return;
+				}
+				closed = true;
+				clearInterval(heartbeat);
+				unsubscribe();
+				signal.removeEventListener('abort', abort);
+				try {
+					controller.close();
+				} catch {
+					// already closed
+				}
+			};
+
+			if (signal.aborted) {
+				abort();
+				return;
+			}
+
+			signal.addEventListener('abort', abort);
+			cleanup = abort;
+		},
+		cancel() {
+			cleanup?.();
+			cleanup = null;
+		}
+	});
+
+	return new Response(stream, {
+		headers: {
+			'content-type': 'text/event-stream',
+			'cache-control': 'no-cache',
+			connection: 'keep-alive'
+		}
+	});
+};


### PR DESCRIPTION
## Summary
- migrate the agent registry to Drizzle-backed tables and wire the AgentRegistry to persist through the shared database while broadcasting state changes
- add an /api/agents/events SSE endpoint and update the clients table store/page to subscribe to live snapshots
- expand the registry tests to cover database persistence, concurrent mutations, and event fan-out

## Testing
- `bun test:unit` *(fails: Playwright browsers not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f51cc05970832b901f5746e1782b24