### PR TITLE
Add authorization roles and audit logging

### DIFF
--- a/tenvy-server/drizzle/0000_add_roles_and_audit.sql
+++ b/tenvy-server/drizzle/0000_add_roles_and_audit.sql
@@ -1,0 +1,17 @@
+ALTER TABLE `user` ADD COLUMN `role` text DEFAULT 'operator' NOT NULL;
+
+CREATE TABLE `audit_event` (
+        `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        `command_id` text NOT NULL,
+        `agent_id` text NOT NULL,
+        `operator_id` text,
+        `command_name` text NOT NULL,
+        `payload_hash` text NOT NULL,
+        `queued_at` integer NOT NULL,
+        `executed_at` integer,
+        `result` text,
+        FOREIGN KEY (`operator_id`) REFERENCES `user`(`id`) ON DELETE set null
+);
+
+CREATE UNIQUE INDEX `audit_event_command_idx` ON `audit_event` (`command_id`);
+CREATE INDEX `audit_event_agent_idx` ON `audit_event` (`agent_id`);

--- a/tenvy-server/drizzle/meta/_journal.json
+++ b/tenvy-server/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+        "version": "5",
+        "dialect": "sqlite",
+        "entries": [
+                {
+                        "idx": 0,
+                        "version": "5",
+                        "when": 1760897870,
+                        "tag": "0000_add_roles_and_audit",
+                        "breakpoints": true
+                }
+        ]
+}

--- a/tenvy-server/resources/plugin-manifests/clipboard-sync.json
+++ b/tenvy-server/resources/plugin-manifests/clipboard-sync.json
@@ -1,38 +1,38 @@
 {
-  "id": "clipboard-sync",
-  "name": "Clipboard Sync",
-  "version": "1.4.2",
-  "description": "Synchronize clipboard activity across operator sessions with encryption at rest.",
-  "entry": "clipboard-sync.dll",
-  "author": "Tenvy Labs",
-  "categories": ["collection"],
-  "capabilities": [
-    {
-      "name": "clipboard.capture",
-      "module": "clipboard",
-      "description": "Capture remote clipboard history and relay updates in real time."
-    },
-    {
-      "name": "clipboard.push",
-      "module": "clipboard",
-      "description": "Inject clipboard payloads into the remote workstation."
-    }
-  ],
-  "requirements": {
-    "minAgentVersion": "1.2.0",
-    "platforms": ["windows", "darwin"],
-    "requiredModules": ["clipboard"]
-  },
-  "distribution": {
-    "defaultMode": "automatic",
-    "autoUpdate": true,
-    "signature": {
-      "type": "sha256",
-      "hash": "d8b8a0fb9c8f8e3a72d88e3f7a8c6d1f1fbb83c9f6c2ddacb12e3b45f1a8bbef"
-    }
-  },
-  "package": {
-    "artifact": "clipboard-sync-1.4.2.dll",
-    "sizeBytes": 18743296
-  }
+	"id": "clipboard-sync",
+	"name": "Clipboard Sync",
+	"version": "1.4.2",
+	"description": "Synchronize clipboard activity across operator sessions with encryption at rest.",
+	"entry": "clipboard-sync.dll",
+	"author": "Tenvy Labs",
+	"categories": ["collection"],
+	"capabilities": [
+		{
+			"name": "clipboard.capture",
+			"module": "clipboard",
+			"description": "Capture remote clipboard history and relay updates in real time."
+		},
+		{
+			"name": "clipboard.push",
+			"module": "clipboard",
+			"description": "Inject clipboard payloads into the remote workstation."
+		}
+	],
+	"requirements": {
+		"minAgentVersion": "1.2.0",
+		"platforms": ["windows", "darwin"],
+		"requiredModules": ["clipboard"]
+	},
+	"distribution": {
+		"defaultMode": "automatic",
+		"autoUpdate": true,
+		"signature": {
+			"type": "sha256",
+			"hash": "d8b8a0fb9c8f8e3a72d88e3f7a8c6d1f1fbb83c9f6c2ddacb12e3b45f1a8bbef"
+		}
+	},
+	"package": {
+		"artifact": "clipboard-sync-1.4.2.dll",
+		"sizeBytes": 18743296
+	}
 }

--- a/tenvy-server/resources/plugin-manifests/incident-notes.json
+++ b/tenvy-server/resources/plugin-manifests/incident-notes.json
@@ -1,31 +1,31 @@
 {
-  "id": "incident-notes",
-  "name": "Incident Notes Sync",
-  "version": "1.0.1",
-  "description": "Synchronize analyst notes to the secure operations vault with delta compression.",
-  "entry": "incident-notes.dll",
-  "author": "Ops Collective",
-  "categories": ["persistence"],
-  "capabilities": [
-    {
-      "name": "notes.sync",
-      "module": "notes",
-      "description": "Push local notes to the operator vault after each sync cycle."
-    }
-  ],
-  "requirements": {
-    "minAgentVersion": "1.0.0",
-    "requiredModules": ["notes"]
-  },
-  "distribution": {
-    "defaultMode": "automatic",
-    "autoUpdate": true,
-    "signature": {
-      "type": "none"
-    }
-  },
-  "package": {
-    "artifact": "incident-notes-1.0.1.dll",
-    "sizeBytes": 7340032
-  }
+	"id": "incident-notes",
+	"name": "Incident Notes Sync",
+	"version": "1.0.1",
+	"description": "Synchronize analyst notes to the secure operations vault with delta compression.",
+	"entry": "incident-notes.dll",
+	"author": "Ops Collective",
+	"categories": ["persistence"],
+	"capabilities": [
+		{
+			"name": "notes.sync",
+			"module": "notes",
+			"description": "Push local notes to the operator vault after each sync cycle."
+		}
+	],
+	"requirements": {
+		"minAgentVersion": "1.0.0",
+		"requiredModules": ["notes"]
+	},
+	"distribution": {
+		"defaultMode": "automatic",
+		"autoUpdate": true,
+		"signature": {
+			"type": "none"
+		}
+	},
+	"package": {
+		"artifact": "incident-notes-1.0.1.dll",
+		"sizeBytes": 7340032
+	}
 }

--- a/tenvy-server/resources/plugin-manifests/remote-vault.json
+++ b/tenvy-server/resources/plugin-manifests/remote-vault.json
@@ -1,38 +1,38 @@
 {
-  "id": "remote-vault",
-  "name": "Remote Vault",
-  "version": "0.9.5",
-  "description": "Collect credential material from browsers and secure storage providers.",
-  "entry": "remote-vault.dll",
-  "author": "Nimbus Team",
-  "categories": ["collection", "operations"],
-  "capabilities": [
-    {
-      "name": "vault.enumerate",
-      "module": "system-info",
-      "description": "Enumerate installed password managers and browser credential stores."
-    },
-    {
-      "name": "vault.export",
-      "module": "recovery",
-      "description": "Stage and exfiltrate vault exports via the recovery pipeline."
-    }
-  ],
-  "requirements": {
-    "minAgentVersion": "1.3.0",
-    "requiredModules": ["system-info", "recovery"]
-  },
-  "distribution": {
-    "defaultMode": "manual",
-    "autoUpdate": false,
-    "signature": {
-      "type": "ed25519",
-      "hash": "9e4cba26f4f913a52fcb11f16a34f1db493f9204f0545d01b7a086764d814176",
-      "publicKey": "edpk1tVL7Ah5pPqgZRtM7Ypc9S8vUuB1yhXqn7t5u8XH2"
-    }
-  },
-  "package": {
-    "artifact": "remote-vault-0.9.5.dll",
-    "sizeBytes": 24641536
-  }
+	"id": "remote-vault",
+	"name": "Remote Vault",
+	"version": "0.9.5",
+	"description": "Collect credential material from browsers and secure storage providers.",
+	"entry": "remote-vault.dll",
+	"author": "Nimbus Team",
+	"categories": ["collection", "operations"],
+	"capabilities": [
+		{
+			"name": "vault.enumerate",
+			"module": "system-info",
+			"description": "Enumerate installed password managers and browser credential stores."
+		},
+		{
+			"name": "vault.export",
+			"module": "recovery",
+			"description": "Stage and exfiltrate vault exports via the recovery pipeline."
+		}
+	],
+	"requirements": {
+		"minAgentVersion": "1.3.0",
+		"requiredModules": ["system-info", "recovery"]
+	},
+	"distribution": {
+		"defaultMode": "manual",
+		"autoUpdate": false,
+		"signature": {
+			"type": "ed25519",
+			"hash": "9e4cba26f4f913a52fcb11f16a34f1db493f9204f0545d01b7a086764d814176",
+			"publicKey": "edpk1tVL7Ah5pPqgZRtM7Ypc9S8vUuB1yhXqn7t5u8XH2"
+		}
+	},
+	"package": {
+		"artifact": "remote-vault-0.9.5.dll",
+		"sizeBytes": 24641536
+	}
 }

--- a/tenvy-server/resources/plugin-manifests/stream-relay.json
+++ b/tenvy-server/resources/plugin-manifests/stream-relay.json
@@ -1,32 +1,32 @@
 {
-  "id": "stream-relay",
-  "name": "Stream Relay",
-  "version": "2.1.0",
-  "description": "Optimized relay for high fidelity remote desktop streaming and archival.",
-  "entry": "stream-relay.dll",
-  "author": "Tenvy Labs",
-  "categories": ["transport"],
-  "capabilities": [
-    {
-      "name": "remote-desktop.metrics",
-      "module": "remote-desktop",
-      "description": "Collect frame quality and adaptive bitrate metrics for dashboards."
-    }
-  ],
-  "requirements": {
-    "minAgentVersion": "1.1.0",
-    "requiredModules": ["remote-desktop"]
-  },
-  "distribution": {
-    "defaultMode": "automatic",
-    "autoUpdate": true,
-    "signature": {
-      "type": "sha256",
-      "hash": "4fa1e33f99de3c58a4f0b6cbb9df450c3a7fd41b944fdc0bb70a0e0c3a4c299a"
-    }
-  },
-  "package": {
-    "artifact": "stream-relay-2.1.0.dll",
-    "sizeBytes": 15073280
-  }
+	"id": "stream-relay",
+	"name": "Stream Relay",
+	"version": "2.1.0",
+	"description": "Optimized relay for high fidelity remote desktop streaming and archival.",
+	"entry": "stream-relay.dll",
+	"author": "Tenvy Labs",
+	"categories": ["transport"],
+	"capabilities": [
+		{
+			"name": "remote-desktop.metrics",
+			"module": "remote-desktop",
+			"description": "Collect frame quality and adaptive bitrate metrics for dashboards."
+		}
+	],
+	"requirements": {
+		"minAgentVersion": "1.1.0",
+		"requiredModules": ["remote-desktop"]
+	},
+	"distribution": {
+		"defaultMode": "automatic",
+		"autoUpdate": true,
+		"signature": {
+			"type": "sha256",
+			"hash": "4fa1e33f99de3c58a4f0b6cbb9df450c3a7fd41b944fdc0bb70a0e0c3a4c299a"
+		}
+	},
+	"package": {
+		"artifact": "stream-relay-2.1.0.dll",
+		"sizeBytes": 15073280
+	}
 }

--- a/tenvy-server/src/lib/components/client-tool-dialog.svelte
+++ b/tenvy-server/src/lib/components/client-tool-dialog.svelte
@@ -276,7 +276,7 @@
 							{#if keyloggerMode}
 								<KeyloggerWorkspace {client} mode={keyloggerMode} />
 							{:else if toolId === 'remote-desktop'}
-								<RemoteDesktopWorkspace client={client} initialSession={null} />
+								<RemoteDesktopWorkspace {client} initialSession={null} />
 							{:else if activeWorkspace}
 								{@const Workspace = activeWorkspace}
 								{#if toolId === 'cmd'}

--- a/tenvy-server/src/lib/components/ui/movablewindow/MovableWindow.svelte
+++ b/tenvy-server/src/lib/components/ui/movablewindow/MovableWindow.svelte
@@ -172,16 +172,18 @@
 		style:z-index={z}
 		onpointerdown={handlePointerDown}
 	>
-		<div class="window-header flex cursor-move items-center justify-between border-b border-border bg-muted/70 px-4 py-2 text-sm font-medium backdrop-blur-sm">
+		<div
+			class="window-header flex cursor-move items-center justify-between border-b border-border bg-muted/70 px-4 py-2 text-sm font-medium backdrop-blur-sm"
+		>
 			<span>{title}</span>
 			<div class="flex gap-1">
 				<button
-					class="h-3 w-3 rounded-full bg-green-500/80 transition-colors hover:bg-green-500 cursor-pointer"
+					class="h-3 w-3 cursor-pointer rounded-full bg-green-500/80 transition-colors hover:bg-green-500"
 					onclick={handleFullscreen}
 					aria-label="Fullscreen"
 				></button>
 				<button
-					class="h-3 w-3 rounded-full bg-destructive/80 transition-colors hover:bg-destructive cursor-pointer"
+					class="h-3 w-3 cursor-pointer rounded-full bg-destructive/80 transition-colors hover:bg-destructive"
 					onclick={handleClose}
 					aria-label="Close"
 				></button>
@@ -192,15 +194,15 @@
 
 		<div
 			onpointerdown={(e) => startResize(e, 'bottom')}
-			class="absolute bottom-0 left-0 right-0 h-1 cursor-s-resize"
+			class="absolute right-0 bottom-0 left-0 h-1 cursor-s-resize"
 		></div>
 		<div
 			onpointerdown={(e) => startResize(e, 'right')}
-			class="absolute top-0 bottom-0 right-0 w-1 cursor-e-resize"
+			class="absolute top-0 right-0 bottom-0 w-1 cursor-e-resize"
 		></div>
 		<div
 			onpointerdown={(e) => startResize(e, 'bottom-right')}
-			class="absolute bottom-0 right-0 w-2 h-2 cursor-se-resize"
+			class="absolute right-0 bottom-0 h-2 w-2 cursor-se-resize"
 		></div>
 	</div>
 {/if}

--- a/tenvy-server/src/lib/server/auth.ts
+++ b/tenvy-server/src/lib/server/auth.ts
@@ -49,6 +49,7 @@ export async function validateSessionToken(token: string) {
 		.select({
 			user: {
 				id: table.user.id,
+				role: table.user.role,
 				passkeyRegistered: table.user.passkeyRegistered,
 				voucherId: table.user.voucherId
 			},
@@ -101,6 +102,7 @@ export async function validateSessionToken(token: string) {
 
 	const sanitizedUser = {
 		id: user.id,
+		role: user.role as UserRole,
 		passkeyRegistered: Boolean(user.passkeyRegistered),
 		voucherId: user.voucherId,
 		voucherActive,
@@ -141,8 +143,11 @@ export function hashVoucherCode(code: string) {
 	return encodeHexLowerCase(digest);
 }
 
+export type UserRole = 'viewer' | 'operator' | 'admin';
+
 export type AuthenticatedUser = {
 	id: string;
+	role: UserRole;
 	passkeyRegistered: boolean;
 	voucherId: string;
 	voucherActive: boolean;

--- a/tenvy-server/src/lib/server/authorization.ts
+++ b/tenvy-server/src/lib/server/authorization.ts
@@ -1,0 +1,58 @@
+import { error } from '@sveltejs/kit';
+import type { AuthenticatedUser, UserRole } from '$lib/server/auth';
+
+const ROLE_PRIORITY: Record<UserRole, number> = {
+	viewer: 0,
+	operator: 1,
+	admin: 2
+};
+
+function meetsRequirement(userRole: UserRole, required: UserRole): boolean {
+	return ROLE_PRIORITY[userRole] >= ROLE_PRIORITY[required];
+}
+
+function normalizeRequirements(required: UserRole | UserRole[]): UserRole[] {
+	return Array.isArray(required) ? required : [required];
+}
+
+export function hasRole(
+	user: AuthenticatedUser | null | undefined,
+	required: UserRole | UserRole[]
+): user is AuthenticatedUser {
+	if (!user) {
+		return false;
+	}
+
+	const requirements = normalizeRequirements(required);
+	return requirements.some((role) => meetsRequirement(user.role, role));
+}
+
+export function requireRole<T extends UserRole | UserRole[]>(
+	user: AuthenticatedUser | null | undefined,
+	required: T,
+	message = 'Insufficient privileges'
+): AuthenticatedUser {
+	if (!user) {
+		throw error(401, 'Authentication required');
+	}
+
+	if (!hasRole(user, required)) {
+		throw error(403, message);
+	}
+
+	return user;
+}
+
+export function requireOperator(user: AuthenticatedUser | null | undefined): AuthenticatedUser {
+	return requireRole(user, 'operator');
+}
+
+export function requireViewer(user: AuthenticatedUser | null | undefined): AuthenticatedUser {
+	return requireRole(user, 'viewer');
+}
+
+export function requireAdmin(user: AuthenticatedUser | null | undefined): AuthenticatedUser {
+	return requireRole(user, 'admin');
+}
+
+export { ROLE_PRIORITY };

--- a/tenvy-server/src/lib/server/db/index.ts
+++ b/tenvy-server/src/lib/server/db/index.ts
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS user (
         id TEXT PRIMARY KEY NOT NULL,
         created_at INTEGER NOT NULL,
         voucher_id TEXT NOT NULL,
+        role TEXT NOT NULL DEFAULT 'operator',
         passkey_registered INTEGER NOT NULL DEFAULT 0,
         current_challenge TEXT,
         challenge_type TEXT,
@@ -129,6 +130,21 @@ CREATE TABLE IF NOT EXISTS agent_result (
         FOREIGN KEY (agent_id) REFERENCES agent(id) ON DELETE CASCADE
 );
 CREATE UNIQUE INDEX IF NOT EXISTS agent_result_command_idx ON agent_result (agent_id, command_id);
+
+CREATE TABLE IF NOT EXISTS audit_event (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        command_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        operator_id TEXT,
+        command_name TEXT NOT NULL,
+        payload_hash TEXT NOT NULL,
+        queued_at INTEGER NOT NULL,
+        executed_at INTEGER,
+        result TEXT,
+        FOREIGN KEY (operator_id) REFERENCES user(id) ON DELETE SET NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS audit_event_command_idx ON audit_event (command_id);
+CREATE INDEX IF NOT EXISTS audit_event_agent_idx ON audit_event (agent_id);
 COMMIT;`
 );
 
@@ -141,5 +157,6 @@ const ensureColumn = (table: string, column: string, ddl: string) => {
 };
 
 ensureColumn('passkey', 'last_used_at', 'last_used_at INTEGER');
+ensureColumn('user', 'role', "role TEXT NOT NULL DEFAULT 'operator'");
 
 export const db = drizzle(client, { schema });

--- a/tenvy-server/src/lib/server/rat/remote-desktop.test.ts
+++ b/tenvy-server/src/lib/server/rat/remote-desktop.test.ts
@@ -8,150 +8,150 @@ const sendRemoteDesktopInput = vi.fn(() => true);
 const queueCommand = vi.fn();
 
 vi.mock('./store', () => ({
-        registry: {
-                sendRemoteDesktopInput,
-                queueCommand
-        }
+	registry: {
+		sendRemoteDesktopInput,
+		queueCommand
+	}
 }));
 
 class MockRTCDataChannel {
-        label: string;
-        binaryType: BinaryType = 'arraybuffer';
-        onmessage?: (evt: { data: unknown }) => void;
-        onclose?: () => void;
+	label: string;
+	binaryType: BinaryType = 'arraybuffer';
+	onmessage?: (evt: { data: unknown }) => void;
+	onclose?: () => void;
 
-        constructor(label: string) {
-                this.label = label;
-                createdChannels.push(this);
-        }
+	constructor(label: string) {
+		this.label = label;
+		createdChannels.push(this);
+	}
 
-        close() {
-                this.onclose?.();
-        }
+	close() {
+		this.onclose?.();
+	}
 
-        emit(data: unknown) {
-                this.onmessage?.({ data });
-        }
+	emit(data: unknown) {
+		this.onmessage?.({ data });
+	}
 }
 
 class MockRTCPeerConnection {
-        configuration: RTCConfiguration;
-        localDescription: RTCSessionDescriptionInit | null = null;
-        remoteDescription: RTCSessionDescriptionInit | null = null;
-        iceGatheringState: RTCIceGatheringState = 'complete';
-        connectionState: RTCPeerConnectionState = 'new';
-        onicegatheringstatechange: (() => void) | null = null;
-        ondatachannel: ((event: { channel: RTCDataChannel }) => void) | null = null;
-        onconnectionstatechange: (() => void) | null = null;
-        channel: MockRTCDataChannel | null = null;
+	configuration: RTCConfiguration;
+	localDescription: RTCSessionDescriptionInit | null = null;
+	remoteDescription: RTCSessionDescriptionInit | null = null;
+	iceGatheringState: RTCIceGatheringState = 'complete';
+	connectionState: RTCPeerConnectionState = 'new';
+	onicegatheringstatechange: (() => void) | null = null;
+	ondatachannel: ((event: { channel: RTCDataChannel }) => void) | null = null;
+	onconnectionstatechange: (() => void) | null = null;
+	channel: MockRTCDataChannel | null = null;
 
-        constructor(configuration?: RTCConfiguration) {
-                this.configuration = configuration ?? { iceServers: [] };
-                createdPeerConnections.push(this);
-        }
+	constructor(configuration?: RTCConfiguration) {
+		this.configuration = configuration ?? { iceServers: [] };
+		createdPeerConnections.push(this);
+	}
 
-        async setRemoteDescription(desc: RTCSessionDescriptionInit) {
-                this.remoteDescription = desc;
-                if (!this.channel && this.ondatachannel) {
-                        const channel = new MockRTCDataChannel('remote-desktop-frames');
-                        this.channel = channel;
-                        this.ondatachannel({ channel } as unknown as { channel: RTCDataChannel });
-                }
-        }
+	async setRemoteDescription(desc: RTCSessionDescriptionInit) {
+		this.remoteDescription = desc;
+		if (!this.channel && this.ondatachannel) {
+			const channel = new MockRTCDataChannel('remote-desktop-frames');
+			this.channel = channel;
+			this.ondatachannel({ channel } as unknown as { channel: RTCDataChannel });
+		}
+	}
 
-        async createAnswer(): Promise<RTCSessionDescriptionInit> {
-                return { type: 'answer', sdp: 'mock-answer' };
-        }
+	async createAnswer(): Promise<RTCSessionDescriptionInit> {
+		return { type: 'answer', sdp: 'mock-answer' };
+	}
 
-        async setLocalDescription(desc: RTCSessionDescriptionInit) {
-                this.localDescription = desc;
-        }
+	async setLocalDescription(desc: RTCSessionDescriptionInit) {
+		this.localDescription = desc;
+	}
 
-        close() {
-                this.connectionState = 'closed';
-                this.onconnectionstatechange?.();
-                this.channel?.close();
-        }
+	close() {
+		this.connectionState = 'closed';
+		this.onconnectionstatechange?.();
+		this.channel?.close();
+	}
 }
 
 vi.mock('@koush/wrtc', () => ({
-        RTCPeerConnection: MockRTCPeerConnection
+	RTCPeerConnection: MockRTCPeerConnection
 }));
 
 describe('RemoteDesktopManager WebRTC negotiation', () => {
-        beforeEach(() => {
-                vi.resetModules();
-                createdPeerConnections.length = 0;
-                createdChannels.length = 0;
-                sendRemoteDesktopInput.mockReset();
-                queueCommand.mockReset();
-        });
+	beforeEach(() => {
+		vi.resetModules();
+		createdPeerConnections.length = 0;
+		createdChannels.length = 0;
+		sendRemoteDesktopInput.mockReset();
+		queueCommand.mockReset();
+	});
 
-        afterEach(() => {
-                delete process.env.TENVY_REMOTE_DESKTOP_ICE_SERVERS;
-        });
+	afterEach(() => {
+		delete process.env.TENVY_REMOTE_DESKTOP_ICE_SERVERS;
+	});
 
-        async function createManager() {
-                process.env.TENVY_REMOTE_DESKTOP_ICE_SERVERS = JSON.stringify([
-                        {
-                                urls: ['turn:turn.example.com:3478?transport=tcp'],
-                                username: 'turn-user',
-                                credential: 'turn-pass',
-                                credentialType: 'password'
-                        }
-                ]);
-                const module = await import('./remote-desktop');
-                return new module.RemoteDesktopManager();
-        }
+	async function createManager() {
+		process.env.TENVY_REMOTE_DESKTOP_ICE_SERVERS = JSON.stringify([
+			{
+				urls: ['turn:turn.example.com:3478?transport=tcp'],
+				username: 'turn-user',
+				credential: 'turn-pass',
+				credentialType: 'password'
+			}
+		]);
+		const module = await import('./remote-desktop');
+		return new module.RemoteDesktopManager();
+	}
 
-        it('negotiates WebRTC using TURN-only ICE servers and streams frames', async () => {
-                const manager = await createManager();
-                const session = manager.createSession('agent-1');
+	it('negotiates WebRTC using TURN-only ICE servers and streams frames', async () => {
+		const manager = await createManager();
+		const session = manager.createSession('agent-1');
 
-                const offerSdp = 'mock-offer';
-                const request: RemoteDesktopSessionNegotiationRequest = {
-                        sessionId: session.sessionId,
-                        transports: [
-                                { transport: 'webrtc', codecs: ['hevc'], features: { intraRefresh: true } },
-                                { transport: 'http', codecs: ['hevc', 'avc'] }
-                        ],
-                        codecs: ['hevc', 'avc'],
-                        intraRefresh: true,
-                        webrtc: {
-                                offer: Buffer.from(offerSdp, 'utf8').toString('base64'),
-                                dataChannel: 'remote-desktop-frames'
-                        }
-                };
+		const offerSdp = 'mock-offer';
+		const request: RemoteDesktopSessionNegotiationRequest = {
+			sessionId: session.sessionId,
+			transports: [
+				{ transport: 'webrtc', codecs: ['hevc'], features: { intraRefresh: true } },
+				{ transport: 'http', codecs: ['hevc', 'avc'] }
+			],
+			codecs: ['hevc', 'avc'],
+			intraRefresh: true,
+			webrtc: {
+				offer: Buffer.from(offerSdp, 'utf8').toString('base64'),
+				dataChannel: 'remote-desktop-frames'
+			}
+		};
 
-                const response = await manager.negotiateTransport('agent-1', request);
+		const response = await manager.negotiateTransport('agent-1', request);
 
-                expect(response.accepted).toBe(true);
-                expect(response.transport).toBe('webrtc');
-                expect(response.webrtc?.answer).toBeDefined();
-                expect(response.webrtc?.iceServers?.[0]?.urls[0]).toContain('turn:turn.example.com');
-                expect(createdPeerConnections).toHaveLength(1);
-                expect(createdPeerConnections[0]?.configuration.iceServers?.[0]?.urls).toContain(
-                        'turn:turn.example.com:3478?transport=tcp'
-                );
+		expect(response.accepted).toBe(true);
+		expect(response.transport).toBe('webrtc');
+		expect(response.webrtc?.answer).toBeDefined();
+		expect(response.webrtc?.iceServers?.[0]?.urls[0]).toContain('turn:turn.example.com');
+		expect(createdPeerConnections).toHaveLength(1);
+		expect(createdPeerConnections[0]?.configuration.iceServers?.[0]?.urls).toContain(
+			'turn:turn.example.com:3478?transport=tcp'
+		);
 
-                const channel = createdChannels[0];
-                expect(channel).toBeDefined();
+		const channel = createdChannels[0];
+		expect(channel).toBeDefined();
 
-                const frame = {
-                        sessionId: session.sessionId,
-                        sequence: 1,
-                        timestamp: new Date().toISOString(),
-                        width: 1280,
-                        height: 720,
-                        keyFrame: true,
-                        encoding: 'jpeg' as const,
-                        image: Buffer.from([1]).toString('base64')
-                };
+		const frame = {
+			sessionId: session.sessionId,
+			sequence: 1,
+			timestamp: new Date().toISOString(),
+			width: 1280,
+			height: 720,
+			keyFrame: true,
+			encoding: 'jpeg' as const,
+			image: Buffer.from([1]).toString('base64')
+		};
 
-                channel?.emit(JSON.stringify(frame));
+		channel?.emit(JSON.stringify(frame));
 
-                const state = manager.getSessionState('agent-1');
-                expect(state?.lastSequence).toBe(1);
-                expect(state?.negotiatedTransport).toBe('webrtc');
-        });
+		const state = manager.getSessionState('agent-1');
+		expect(state?.lastSequence).toBe(1);
+		expect(state?.negotiatedTransport).toBe('webrtc');
+	});
 });

--- a/tenvy-server/src/lib/server/rat/remote-desktop.ts
+++ b/tenvy-server/src/lib/server/rat/remote-desktop.ts
@@ -1,19 +1,19 @@
 import { randomUUID } from 'crypto';
 import type {
-        RemoteDesktopEncoder,
-        RemoteDesktopFrameMetrics,
-        RemoteDesktopFramePacket,
-        RemoteDesktopInputBurst,
-        RemoteDesktopInputEvent,
-        RemoteDesktopMonitor,
-        RemoteDesktopSessionNegotiationRequest,
-        RemoteDesktopSessionNegotiationResponse,
-        RemoteDesktopSessionState,
-        RemoteDesktopSettings,
-        RemoteDesktopSettingsPatch,
-        RemoteDesktopTransport,
-        RemoteDesktopTransportCapability,
-        RemoteDesktopWebRTCICEServer
+	RemoteDesktopEncoder,
+	RemoteDesktopFrameMetrics,
+	RemoteDesktopFramePacket,
+	RemoteDesktopInputBurst,
+	RemoteDesktopInputEvent,
+	RemoteDesktopMonitor,
+	RemoteDesktopSessionNegotiationRequest,
+	RemoteDesktopSessionNegotiationResponse,
+	RemoteDesktopSessionState,
+	RemoteDesktopSettings,
+	RemoteDesktopSettingsPatch,
+	RemoteDesktopTransport,
+	RemoteDesktopTransportCapability,
+	RemoteDesktopWebRTCICEServer
 } from '$lib/types/remote-desktop';
 import { registry } from './store';
 
@@ -37,7 +37,7 @@ const defaultSettings: RemoteDesktopSettings = Object.freeze({
 });
 
 const defaultMonitors: readonly RemoteDesktopMonitor[] = Object.freeze([
-        { id: 0, label: 'Primary', width: 1280, height: 720 }
+	{ id: 0, label: 'Primary', width: 1280, height: 720 }
 ]);
 
 const qualities = new Set<RemoteDesktopSettings['quality']>(['auto', 'high', 'medium', 'low']);
@@ -49,123 +49,123 @@ const preferredCodecs: RemoteDesktopEncoder[] = ['hevc', 'avc', 'jpeg'];
 const configuredIceServers = parseConfiguredIceServers();
 
 function parseConfiguredIceServers(): RemoteDesktopWebRTCICEServer[] {
-        const raw = process.env.TENVY_REMOTE_DESKTOP_ICE_SERVERS;
-        if (!raw) {
-                return [];
-        }
+	const raw = process.env.TENVY_REMOTE_DESKTOP_ICE_SERVERS;
+	if (!raw) {
+		return [];
+	}
 
-        try {
-                const parsed = JSON.parse(raw) as RemoteDesktopWebRTCICEServer[];
-                const normalized = normalizeIceServers(parsed);
-                if (normalized.length === 0) {
-                        return [];
-                }
-                return Object.freeze(cloneIceServers(normalized));
-        } catch (err) {
-                console.warn('Failed to parse remote desktop ICE server configuration', err);
-                return [];
-        }
+	try {
+		const parsed = JSON.parse(raw) as RemoteDesktopWebRTCICEServer[];
+		const normalized = normalizeIceServers(parsed);
+		if (normalized.length === 0) {
+			return [];
+		}
+		return Object.freeze(cloneIceServers(normalized));
+	} catch (err) {
+		console.warn('Failed to parse remote desktop ICE server configuration', err);
+		return [];
+	}
 }
 
 function normalizeIceServers(
-        servers?: RemoteDesktopWebRTCICEServer[] | null
+	servers?: RemoteDesktopWebRTCICEServer[] | null
 ): RemoteDesktopWebRTCICEServer[] {
-        if (!servers || servers.length === 0) {
-                return [];
-        }
+	if (!servers || servers.length === 0) {
+		return [];
+	}
 
-        const normalized: RemoteDesktopWebRTCICEServer[] = [];
-        for (const server of servers) {
-                if (!server) continue;
+	const normalized: RemoteDesktopWebRTCICEServer[] = [];
+	for (const server of servers) {
+		if (!server) continue;
 
-                const urls = Array.isArray(server.urls)
-                        ? server.urls
-                        : typeof (server as { urls?: unknown }).urls === 'string'
-                          ? [(server as { urls: string }).urls]
-                          : [];
+		const urls = Array.isArray(server.urls)
+			? server.urls
+			: typeof (server as { urls?: unknown }).urls === 'string'
+				? [(server as { urls: string }).urls]
+				: [];
 
-                const cleaned = urls
-                        .map((url) => (typeof url === 'string' ? url.trim() : ''))
-                        .filter((url) => url.length > 0);
+		const cleaned = urls
+			.map((url) => (typeof url === 'string' ? url.trim() : ''))
+			.filter((url) => url.length > 0);
 
-                if (cleaned.length === 0) {
-                        continue;
-                }
+		if (cleaned.length === 0) {
+			continue;
+		}
 
-                const entry: RemoteDesktopWebRTCICEServer = { urls: cleaned };
+		const entry: RemoteDesktopWebRTCICEServer = { urls: cleaned };
 
-                if (typeof server.username === 'string' && server.username.trim() !== '') {
-                        entry.username = server.username.trim();
-                }
-                if (typeof server.credential === 'string' && server.credential.trim() !== '') {
-                        entry.credential = server.credential.trim();
-                }
+		if (typeof server.username === 'string' && server.username.trim() !== '') {
+			entry.username = server.username.trim();
+		}
+		if (typeof server.credential === 'string' && server.credential.trim() !== '') {
+			entry.credential = server.credential.trim();
+		}
 
-                const credentialType =
-                        typeof server.credentialType === 'string'
-                                ? server.credentialType.trim().toLowerCase()
-                                : undefined;
-                if (credentialType === 'oauth') {
-                        entry.credentialType = 'oauth';
-                } else if (credentialType === 'password' || entry.credential) {
-                        if (entry.credential) {
-                                entry.credentialType = 'password';
-                        }
-                }
+		const credentialType =
+			typeof server.credentialType === 'string'
+				? server.credentialType.trim().toLowerCase()
+				: undefined;
+		if (credentialType === 'oauth') {
+			entry.credentialType = 'oauth';
+		} else if (credentialType === 'password' || entry.credential) {
+			if (entry.credential) {
+				entry.credentialType = 'password';
+			}
+		}
 
-                normalized.push(entry);
-        }
+		normalized.push(entry);
+	}
 
-        return normalized;
+	return normalized;
 }
 
 function cloneIceServer(server: RemoteDesktopWebRTCICEServer): RemoteDesktopWebRTCICEServer {
-        const cloned: RemoteDesktopWebRTCICEServer = { urls: [...server.urls] };
-        if (server.username) {
-                        cloned.username = server.username;
-        }
-        if (server.credential) {
-                        cloned.credential = server.credential;
-        }
-        if (server.credentialType) {
-                        cloned.credentialType = server.credentialType;
-        }
-        return cloned;
+	const cloned: RemoteDesktopWebRTCICEServer = { urls: [...server.urls] };
+	if (server.username) {
+		cloned.username = server.username;
+	}
+	if (server.credential) {
+		cloned.credential = server.credential;
+	}
+	if (server.credentialType) {
+		cloned.credentialType = server.credentialType;
+	}
+	return cloned;
 }
 
 function cloneIceServers(servers: RemoteDesktopWebRTCICEServer[]): RemoteDesktopWebRTCICEServer[] {
-        return servers.map((server) => cloneIceServer(server));
+	return servers.map((server) => cloneIceServer(server));
 }
 
 function resolveIceServers(
-        requested?: RemoteDesktopWebRTCICEServer[] | null
+	requested?: RemoteDesktopWebRTCICEServer[] | null
 ): RemoteDesktopWebRTCICEServer[] {
-        const normalized = normalizeIceServers(requested);
-        if (normalized.length > 0) {
-                return cloneIceServers(normalized);
-        }
-        return cloneIceServers(configuredIceServers);
+	const normalized = normalizeIceServers(requested);
+	if (normalized.length > 0) {
+		return cloneIceServers(normalized);
+	}
+	return cloneIceServers(configuredIceServers);
 }
 
 function toRtcIceServers(servers: RemoteDesktopWebRTCICEServer[]): RTCIceServer[] {
-        return servers.map((server) => {
-                const entry: RTCIceServer = { urls: [...server.urls] };
-                if (server.username) {
-                        entry.username = server.username;
-                }
-                if (server.credential) {
-                        entry.credential = server.credential;
-                }
-                const type = server.credentialType?.toLowerCase();
-                if (type === 'oauth') {
-                        entry.credentialType = 'oauth';
-                } else if (type === 'password' || (!type && server.credential)) {
-                        if (entry.credential) {
-                                entry.credentialType = 'password';
-                        }
-                }
-                return entry;
-        });
+	return servers.map((server) => {
+		const entry: RTCIceServer = { urls: [...server.urls] };
+		if (server.username) {
+			entry.username = server.username;
+		}
+		if (server.credential) {
+			entry.credential = server.credential;
+		}
+		const type = server.credentialType?.toLowerCase();
+		if (type === 'oauth') {
+			entry.credentialType = 'oauth';
+		} else if (type === 'password' || (!type && server.credential)) {
+			if (entry.credential) {
+				entry.credentialType = 'password';
+			}
+		}
+		return entry;
+	});
 }
 
 class RemoteDesktopError extends Error {
@@ -699,13 +699,13 @@ export class RemoteDesktopManager {
 			throw new RemoteDesktopError('No supported transports offered', 400);
 		}
 
-                let selectedTransport: RemoteDesktopTransport = 'http';
-                let selectedCodec: RemoteDesktopEncoder | null = null;
-                let intraRefresh = false;
-                let answer: string | undefined;
-                let reason: string | undefined;
-                let handle: RemoteDesktopTransportHandle | null = null;
-                let negotiationIceServers: RemoteDesktopWebRTCICEServer[] = [];
+		let selectedTransport: RemoteDesktopTransport = 'http';
+		let selectedCodec: RemoteDesktopEncoder | null = null;
+		let intraRefresh = false;
+		let answer: string | undefined;
+		let reason: string | undefined;
+		let handle: RemoteDesktopTransportHandle | null = null;
+		let negotiationIceServers: RemoteDesktopWebRTCICEServer[] = [];
 
 		const webrtcCapability = capabilities.find(
 			(cap) => cap.transport === 'webrtc' && request.webrtc?.offer
@@ -715,14 +715,14 @@ export class RemoteDesktopManager {
 			if (codec) {
 				try {
 					const enableIntra = supportsIntraRefresh(webrtcCapability, request.intraRefresh);
-                                        const result = await this.establishWebRTCTransport(agentId, record, request.webrtc!);
-                                        handle = result.handle;
-                                        answer = result.answer;
-                                        negotiationIceServers = result.iceServers;
-                                        selectedTransport = 'webrtc';
-                                        selectedCodec = codec;
-                                        intraRefresh = enableIntra;
-                                } catch (err) {
+					const result = await this.establishWebRTCTransport(agentId, record, request.webrtc!);
+					handle = result.handle;
+					answer = result.answer;
+					negotiationIceServers = result.iceServers;
+					selectedTransport = 'webrtc';
+					selectedCodec = codec;
+					intraRefresh = enableIntra;
+				} catch (err) {
 					reason = err instanceof Error ? err.message : 'Failed to establish WebRTC transport';
 				}
 			} else {
@@ -755,14 +755,15 @@ export class RemoteDesktopManager {
 			codec: selectedCodec ?? undefined,
 			intraRefresh
 		};
-                if (answer) {
-                        const responseIce = negotiationIceServers.length > 0 ? cloneIceServers(negotiationIceServers) : undefined;
-                        response.webrtc = {
-                                answer,
-                                dataChannel: request.webrtc?.dataChannel,
-                                iceServers: responseIce
-                        };
-                }
+		if (answer) {
+			const responseIce =
+				negotiationIceServers.length > 0 ? cloneIceServers(negotiationIceServers) : undefined;
+			response.webrtc = {
+				answer,
+				dataChannel: request.webrtc?.dataChannel,
+				iceServers: responseIce
+			};
+		}
 		if (reason && selectedTransport !== 'webrtc') {
 			response.reason = reason;
 		}
@@ -1039,17 +1040,21 @@ export class RemoteDesktopManager {
 		return next;
 	}
 
-        private async establishWebRTCTransport(
-                agentId: string,
-                record: RemoteDesktopSessionRecord,
-                params: NonNullable<RemoteDesktopSessionNegotiationRequest['webrtc']>
-        ): Promise<{ handle: RemoteDesktopTransportHandle; answer: string; iceServers: RemoteDesktopWebRTCICEServer[] }> {
-                const { RTCPeerConnection } = (await import('@koush/wrtc')) as typeof import('@koush/wrtc');
-                const iceServers = resolveIceServers(params.iceServers);
-                const configuration = { iceServers: toRtcIceServers(iceServers) };
-                const pc: RTCPeerConnection = new RTCPeerConnection(configuration);
-                let channel: RTCDataChannel | null = null;
-                let handle: RemoteDesktopTransportHandle | null = null;
+	private async establishWebRTCTransport(
+		agentId: string,
+		record: RemoteDesktopSessionRecord,
+		params: NonNullable<RemoteDesktopSessionNegotiationRequest['webrtc']>
+	): Promise<{
+		handle: RemoteDesktopTransportHandle;
+		answer: string;
+		iceServers: RemoteDesktopWebRTCICEServer[];
+	}> {
+		const { RTCPeerConnection } = (await import('@koush/wrtc')) as typeof import('@koush/wrtc');
+		const iceServers = resolveIceServers(params.iceServers);
+		const configuration = { iceServers: toRtcIceServers(iceServers) };
+		const pc: RTCPeerConnection = new RTCPeerConnection(configuration);
+		let channel: RTCDataChannel | null = null;
+		let handle: RemoteDesktopTransportHandle | null = null;
 
 		const offerSdp = decodeBase64(params.offer ?? '');
 		if (!offerSdp) {
@@ -1115,8 +1120,8 @@ export class RemoteDesktopManager {
 
 		handle = transportHandle;
 
-                return { handle: transportHandle, answer: encodeBase64(local.sdp), iceServers };
-        }
+		return { handle: transportHandle, answer: encodeBase64(local.sdp), iceServers };
+	}
 
 	private handleWebRTCFrame(agentId: string, sessionId: string, data: unknown) {
 		try {

--- a/tenvy-server/src/routes/(app)/agents/[agentId]/+layout.ts
+++ b/tenvy-server/src/routes/(app)/agents/[agentId]/+layout.ts
@@ -1,0 +1,18 @@
+import { error } from '@sveltejs/kit';
+import type { LayoutLoad } from './$types';
+import type { AgentDetailResponse } from '../../../../../../shared/types/agent';
+
+export const load = (async ({ params, fetch }) => {
+	const id = params.agentId;
+	if (!id) {
+		throw error(404, 'Agent not found');
+	}
+
+	const response = await fetch(`/api/agents/${id}`);
+	if (!response.ok) {
+		throw error(response.status, 'Failed to load agent');
+	}
+
+	const data = (await response.json()) as AgentDetailResponse;
+	return { agent: data.agent };
+}) satisfies LayoutLoad;

--- a/tenvy-server/src/routes/(app)/agents/[agentId]/+page.svelte
+++ b/tenvy-server/src/routes/(app)/agents/[agentId]/+page.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+	import {
+		Card,
+		CardContent,
+		CardDescription,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
+	import type { PageData } from './$types';
+	import type { AuditEventSummary } from './+page';
+
+	let { data } = $props<{ data: PageData }>();
+	const agent = $derived(data.agent);
+	const events = $derived(data.events);
+
+	const formatter = new Intl.DateTimeFormat(undefined, {
+		dateStyle: 'medium',
+		timeStyle: 'short'
+	});
+
+	const statusStyles: Record<'success' | 'failure' | 'pending', string> = {
+		success: 'bg-emerald-500/10 text-emerald-600 border border-emerald-500/30',
+		failure: 'bg-rose-500/10 text-rose-600 border border-rose-500/30',
+		pending: 'bg-amber-500/10 text-amber-600 border border-amber-500/30'
+	};
+
+	type ParsedResult = { success: boolean; output?: string | null; error?: string | null } | null;
+
+	function parseResult(value: string | null): ParsedResult {
+		if (!value) return null;
+		try {
+			const parsed = JSON.parse(value) as ParsedResult;
+			if (parsed && typeof parsed === 'object') {
+				return parsed;
+			}
+		} catch {
+			// fall through to plain text
+		}
+		return null;
+	}
+
+	function summarizeResult(event: AuditEventSummary): string {
+		if (!event.executedAt) {
+			return 'Awaiting execution';
+		}
+		if (!event.result) {
+			return 'Completed (no result payload)';
+		}
+		const parsed = parseResult(event.result);
+		if (!parsed) {
+			return event.result.slice(0, 160);
+		}
+		if (parsed.success) {
+			return (parsed.output ?? 'Command completed successfully').slice(0, 160);
+		}
+		return (parsed.error ?? 'Command failed').slice(0, 160);
+	}
+
+	function resolveStatus(event: AuditEventSummary): 'pending' | 'success' | 'failure' {
+		if (!event.executedAt) {
+			return 'pending';
+		}
+		const parsed = parseResult(event.result);
+		if (!parsed) {
+			return 'success';
+		}
+		return parsed.success ? 'success' : 'failure';
+	}
+
+	function formatTimestamp(value: string | null): string {
+		if (!value) {
+			return '—';
+		}
+		const date = new Date(value);
+		if (Number.isNaN(date.getTime())) {
+			return '—';
+		}
+		return formatter.format(date);
+	}
+
+	function formatOperator(value: string | null): string {
+		return value ?? '—';
+	}
+</script>
+
+<div class="space-y-6">
+	<Card>
+		<CardHeader class="gap-2">
+			<CardTitle class="text-lg">Audit trail</CardTitle>
+			<CardDescription>
+				Review command activity for <span class="font-semibold text-slate-900 dark:text-slate-100"
+					>{agent.metadata.hostname ?? agent.id}</span
+				>.
+			</CardDescription>
+		</CardHeader>
+		<CardContent class="space-y-4">
+			<div class="grid gap-2 text-sm text-slate-600 sm:grid-cols-2 dark:text-slate-400">
+				<div>
+					<span class="font-semibold text-slate-900 dark:text-slate-100">Agent ID:</span>
+					<span class="ml-2 font-mono text-slate-700 dark:text-slate-300">{agent.id}</span>
+				</div>
+				<div>
+					<span class="font-semibold text-slate-900 dark:text-slate-100">Status:</span>
+					<span class="ml-2 text-slate-700 capitalize dark:text-slate-300">{agent.status}</span>
+				</div>
+				<div>
+					<span class="font-semibold text-slate-900 dark:text-slate-100">Queued events:</span>
+					<span class="ml-2 text-slate-700 dark:text-slate-300">{events.length}</span>
+				</div>
+			</div>
+			<Separator class="my-2" />
+			{#if events.length === 0}
+				<p class="text-sm text-slate-600 dark:text-slate-400">
+					No command activity has been recorded for this agent yet.
+				</p>
+			{:else}
+				<div class="overflow-x-auto">
+					<table
+						class="min-w-full divide-y divide-slate-200 text-left text-sm dark:divide-slate-800"
+					>
+						<thead class="bg-slate-50 dark:bg-slate-900/40">
+							<tr class="text-xs tracking-wide text-slate-500 uppercase dark:text-slate-400">
+								<th class="px-4 py-3 font-semibold">Command</th>
+								<th class="px-4 py-3 font-semibold">Operator</th>
+								<th class="px-4 py-3 font-semibold">Status</th>
+								<th class="px-4 py-3 font-semibold">Queued</th>
+								<th class="px-4 py-3 font-semibold">Executed</th>
+								<th class="px-4 py-3 font-semibold">Payload hash</th>
+								<th class="px-4 py-3 font-semibold">Result</th>
+							</tr>
+						</thead>
+						<tbody class="divide-y divide-slate-100 dark:divide-slate-900/60">
+							{#each events as event (event.id)}
+								{@const status = resolveStatus(event)}
+								<tr
+									class="bg-white/70 transition hover:bg-slate-50 dark:bg-slate-900/60 dark:hover:bg-slate-900"
+								>
+									<td class="px-4 py-3 font-mono text-xs text-slate-700 dark:text-slate-200">
+										{event.commandName}
+									</td>
+									<td class="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
+										{formatOperator(event.operatorId)}
+									</td>
+									<td class="px-4 py-3">
+										<Badge class={statusStyles[status]}
+											>{status === 'pending'
+												? 'Pending'
+												: status === 'success'
+													? 'Succeeded'
+													: 'Failed'}</Badge
+										>
+									</td>
+									<td class="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
+										{formatTimestamp(event.queuedAt)}
+									</td>
+									<td class="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
+										{formatTimestamp(event.executedAt)}
+									</td>
+									<td class="px-4 py-3">
+										<code
+											class="rounded bg-slate-100 px-2 py-1 font-mono text-[11px] text-slate-700 dark:bg-slate-900/60 dark:text-slate-200"
+										>
+											{event.payloadHash}
+										</code>
+									</td>
+									<td class="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
+										{summarizeResult(event)}
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+		</CardContent>
+	</Card>
+</div>

--- a/tenvy-server/src/routes/(app)/agents/[agentId]/+page.ts
+++ b/tenvy-server/src/routes/(app)/agents/[agentId]/+page.ts
@@ -1,0 +1,29 @@
+import { error } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export type AuditEventSummary = {
+	id: number;
+	commandId: string;
+	commandName: string;
+	operatorId: string | null;
+	payloadHash: string;
+	queuedAt: string | null;
+	executedAt: string | null;
+	result: string | null;
+};
+
+export const load = (async ({ params, fetch, parent }) => {
+	const { agent } = await parent();
+	const id = params.agentId;
+	if (!id) {
+		throw error(404, 'Agent not found');
+	}
+
+	const response = await fetch(`/api/agents/${id}/audit`);
+	if (!response.ok) {
+		throw error(response.status, 'Failed to load audit events');
+	}
+
+	const data = (await response.json()) as { events: AuditEventSummary[] };
+	return { agent, events: data.events };
+}) satisfies PageLoad;

--- a/tenvy-server/src/routes/(app)/build/components/ExecutionTab.svelte
+++ b/tenvy-server/src/routes/(app)/build/components/ExecutionTab.svelte
@@ -104,9 +104,7 @@
 	>
 		<div>
 			<p class="font-medium">Require internet connectivity</p>
-			<p class="text-muted-foreground">
-				Delay execution until a network connection is available.
-			</p>
+			<p class="text-muted-foreground">Delay execution until a network connection is available.</p>
 		</div>
 		<Switch
 			bind:checked={executionRequireInternet}

--- a/tenvy-server/src/routes/(app)/build/components/PersistenceTab.svelte
+++ b/tenvy-server/src/routes/(app)/build/components/PersistenceTab.svelte
@@ -111,7 +111,9 @@
 	</div>
 
 	<div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-		<div class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4">
+		<div
+			class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4"
+		>
 			<div>
 				<p class="text-sm font-medium">Melt after run</p>
 				<p class="text-xs text-muted-foreground">
@@ -121,7 +123,9 @@
 			<Switch bind:checked={meltAfterRun} aria-label="Toggle melt-after-run" />
 		</div>
 
-		<div class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4">
+		<div
+			class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4"
+		>
 			<div>
 				<p class="text-sm font-medium">Startup on boot</p>
 				<p class="text-xs text-muted-foreground">
@@ -131,7 +135,9 @@
 			<Switch bind:checked={startupOnBoot} aria-label="Toggle startup persistence" />
 		</div>
 
-		<div class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4">
+		<div
+			class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4"
+		>
 			<div>
 				<p class="text-sm font-medium">Developer mode</p>
 				<p class="text-xs text-muted-foreground">
@@ -141,7 +147,9 @@
 			<Switch bind:checked={developerMode} aria-label="Toggle developer mode" />
 		</div>
 
-		<div class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4">
+		<div
+			class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4"
+		>
 			<div>
 				<p class="text-sm font-medium">Binary compression</p>
 				<p class="text-xs text-muted-foreground">
@@ -151,7 +159,9 @@
 			<Switch bind:checked={compressBinary} aria-label="Toggle binary compression" />
 		</div>
 
-		<div class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4">
+		<div
+			class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4"
+		>
 			<div>
 				<p class="text-sm font-medium">Require administrator</p>
 				<p class="text-xs text-muted-foreground">
@@ -161,7 +171,9 @@
 			<Switch bind:checked={forceAdmin} aria-label="Toggle admin requirement" />
 		</div>
 
-		<div class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4">
+		<div
+			class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4"
+		>
 			<div class="w-full">
 				<p class="text-sm font-medium">Watchdog</p>
 				<p class="text-xs text-muted-foreground">
@@ -188,7 +200,9 @@
 			<Switch bind:checked={watchdogEnabled} aria-label="Toggle watchdog" />
 		</div>
 
-		<div class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4">
+		<div
+			class="flex items-start justify-between gap-4 rounded-lg border border-border bg-muted/30 p-4"
+		>
 			<div class="w-full">
 				<p class="text-sm font-medium">File pumper</p>
 				<p class="text-xs text-muted-foreground">

--- a/tenvy-server/src/routes/(app)/build/components/PresentationTab.svelte
+++ b/tenvy-server/src/routes/(app)/build/components/PresentationTab.svelte
@@ -67,9 +67,7 @@
 						<p class="text-xs text-red-500">{fileIconError}</p>
 					{/if}
 
-					<p class="text-xs text-muted-foreground">
-						Optional. Accepted format: .ico (max 512KB).
-					</p>
+					<p class="text-xs text-muted-foreground">Optional. Accepted format: .ico (max 512KB).</p>
 				</div>
 			</div>
 

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/modules/control/remote-desktop/+page.svelte
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/modules/control/remote-desktop/+page.svelte
@@ -26,18 +26,13 @@
 	}
 </script>
 
-<MovableWindow
-	title={tool.title}
-	width={windowWidth}
-	height={windowHeight}
-	onClose={handleClose}
->
+<MovableWindow title={tool.title} width={windowWidth} height={windowHeight} onClose={handleClose}>
 	<div class="flex h-full flex-col bg-background">
 		<div class="border-b border-border/70 bg-muted/40 px-6 py-4 text-sm text-muted-foreground">
 			{tool.description}
 		</div>
 		<div class="flex-1 overflow-auto px-6 py-5">
-			<RemoteDesktopWorkspace client={client} initialSession={initialSession} />
+			<RemoteDesktopWorkspace {client} {initialSession} />
 		</div>
 	</div>
 </MovableWindow>

--- a/tenvy-server/src/routes/api/agents/[id]/audio/devices/refresh/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/audio/devices/refresh/+server.ts
@@ -2,14 +2,17 @@ import { randomUUID } from 'crypto';
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { registry, RegistryError } from '$lib/server/rat/store';
+import { requireOperator } from '$lib/server/authorization';
 import { audioBridgeManager } from '$lib/server/rat/audio';
 import type { AudioControlCommandPayload } from '$lib/types/audio';
 
-export const POST: RequestHandler = ({ params }) => {
+export const POST: RequestHandler = ({ params, locals }) => {
 	const id = params.id;
 	if (!id) {
 		throw error(400, 'Missing agent identifier');
 	}
+
+	const user = requireOperator(locals.user);
 
 	const requestId = randomUUID();
 	audioBridgeManager.markInventoryRequest(id, requestId);
@@ -20,7 +23,7 @@ export const POST: RequestHandler = ({ params }) => {
 	};
 
 	try {
-		registry.queueCommand(id, { name: 'audio-control', payload });
+		registry.queueCommand(id, { name: 'audio-control', payload }, { operatorId: user.id });
 	} catch (err) {
 		if (err instanceof RegistryError) {
 			throw error(err.status, err.message);

--- a/tenvy-server/src/routes/api/agents/[id]/audio/playback/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/audio/playback/+server.ts
@@ -2,6 +2,7 @@ import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { audioBridgeManager } from '$lib/server/rat/audio';
 import { registry, RegistryError } from '$lib/server/rat/store';
+import { requireOperator } from '$lib/server/authorization';
 import type { AudioControlCommandPayload } from '$lib/types/audio';
 
 interface PlaybackRequest {
@@ -44,11 +45,13 @@ function normalize(body: Record<string, unknown>): PlaybackRequest {
 	return request;
 }
 
-export const POST: RequestHandler = async ({ params, request }) => {
+export const POST: RequestHandler = async ({ params, request, locals }) => {
 	const id = params.id;
 	if (!id) {
 		throw error(400, 'Missing agent identifier');
 	}
+
+	const user = requireOperator(locals.user);
 
 	let payload: Record<string, unknown> = {};
 	try {
@@ -110,7 +113,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 	}
 
 	try {
-		registry.queueCommand(id, { name: 'audio-control', payload: command });
+		registry.queueCommand(id, { name: 'audio-control', payload: command }, { operatorId: user.id });
 	} catch (err) {
 		if (err instanceof RegistryError) {
 			throw error(err.status, err.message);

--- a/tenvy-server/src/routes/api/agents/[id]/audit/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/audit/+server.ts
@@ -1,0 +1,38 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { db } from '$lib/server/db';
+import * as table from '$lib/server/db/schema';
+import { desc, eq } from 'drizzle-orm';
+import { requireViewer } from '$lib/server/authorization';
+
+export const GET: RequestHandler = ({ params, locals }) => {
+	const id = params.id;
+	if (!id) {
+		throw error(400, 'Missing agent identifier');
+	}
+
+	requireViewer(locals.user);
+
+	const events = db
+		.select({
+			id: table.auditEvent.id,
+			commandId: table.auditEvent.commandId,
+			commandName: table.auditEvent.commandName,
+			operatorId: table.auditEvent.operatorId,
+			payloadHash: table.auditEvent.payloadHash,
+			queuedAt: table.auditEvent.queuedAt,
+			executedAt: table.auditEvent.executedAt,
+			result: table.auditEvent.result
+		})
+		.from(table.auditEvent)
+		.where(eq(table.auditEvent.agentId, id))
+		.orderBy(desc(table.auditEvent.queuedAt))
+		.all()
+		.map((event) => ({
+			...event,
+			queuedAt: event.queuedAt instanceof Date ? event.queuedAt.toISOString() : null,
+			executedAt: event.executedAt instanceof Date ? event.executedAt.toISOString() : null
+		}));
+
+	return json({ events });
+};

--- a/tenvy-server/src/routes/api/agents/[id]/session-token/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/session-token/+server.ts
@@ -3,31 +3,31 @@ import type { RequestHandler } from './$types';
 import { registry, RegistryError } from '$lib/server/rat/store';
 
 function extractBearerToken(headerValue: string | null): string | null {
-        if (!headerValue) {
-                return null;
-        }
-        const match = /^Bearer\s+(?<token>.+)$/i.exec(headerValue.trim());
-        return match?.groups?.token?.trim() ?? null;
+	if (!headerValue) {
+		return null;
+	}
+	const match = /^Bearer\s+(?<token>.+)$/i.exec(headerValue.trim());
+	return match?.groups?.token?.trim() ?? null;
 }
 
 export const POST: RequestHandler = async ({ params, request }) => {
-        const id = params.id;
-        if (!id) {
-                throw error(400, 'Missing agent identifier');
-        }
+	const id = params.id;
+	if (!id) {
+		throw error(400, 'Missing agent identifier');
+	}
 
-        const key = extractBearerToken(request.headers.get('authorization'));
-        if (!key) {
-                throw error(401, 'Missing agent key');
-        }
+	const key = extractBearerToken(request.headers.get('authorization'));
+	if (!key) {
+		throw error(401, 'Missing agent key');
+	}
 
-        try {
-                const response = registry.issueSessionToken(id, key);
-                return json(response);
-        } catch (err) {
-                if (err instanceof RegistryError) {
-                        throw error(err.status, err.message);
-                }
-                throw error(500, 'Failed to issue session token');
-        }
+	try {
+		const response = registry.issueSessionToken(id, key);
+		return json(response);
+	} catch (err) {
+		if (err instanceof RegistryError) {
+			throw error(err.status, err.message);
+		}
+		throw error(500, 'Failed to issue session token');
+	}
 };

--- a/tenvy-server/src/routes/api/agents/[id]/session/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/session/+server.ts
@@ -2,8 +2,8 @@ import { error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { registry, RegistryError } from '$lib/server/rat/store';
 import {
-        COMMAND_STREAM_SUBPROTOCOL,
-        AGENT_SESSION_TOKEN_HEADER
+	COMMAND_STREAM_SUBPROTOCOL,
+	AGENT_SESSION_TOKEN_HEADER
 } from '../../../../../../../shared/constants/protocol';
 
 function parseSubprotocolHeader(headerValue: string | null): string[] {
@@ -17,24 +17,24 @@ function parseSubprotocolHeader(headerValue: string | null): string[] {
 }
 
 export const GET: RequestHandler = ({ request, params, getClientAddress }) => {
-        if (request.headers.get('upgrade')?.toLowerCase() !== 'websocket') {
-                throw error(400, 'Expected WebSocket upgrade request');
-        }
+	if (request.headers.get('upgrade')?.toLowerCase() !== 'websocket') {
+		throw error(400, 'Expected WebSocket upgrade request');
+	}
 
-        const url = new URL(request.url);
-        if (url.protocol !== 'https:') {
-                throw error(400, 'Secure transport required');
-        }
+	const url = new URL(request.url);
+	if (url.protocol !== 'https:') {
+		throw error(400, 'Secure transport required');
+	}
 
-        const id = params.id;
-        if (!id) {
-                throw error(400, 'Missing agent identifier');
-        }
+	const id = params.id;
+	if (!id) {
+		throw error(400, 'Missing agent identifier');
+	}
 
-        const token = request.headers.get(AGENT_SESSION_TOKEN_HEADER);
-        if (!token) {
-                throw error(401, 'Missing session token');
-        }
+	const token = request.headers.get(AGENT_SESSION_TOKEN_HEADER);
+	if (!token) {
+		throw error(401, 'Missing session token');
+	}
 
 	const requestedProtocols = parseSubprotocolHeader(request.headers.get('sec-websocket-protocol'));
 	if (!requestedProtocols.includes(COMMAND_STREAM_SUBPROTOCOL)) {
@@ -53,8 +53,8 @@ export const GET: RequestHandler = ({ request, params, getClientAddress }) => {
 
 	const { 0: client, 1: serverSocket } = new pairFactory();
 
-        try {
-                registry.attachSession(id, token, serverSocket, { remoteAddress: getClientAddress() });
+	try {
+		registry.attachSession(id, token, serverSocket, { remoteAddress: getClientAddress() });
 	} catch (err) {
 		serverSocket.close(1008, 'Session rejected');
 		if (err instanceof RegistryError) {

--- a/tenvy-server/src/routes/api/auth/webauthn/login/verify/+server.ts
+++ b/tenvy-server/src/routes/api/auth/webauthn/login/verify/+server.ts
@@ -109,6 +109,7 @@ export const POST: RequestHandler = async (event) => {
 	event.locals.session = session;
 	event.locals.user = {
 		id: record.user.id,
+		role: record.user.role as auth.UserRole,
 		passkeyRegistered: Boolean(record.user.passkeyRegistered),
 		voucherId: record.user.voucherId,
 		voucherActive,

--- a/tenvy-server/src/routes/api/build/normalizer.ts
+++ b/tenvy-server/src/routes/api/build/normalizer.ts
@@ -121,9 +121,9 @@ function sanitizePositiveInteger(
 }
 
 function sanitizeMutexName(value: string | undefined): string {
-        if (!value) {
-                return '';
-        }
+	if (!value) {
+		return '';
+	}
 	const trimmed = value.trim();
 	if (!trimmed) {
 		return '';
@@ -132,12 +132,14 @@ function sanitizeMutexName(value: string | undefined): string {
 	return sanitized.slice(0, maxMutexLength);
 }
 
-function normalizeAudioStreaming(value: BuildRequest['audio'] | undefined): NormalizedAudioStreaming {
-        if (!value || value.streaming === undefined) {
-                return 'unset';
-        }
+function normalizeAudioStreaming(
+	value: BuildRequest['audio'] | undefined
+): NormalizedAudioStreaming {
+	if (!value || value.streaming === undefined) {
+		return 'unset';
+	}
 
-        return value.streaming ? 'enabled' : 'disabled';
+	return value.streaming ? 'enabled' : 'disabled';
 }
 
 type VersionParts = { Major: number; Minor: number; Patch: number; Build: number };
@@ -199,10 +201,10 @@ export function parseVersionParts(value: string | undefined): VersionParts | nul
 }
 
 export type NormalizedBuildRequest = {
-        host: string;
-        port: string;
-        targetOS: TargetOS;
-        targetArch: TargetArch;
+	host: string;
+	port: string;
+	targetOS: TargetOS;
+	targetArch: TargetArch;
 	outputExtension: string;
 	outputFilename: string;
 	installationPath: string;
@@ -214,11 +216,11 @@ export type NormalizedBuildRequest = {
 	forceAdmin: boolean;
 	pollIntervalMs: string | null;
 	maxBackoffMs: string | null;
-        shellTimeoutSeconds: string | null;
-        fileIcon: BuildRequest['fileIcon'] | null | undefined;
-        fileInformation: BuildRequest['fileInformation'] | null | undefined;
-        audio: { streaming: NormalizedAudioStreaming };
-        raw: BuildRequest;
+	shellTimeoutSeconds: string | null;
+	fileIcon: BuildRequest['fileIcon'] | null | undefined;
+	fileInformation: BuildRequest['fileInformation'] | null | undefined;
+	audio: { streaming: NormalizedAudioStreaming };
+	raw: BuildRequest;
 };
 
 function formatZodError(err: ZodError): string {
@@ -289,11 +291,11 @@ export function normalizeBuildRequestPayload(body: unknown): NormalizedBuildRequ
 		'Shell timeout'
 	);
 
-        return {
-                host,
-                port,
-                targetOS,
-                targetArch,
+	return {
+		host,
+		port,
+		targetOS,
+		targetArch,
 		outputExtension,
 		outputFilename,
 		installationPath,
@@ -305,10 +307,10 @@ export function normalizeBuildRequestPayload(body: unknown): NormalizedBuildRequ
 		forceAdmin,
 		pollIntervalMs,
 		maxBackoffMs,
-                shellTimeoutSeconds,
-                fileIcon: parsed.fileIcon ?? null,
-                fileInformation: parsed.fileInformation ?? null,
-                audio: { streaming: normalizeAudioStreaming(parsed.audio) },
-                raw: parsed
-        } satisfies NormalizedBuildRequest;
+		shellTimeoutSeconds,
+		fileIcon: parsed.fileIcon ?? null,
+		fileInformation: parsed.fileInformation ?? null,
+		audio: { streaming: normalizeAudioStreaming(parsed.audio) },
+		raw: parsed
+	} satisfies NormalizedBuildRequest;
 }

--- a/tenvy-server/src/routes/redeem/+page.server.ts
+++ b/tenvy-server/src/routes/redeem/+page.server.ts
@@ -126,7 +126,8 @@ export const actions: Actions = {
 					.values({
 						id: userId,
 						voucherId: voucher.id,
-						createdAt: now
+						createdAt: now,
+						role: 'operator'
 					})
 					.run();
 
@@ -150,6 +151,7 @@ export const actions: Actions = {
 
 		const sanitizedUser = {
 			id: userId,
+			role: 'operator' as const,
 			passkeyRegistered: false,
 			voucherId: voucherRecord.id,
 			voucherActive: true,


### PR DESCRIPTION
## Summary
- add role-aware auth helpers and extend schema with user roles and audit events
- guard agent APIs with viewer/operator checks and persist audit log entries for queued/executed commands
- expose an agent audit trail view in the UI backed by a new audit API endpoint

## Testing
- bun x vitest run src/lib/server/rat/store.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f528566db8832b9fe76eff33dd4c3b