### PR TITLE
Persist agent registry to database and stream updates

### DIFF
--- a/shared/types/registry-events.ts
+++ b/shared/types/registry-events.ts
@@ -1,0 +1,9 @@
+import type { AgentSnapshot } from './agent';
+import type { NoteEnvelope } from './notes';
+import type { Command, CommandDeliveryMode } from './messages';
+
+export type AgentRegistryEvent =
+  | { type: 'agents'; agents: AgentSnapshot[] }
+  | { type: 'agent'; agent: AgentSnapshot }
+  | { type: 'notes'; agentId: string; notes: NoteEnvelope[] }
+  | { type: 'command'; agentId: string; command: Command; delivery: CommandDeliveryMode };

--- a/tenvy-server/src/lib/server/db/index.ts
+++ b/tenvy-server/src/lib/server/db/index.ts
@@ -81,6 +81,54 @@ CREATE TABLE IF NOT EXISTS plugin (
         created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
         updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
 );
+
+CREATE TABLE IF NOT EXISTS agent (
+        id TEXT PRIMARY KEY NOT NULL,
+        key_hash TEXT NOT NULL,
+        metadata TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'offline',
+        connected_at INTEGER NOT NULL,
+        last_seen INTEGER NOT NULL,
+        metrics TEXT,
+        config TEXT NOT NULL,
+        fingerprint TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS agent_fingerprint_idx ON agent (fingerprint);
+
+CREATE TABLE IF NOT EXISTS agent_note (
+        agent_id TEXT NOT NULL,
+        note_id TEXT NOT NULL,
+        ciphertext TEXT NOT NULL,
+        nonce TEXT NOT NULL,
+        digest TEXT NOT NULL,
+        version INTEGER NOT NULL DEFAULT 1,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (agent_id, note_id),
+        FOREIGN KEY (agent_id) REFERENCES agent(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS agent_command (
+        id TEXT PRIMARY KEY NOT NULL,
+        agent_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        FOREIGN KEY (agent_id) REFERENCES agent(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS agent_result (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        agent_id TEXT NOT NULL,
+        command_id TEXT NOT NULL,
+        success INTEGER NOT NULL DEFAULT 1,
+        output TEXT,
+        error TEXT,
+        completed_at INTEGER NOT NULL,
+        FOREIGN KEY (agent_id) REFERENCES agent(id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS agent_result_command_idx ON agent_result (agent_id, command_id);
 COMMIT;`
 );
 

--- a/tenvy-server/src/lib/server/db/schema.ts
+++ b/tenvy-server/src/lib/server/db/schema.ts
@@ -1,4 +1,10 @@
-import { sqliteTable, integer, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
+import {
+        sqliteTable,
+        integer,
+        text,
+        uniqueIndex,
+        primaryKey
+} from 'drizzle-orm/sqlite-core';
 
 const timestamp = (
 	name: string,
@@ -76,8 +82,8 @@ export const recoveryCode = sqliteTable('recovery_code', {
 });
 
 export const plugin = sqliteTable('plugin', {
-	id: text('id').primaryKey(),
-	status: text('status').notNull().default('active'),
+        id: text('id').primaryKey(),
+        status: text('status').notNull().default('active'),
 	enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
 	autoUpdate: integer('auto_update', { mode: 'boolean' }).notNull().default(false),
 	installations: integer('installations').notNull().default(0),
@@ -91,8 +97,77 @@ export const plugin = sqliteTable('plugin', {
 	lastDeployedAt: timestamp('last_deployed_at', { optional: true }),
 	lastCheckedAt: timestamp('last_checked_at', { optional: true }),
 	createdAt: timestamp('created_at', { defaultNow: true }),
-	updatedAt: timestamp('updated_at', { defaultNow: true })
+        updatedAt: timestamp('updated_at', { defaultNow: true })
 });
+
+export const agent = sqliteTable(
+        'agent',
+        {
+                id: text('id').primaryKey(),
+                keyHash: text('key_hash').notNull(),
+                metadata: text('metadata').notNull(),
+                status: text('status').notNull().default('offline'),
+                connectedAt: timestamp('connected_at', { defaultNow: true }),
+                lastSeen: timestamp('last_seen', { defaultNow: true }),
+                metrics: text('metrics'),
+                config: text('config').notNull(),
+                fingerprint: text('fingerprint').notNull(),
+                createdAt: timestamp('created_at', { defaultNow: true }),
+                updatedAt: timestamp('updated_at', { defaultNow: true })
+        },
+        (table) => ({
+                fingerprintIdx: uniqueIndex('agent_fingerprint_idx').on(table.fingerprint)
+        })
+);
+
+export const agentNote = sqliteTable(
+        'agent_note',
+        {
+                agentId: text('agent_id')
+                        .notNull()
+                        .references(() => agent.id, { onDelete: 'cascade' }),
+                noteId: text('note_id').notNull(),
+                ciphertext: text('ciphertext').notNull(),
+                nonce: text('nonce').notNull(),
+                digest: text('digest').notNull(),
+                version: integer('version').notNull().default(1),
+                updatedAt: timestamp('updated_at', { defaultNow: true })
+        },
+        (table) => ({
+                pk: primaryKey({ columns: [table.agentId, table.noteId] })
+        })
+);
+
+export const agentCommand = sqliteTable('agent_command', {
+        id: text('id').primaryKey(),
+        agentId: text('agent_id')
+                .notNull()
+                .references(() => agent.id, { onDelete: 'cascade' }),
+        name: text('name').notNull(),
+        payload: text('payload').notNull(),
+        createdAt: timestamp('created_at', { defaultNow: true })
+});
+
+export const agentResult = sqliteTable(
+        'agent_result',
+        {
+                id: integer('id').primaryKey({ autoIncrement: true }),
+                agentId: text('agent_id')
+                        .notNull()
+                        .references(() => agent.id, { onDelete: 'cascade' }),
+                commandId: text('command_id').notNull(),
+                success: integer('success', { mode: 'boolean' }).notNull().default(true),
+                output: text('output'),
+                error: text('error'),
+                completedAt: timestamp('completed_at', { defaultNow: true })
+        },
+        (table) => ({
+                uniqueCommand: uniqueIndex('agent_result_command_idx').on(
+                        table.agentId,
+                        table.commandId
+                )
+        })
+);
 
 export type Session = typeof session.$inferSelect;
 
@@ -104,3 +179,7 @@ export type Passkey = typeof passkey.$inferSelect;
 
 export type RecoveryCode = typeof recoveryCode.$inferSelect;
 export type Plugin = typeof plugin.$inferSelect;
+export type Agent = typeof agent.$inferSelect;
+export type AgentNote = typeof agentNote.$inferSelect;
+export type AgentCommand = typeof agentCommand.$inferSelect;
+export type AgentResult = typeof agentResult.$inferSelect;

--- a/tenvy-server/src/lib/stores/clients-table.ts
+++ b/tenvy-server/src/lib/stores/clients-table.ts
@@ -1,5 +1,6 @@
 import { derived, get, writable } from 'svelte/store';
 import type { AgentSnapshot } from '../../../../shared/types/agent';
+import type { AgentRegistryEvent } from '../../../../shared/types/registry-events';
 
 export type StatusFilter = 'all' | AgentSnapshot['status'];
 export type TagFilter = 'all' | string;
@@ -138,17 +139,28 @@ export function buildPaginationItems(
 
 // Remove duplicates while keeping the latest snapshot for each agent id.
 function dedupeAgents(agents: AgentSnapshot[]): AgentSnapshot[] {
-	const seen = new Set<string>();
-	const result: AgentSnapshot[] = [];
-	for (let index = agents.length - 1; index >= 0; index -= 1) {
-		const agent = agents[index];
-		if (seen.has(agent.id)) {
-			continue;
-		}
-		seen.add(agent.id);
-		result.unshift(agent);
-	}
-	return result;
+        const seen = new Set<string>();
+        const result: AgentSnapshot[] = [];
+        for (let index = agents.length - 1; index >= 0; index -= 1) {
+                const agent = agents[index];
+                if (seen.has(agent.id)) {
+                        continue;
+                }
+                seen.add(agent.id);
+                result.unshift(agent);
+        }
+        return result;
+}
+
+function upsertAgent(list: AgentSnapshot[], next: AgentSnapshot): AgentSnapshot[] {
+        const clone = [...list];
+        const index = clone.findIndex((agent) => agent.id === next.id);
+        if (index === -1) {
+                clone.push(next);
+        } else {
+                clone[index] = next;
+        }
+        return clone;
 }
 
 export type ClientsTableStore = ReturnType<typeof createClientsTableStore>;
@@ -180,10 +192,10 @@ export function createClientsTableStore(initialAgents: AgentSnapshot[]): {
 		// no-op subscription to keep the derived store active
 	});
 
-	const state = derived(
-		[agents, searchQuery, statusFilter, tagFilter, perPage, currentPage],
-		([$agents, $searchQuery, $statusFilter, $tagFilter, $perPage, $currentPage]) => {
-			const availableTags = computeAvailableTags($agents);
+        const state = derived(
+                [agents, searchQuery, statusFilter, tagFilter, perPage, currentPage],
+                ([$agents, $searchQuery, $statusFilter, $tagFilter, $perPage, $currentPage]) => {
+                        const availableTags = computeAvailableTags($agents);
 			const filteredAgents = filterAgents($agents, $searchQuery, $statusFilter, $tagFilter);
 
 			const totalPages =
@@ -205,11 +217,11 @@ export function createClientsTableStore(initialAgents: AgentSnapshot[]): {
 			const pageRange = computePageRange(filteredAgents.length, paginatedAgents.length, startIndex);
 			const paginationItems = buildPaginationItems(totalPages, safeCurrentPage);
 
-			return {
-				agents: $agents,
-				searchQuery: $searchQuery,
-				statusFilter: $statusFilter,
-				tagFilter: $tagFilter,
+                        return {
+                                agents: $agents,
+                                searchQuery: $searchQuery,
+                                statusFilter: $statusFilter,
+                                tagFilter: $tagFilter,
 				perPage: Math.max(1, $perPage),
 				currentPage: safeCurrentPage,
 				availableTags,
@@ -218,17 +230,105 @@ export function createClientsTableStore(initialAgents: AgentSnapshot[]): {
 				pageRange,
 				totalPages,
 				paginationItems
-			} satisfies ClientsTableState;
-		}
-	);
+                        } satisfies ClientsTableState;
+                }
+        );
 
-	return {
-		subscribe: state.subscribe,
-		setAgents: (nextAgents) => agents.set(dedupeAgents(nextAgents ?? [])),
-		setSearchQuery: (value) => searchQuery.set(value),
-		setStatusFilter: (value) => statusFilter.set(value),
-		setTagFilter: (value) => tagFilter.set(value),
-		setPerPage: (value) => perPage.set(Math.max(1, value)),
+        let subscribers = 0;
+        let source: EventSource | null = null;
+        let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+        const applyRegistryEvent = (event: AgentRegistryEvent) => {
+                if (!event || typeof event !== 'object') {
+                        return;
+                }
+
+                if (event.type === 'agents') {
+                        agents.set(dedupeAgents(event.agents ?? []));
+                        return;
+                }
+
+                if (event.type === 'agent') {
+                        agents.update((current) => dedupeAgents(upsertAgent(current, event.agent)));
+                }
+        };
+
+        const stopStream = () => {
+                if (reconnectTimer) {
+                        clearTimeout(reconnectTimer);
+                        reconnectTimer = null;
+                }
+                if (source) {
+                        source.onmessage = null;
+                        source.onerror = null;
+                        source.close();
+                        source = null;
+                }
+        };
+
+        const scheduleReconnect = () => {
+                if (reconnectTimer || subscribers === 0) {
+                        return;
+                }
+                reconnectTimer = setTimeout(() => {
+                        reconnectTimer = null;
+                        startStream();
+                }, 5_000);
+        };
+
+        const startStream = () => {
+                if (typeof window === 'undefined' || source) {
+                        return;
+                }
+
+                stopStream();
+
+                try {
+                        source = new EventSource('/api/agents/stream');
+                } catch (error) {
+                        console.error('Failed to open agent registry stream', error);
+                        scheduleReconnect();
+                        return;
+                }
+
+                source.onmessage = (event) => {
+                        if (!event.data) {
+                                return;
+                        }
+                        try {
+                                const parsed = JSON.parse(event.data) as AgentRegistryEvent;
+                                applyRegistryEvent(parsed);
+                        } catch (error) {
+                                console.error('Failed to parse agent registry event', error);
+                        }
+                };
+
+                source.onerror = () => {
+                        stopStream();
+                        scheduleReconnect();
+                };
+        };
+
+        return {
+                subscribe: (run, invalidate) => {
+                        const unsubscribe = state.subscribe(run, invalidate);
+                        subscribers += 1;
+                        if (subscribers === 1) {
+                                startStream();
+                        }
+                        return () => {
+                                unsubscribe();
+                                subscribers = Math.max(0, subscribers - 1);
+                                if (subscribers === 0) {
+                                        stopStream();
+                                }
+                        };
+                },
+                setAgents: (nextAgents) => agents.set(dedupeAgents(nextAgents ?? [])),
+                setSearchQuery: (value) => searchQuery.set(value),
+                setStatusFilter: (value) => statusFilter.set(value),
+                setTagFilter: (value) => tagFilter.set(value),
+                setPerPage: (value) => perPage.set(Math.max(1, value)),
 		goToPage: (page) => currentPage.set(Math.max(1, Math.trunc(page))),
 		nextPage: () => {
 			const { currentPage: page, totalPages } = get(state);

--- a/tenvy-server/src/routes/api/agents/stream/+server.ts
+++ b/tenvy-server/src/routes/api/agents/stream/+server.ts
@@ -1,0 +1,51 @@
+import type { RequestHandler } from './$types';
+import { registry } from '$lib/server/rat/store';
+import type { AgentRegistryEvent } from '../../../../../shared/types/registry-events';
+
+const encoder = new TextEncoder();
+const PING_INTERVAL_MS = 15_000;
+
+function formatEvent(event: AgentRegistryEvent): Uint8Array {
+        const payload = JSON.stringify(event);
+        return encoder.encode(`data: ${payload}\n\n`);
+}
+
+export const GET: RequestHandler = () => {
+        const stream = new ReadableStream<Uint8Array>({
+                start(controller) {
+                        const send = (event: AgentRegistryEvent) => {
+                                try {
+                                        controller.enqueue(formatEvent(event));
+                                } catch (error) {
+                                        console.error('Failed to dispatch agent registry event', error);
+                                }
+                        };
+
+                        const unsubscribe = registry.subscribe((event) => {
+                                send(event);
+                        });
+
+                        send({ type: 'agents', agents: registry.listAgents() });
+
+                        const keepAlive = setInterval(() => {
+                                controller.enqueue(encoder.encode(':ping\n\n'));
+                        }, PING_INTERVAL_MS);
+
+                        return () => {
+                                clearInterval(keepAlive);
+                                unsubscribe();
+                        };
+                },
+                cancel() {
+                        // noop; cleanup handled in return from start
+                }
+        });
+
+        return new Response(stream, {
+                headers: {
+                        'Content-Type': 'text/event-stream',
+                        'Cache-Control': 'no-store',
+                        Connection: 'keep-alive'
+                }
+        });
+};


### PR DESCRIPTION
## Summary
- add Drizzle tables for agents, notes, commands, and results to persist the registry in SQLite
- refactor the agent registry to read/write via the database, publish events, and expose an SSE endpoint consumed by the clients table store
- expand rat store/session tests to cover persistence, concurrency, and event fan-out

## Testing
- bun run test:unit --run src/lib/server/rat/store.test.ts src/lib/server/rat/session.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f522dadd7c832bab69b19e532e9449