### PR TITLE
Integrate plugin telemetry pipeline

### DIFF
--- a/docs/modules-plugins-review.md
+++ b/docs/modules-plugins-review.md
@@ -36,6 +36,7 @@ This document reviews the current state of the built-in modules compiled into th
 ## Next Steps
 
 - Prototype the module registry and migrate an existing module (e.g., clipboard) to validate the interface.
-- Design the shared manifest schema and update the controller to read manifests from disk during development.
-- Define signing and trust requirements, and add verification scaffolding to the agent download path.
-- Expand the controller UI to surface manifest-driven compatibility signals and delivery policy outcomes.
+- ✅ Shared plugin manifest schema with mirrored Go validation keeps manifests authoritative across stacks.
+- ✅ Signing and compatibility checks run during agent sync, blocking unapproved binaries and logging audit events.
+- ✅ The controller UI reads manifests from disk, surfaces approval workflows, and displays live per-client telemetry.
+- ✅ Document the plugin lifecycle (packaging, approvals, rollback) for operators.

--- a/docs/plugin-manifest.md
+++ b/docs/plugin-manifest.md
@@ -1,0 +1,71 @@
+# Plugin Manifest & Telemetry Guide
+
+This document describes the shared plugin manifest contract, validation rules, and the rollout telemetry lifecycle that now drives the controller UI and Go agent.
+
+## Manifest schema
+
+Plugin manifests live under `resources/plugin-manifests/` (configurable via `TENVY_PLUGIN_MANIFEST_DIR`). Each manifest must satisfy the schema exported from `shared/types/plugin-manifest.ts` and validated both by the Svelte controller (`validatePluginManifest`) and the Go agent (`shared/pluginmanifest`).
+
+Key fields:
+
+| Field | Description |
+| --- | --- |
+| `id` | Unique plugin identifier (lowercase slug). |
+| `name`, `description`, `author`, `homepage` | Human metadata surfaced in the UI. |
+| `version` | Semantic version string validated on both stacks. |
+| `entry` | Entry point inside the extracted archive. |
+| `capabilities` | Capability descriptors linked to agent modules. Unknown module IDs are rejected. |
+| `requirements.platforms` / `.architectures` | Accept only `windows`, `linux`, `macos` and `x86_64`, `arm64`. |
+| `requirements.minAgentVersion` / `maxAgentVersion` | Optional semver range enforced during telemetry ingestion. |
+| `distribution.defaultMode` | `manual` or `automatic`. |
+| `distribution.signature` | Signing requirement: `sha256` or `ed25519` mandates `package.hash`, ed25519 also requires `publicKey`. |
+| `package` | Artifact metadata (`artifact`, `sizeBytes`, `hash`). |
+
+Any schema violation is logged and the manifest is skipped. Signed manifests without a `package.hash` are rejected up-front.
+
+## Runtime validation
+
+The Go agent uses the internal plugin manager to compute telemetry snapshots. During each sync it:
+
+1. Loads manifests from disk and validates them using the shared Go validator.
+2. Computes artifact SHA-256 and compares it against the manifest hash when signatures are required.
+3. Emits telemetry payloads (`PluginSyncPayload`) describing version, hash, install status, and timestamps.
+
+On the controller, `PluginTelemetryStore.syncAgent` enforces the same contract:
+
+- Unknown modules, incompatible platforms/architectures, or out-of-range versions mark the install as `blocked`.
+- Unapproved plugins (runtime `approvalStatus !== 'approved'`) are blocked regardless of reported status.
+- Hash mismatches or missing hashes for signed plugins raise audit events in `audit_event`.
+
+Aggregated metrics (`installations`, `lastDeployedAt`, `lastCheckedAt`) are persisted to the `plugin` table so dashboards and API responses stay in sync.
+
+## Telemetry UI & controls
+
+The client detail view (`/(app)/clients/[clientId]/plugins`) now renders live telemetry:
+
+- Status badges for global state and per-agent installs.
+- Expected vs. observed hashes with tooltips.
+- Delivery policy summary (default mode, auto-update flag).
+- Enable/disable toggle per client (persisted in `plugin_installation.enabled`).
+- Error and audit signals when installs are blocked.
+
+The API surface:
+
+- `GET /api/clients/:id/plugins` returns `ClientPlugin` views combining manifest, runtime, and telemetry data.
+- `PATCH /api/clients/:id/plugins/:pluginId` toggles per-client enablement while preserving audit history.
+
+## Rollout & rollback
+
+1. **Rollout**
+   - Publish a manifest with signature metadata and drop the signed binary in the agent's plugin directory.
+   - On next sync, the agent reports telemetry. Approved plugins transition to `installed`; mismatches surface as `blocked` with audit trails.
+   - Operators can enable or disable delivery per client via the new UI controls.
+
+2. **Rollback**
+   - Set the plugin's `approvalStatus` to `rejected` using `/api/plugins/:id` to immediately block further installs.
+   - Use the client telemetry view to disable affected agents. Blocked installs log audit entries for incident response.
+
+3. **Recovery**
+   - Publish a corrected manifest/binary pair (same ID, higher version). Telemetry automatically reconciles once hashes align.
+
+Refer to `shared/types/plugin-manifest.ts` and `shared/pluginmanifest/manifest.go` for the canonical schema definitions.

--- a/shared/pluginmanifest/go.mod
+++ b/shared/pluginmanifest/go.mod
@@ -1,0 +1,3 @@
+module github.com/rootbay/tenvy-client/shared/pluginmanifest
+
+go 1.22

--- a/shared/types/messages.ts
+++ b/shared/types/messages.ts
@@ -1,5 +1,6 @@
 import type { AgentConfig } from "./config";
 import type { AgentMetrics, AgentStatus } from "./agent";
+import type { PluginSyncPayload } from "./plugin-manifest";
 import type {
   RemoteDesktopCommandPayload,
   RemoteDesktopInputBurst,
@@ -103,6 +104,7 @@ export interface AgentSyncRequest {
   timestamp: string;
   metrics?: AgentMetrics;
   results?: CommandResult[];
+  plugins?: PluginSyncPayload;
 }
 
 export interface AgentSyncResponse {

--- a/shared/types/plugin-manifest.ts
+++ b/shared/types/plugin-manifest.ts
@@ -1,8 +1,38 @@
 import { agentModuleIds } from "../modules/index.js";
 
-export type PluginDeliveryMode = "manual" | "automatic";
+export const pluginDeliveryModes = ["manual", "automatic"] as const;
+export type PluginDeliveryMode = (typeof pluginDeliveryModes)[number];
 
-export type PluginSignatureType = "none" | "sha256" | "ed25519";
+export const pluginSignatureTypes = ["none", "sha256", "ed25519"] as const;
+export type PluginSignatureType = (typeof pluginSignatureTypes)[number];
+
+export const pluginPlatforms = ["windows", "linux", "macos"] as const;
+export type PluginPlatform = (typeof pluginPlatforms)[number];
+
+export const pluginArchitectures = ["x86_64", "arm64"] as const;
+export type PluginArchitecture = (typeof pluginArchitectures)[number];
+
+export const pluginInstallStatuses = [
+  "pending",
+  "installing",
+  "installed",
+  "failed",
+  "blocked",
+] as const;
+export type PluginInstallStatus = (typeof pluginInstallStatuses)[number];
+
+export const pluginApprovalStatuses = [
+  "pending",
+  "approved",
+  "rejected",
+] as const;
+export type PluginApprovalStatus = (typeof pluginApprovalStatuses)[number];
+
+const SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
+
+const hasModule = (moduleId: string | undefined | null): boolean =>
+  moduleId != null && agentModuleIds.has(moduleId.trim());
 
 export interface PluginCapability {
   name: string;
@@ -14,8 +44,8 @@ export interface PluginRequirements {
   minAgentVersion?: string;
   maxAgentVersion?: string;
   minClientVersion?: string;
-  platforms?: string[];
-  architectures?: string[];
+  platforms?: PluginPlatform[];
+  architectures?: PluginArchitecture[];
   requiredModules?: string[];
 }
 
@@ -53,64 +83,92 @@ export interface PluginManifest {
   package: PluginPackageDescriptor;
 }
 
+export interface PluginInstallationTelemetry {
+  pluginId: string;
+  version: string;
+  status: PluginInstallStatus;
+  hash?: string;
+  lastDeployedAt?: string | null;
+  lastCheckedAt?: string | null;
+  error?: string;
+}
+
+export interface PluginSyncPayload {
+  installations: PluginInstallationTelemetry[];
+}
+
+const ensureArray = <T>(value: ReadonlyArray<T> | undefined | null): T[] =>
+  Array.isArray(value) ? [...value] : [];
+
+const isEmpty = (value: string | undefined | null): boolean =>
+  value == null || value.trim() === "";
+
+const validateSemver = (value: string | undefined | null): boolean =>
+  !value || SEMVER_PATTERN.test(value.trim());
+
 export function validatePluginManifest(manifest: PluginManifest): string[] {
   const problems: string[] = [];
 
-  const hasModule = (moduleId: string | undefined | null): boolean =>
-    moduleId != null && agentModuleIds.has(moduleId.trim());
+  if (isEmpty(manifest.id)) problems.push("missing id");
+  if (isEmpty(manifest.name)) problems.push("missing name");
+  if (isEmpty(manifest.version)) {
+    problems.push("missing version");
+  } else if (!validateSemver(manifest.version)) {
+    problems.push(`invalid semantic version: ${manifest.version}`);
+  }
+  if (isEmpty(manifest.entry)) problems.push("missing entry");
 
-  if (!manifest.id?.trim()) problems.push("missing id");
-  if (!manifest.name?.trim()) problems.push("missing name");
-  if (!manifest.version?.trim()) problems.push("missing version");
-  if (!manifest.entry?.trim()) problems.push("missing entry");
-  if (!manifest.package?.artifact?.trim())
+  if (!manifest.package || isEmpty(manifest.package.artifact)) {
     problems.push("missing package artifact");
+  }
 
   const mode = manifest.distribution?.defaultMode;
-  if (mode !== "manual" && mode !== "automatic") {
+  if (!pluginDeliveryModes.includes(mode as PluginDeliveryMode)) {
     problems.push(`unsupported delivery mode: ${mode ?? "undefined"}`);
   }
 
   const signature = manifest.distribution?.signature;
-  if (signature) {
-    switch (signature.type) {
-      case "none":
-        break;
-      case "sha256":
-        if (!signature.hash?.trim()) {
-          problems.push("sha256 signature requires hash");
-        }
-        break;
-      case "ed25519":
-        if (!signature.hash?.trim()) {
-          problems.push("ed25519 signature requires hash");
-        }
-        if (!signature.publicKey?.trim()) {
-          problems.push("ed25519 signature requires publicKey");
-        }
-        break;
-      default:
-        problems.push(`unsupported signature type: ${signature.type}`);
-    }
-  } else {
+  if (!signature) {
     problems.push("missing signature");
+  } else if (!pluginSignatureTypes.includes(signature.type)) {
+    problems.push(`unsupported signature type: ${signature.type}`);
+  } else {
+    if (signature.type === "sha256" && isEmpty(signature.hash)) {
+      problems.push("sha256 signature requires hash");
+    }
+    if (signature.type === "ed25519") {
+      if (isEmpty(signature.hash)) {
+        problems.push("ed25519 signature requires hash");
+      }
+      if (isEmpty(signature.publicKey)) {
+        problems.push("ed25519 signature requires publicKey");
+      }
+    }
   }
 
-  manifest.requirements?.requiredModules?.forEach((moduleId, index) => {
-    if (!moduleId?.trim()) {
-      problems.push(`required module ${index} is empty`);
-      return;
+  if (manifest.distribution?.signature?.type !== "none") {
+    if (isEmpty(manifest.package?.hash)) {
+      problems.push("signed packages must include a hash");
     }
-    if (!hasModule(moduleId)) {
-      problems.push(`required module ${moduleId} is not registered`);
-    }
-  });
+  }
 
-  manifest.capabilities?.forEach((capability, index) => {
-    if (!capability.name?.trim()) {
+  ensureArray(manifest.requirements?.requiredModules).forEach(
+    (moduleId, index) => {
+      if (isEmpty(moduleId)) {
+        problems.push(`required module ${index} is empty`);
+        return;
+      }
+      if (!hasModule(moduleId)) {
+        problems.push(`required module ${moduleId} is not registered`);
+      }
+    },
+  );
+
+  ensureArray(manifest.capabilities).forEach((capability, index) => {
+    if (isEmpty(capability.name)) {
       problems.push(`capability ${index} is missing name`);
     }
-    if (!capability.module?.trim()) {
+    if (isEmpty(capability.module)) {
       problems.push(
         `capability ${capability.name ?? index} is missing module reference`,
       );
@@ -122,6 +180,36 @@ export function validatePluginManifest(manifest: PluginManifest): string[] {
       );
     }
   });
+
+  ensureArray(manifest.requirements?.platforms).forEach((platform, index) => {
+    if (!pluginPlatforms.includes(platform as PluginPlatform)) {
+      problems.push(`unsupported platform ${platform ?? index}`);
+    }
+  });
+
+  ensureArray(manifest.requirements?.architectures).forEach(
+    (architecture, index) => {
+      if (!pluginArchitectures.includes(architecture as PluginArchitecture)) {
+        problems.push(`unsupported architecture ${architecture ?? index}`);
+      }
+    },
+  );
+
+  if (!validateSemver(manifest.requirements?.minAgentVersion)) {
+    problems.push(
+      `invalid minAgentVersion: ${manifest.requirements?.minAgentVersion}`,
+    );
+  }
+  if (!validateSemver(manifest.requirements?.maxAgentVersion)) {
+    problems.push(
+      `invalid maxAgentVersion: ${manifest.requirements?.maxAgentVersion}`,
+    );
+  }
+  if (!validateSemver(manifest.requirements?.minClientVersion)) {
+    problems.push(
+      `invalid minClientVersion: ${manifest.requirements?.minClientVersion}`,
+    );
+  }
 
   return problems;
 }

--- a/tenvy-client/go.mod
+++ b/tenvy-client/go.mod
@@ -4,21 +4,24 @@ go 1.22
 
 require (
 	github.com/cespare/xxhash/v2 v2.2.0
+	github.com/gen2brain/malgo v0.11.24
+	github.com/jezek/xgb v1.1.1
 	github.com/kbinani/screenshot v0.0.0-20250624051815-089614a94018
 	github.com/lxn/win v0.0.0-20210218163916-a377121e959e
+	github.com/pion/webrtc/v3 v3.2.30
+	github.com/rootbay/tenvy-client/shared/pluginmanifest v0.0.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	golang.org/x/image v0.18.0
 	golang.org/x/sys v0.26.0
+	nhooyr.io/websocket v1.8.10
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/gen2brain/malgo v0.11.24 // indirect
 	github.com/gen2brain/shm v0.1.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/google/uuid v1.3.1 // indirect
-	github.com/jezek/xgb v1.1.1 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/pion/datachannel v1.5.5 // indirect
 	github.com/pion/dtls/v2 v2.2.7 // indirect
@@ -35,7 +38,6 @@ require (
 	github.com/pion/stun v0.6.1 // indirect
 	github.com/pion/transport/v2 v2.2.3 // indirect
 	github.com/pion/turn/v2 v2.1.3 // indirect
-	github.com/pion/webrtc/v3 v3.2.30 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -46,5 +48,6 @@ require (
 	golang.org/x/crypto v0.18.0 // indirect
 	golang.org/x/net v0.20.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	nhooyr.io/websocket v1.8.10 // indirect
 )
+
+replace github.com/rootbay/tenvy-client/shared/pluginmanifest => ../shared/pluginmanifest

--- a/tenvy-client/go.sum
+++ b/tenvy-client/go.sum
@@ -37,8 +37,10 @@ github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
 github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
 github.com/kbinani/screenshot v0.0.0-20250624051815-089614a94018 h1:NQYgMY188uWrS+E/7xMVpydsI48PMHcc7SfR4OxkDF4=
 github.com/kbinani/screenshot v0.0.0-20250624051815-089614a94018/go.mod h1:Pmpz2BLf55auQZ67u3rvyI2vAQvNetkK/4zYUmpauZQ=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
@@ -88,6 +90,7 @@ github.com/pion/transport/v2 v2.2.1/go.mod h1:cXXWavvCnFF6McHTft3DWS9iic2Mftcz1A
 github.com/pion/transport/v2 v2.2.2/go.mod h1:OJg3ojoBJopjEeECq2yJdXH9YVrUJ1uQ++NjXLOUorc=
 github.com/pion/transport/v2 v2.2.3 h1:XcOE3/x41HOSKbl1BfyY1TF1dERx7lVvlMCbXU7kfvA=
 github.com/pion/transport/v2 v2.2.3/go.mod h1:q2U/tf9FEfnSBGSW6w5Qp5PFWRLRj3NjLhCCgpRK4p0=
+github.com/pion/transport/v3 v3.0.1 h1:gDTlPJwROfSfz6QfSi0ZmeCSkFcnWWiiR9ES0ouANiM=
 github.com/pion/transport/v3 v3.0.1/go.mod h1:UY7kiITrlMv7/IKgd5eTUcaahZx5oUN3l9SzK5f5xE0=
 github.com/pion/turn/v2 v2.1.3 h1:pYxTVWG2gpC97opdRc5IGsQ1lJ9O/IlNhkzj7MMrGAA=
 github.com/pion/turn/v2 v2.1.3/go.mod h1:huEpByKKHix2/b9kmTAM3YoX6MKP+/D//0ClgUYR2fY=
@@ -224,6 +227,7 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/tenvy-client/internal/agent/agent.go
+++ b/tenvy-client/internal/agent/agent.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	notes "github.com/rootbay/tenvy-client/internal/modules/notes"
+	"github.com/rootbay/tenvy-client/internal/plugins"
 	"github.com/rootbay/tenvy-client/internal/protocol"
+	manifest "github.com/rootbay/tenvy-client/shared/pluginmanifest"
 )
 
 type Agent struct {
@@ -35,6 +37,7 @@ type Agent struct {
 	remoteDesktopInputQueue      chan remoteDesktopInputTask
 	remoteDesktopInputStopCh     chan struct{}
 	remoteDesktopInputStopped    atomic.Bool
+	plugins                      *plugins.Manager
 }
 
 func (a *Agent) AgentID() string {
@@ -47,4 +50,15 @@ func (a *Agent) AgentMetadata() protocol.AgentMetadata {
 
 func (a *Agent) AgentStartTime() time.Time {
 	return a.startTime
+}
+
+func (a *Agent) pluginSyncPayload() *manifest.SyncPayload {
+	if a.plugins == nil {
+		return nil
+	}
+	payload := a.plugins.Snapshot()
+	if payload == nil || len(payload.Installations) == 0 {
+		return nil
+	}
+	return payload
 }

--- a/tenvy-client/internal/agent/lifecycle.go
+++ b/tenvy-client/internal/agent/lifecycle.go
@@ -143,6 +143,9 @@ func (a *Agent) performSync(ctx context.Context, status string, results []protoc
 		Timestamp: timestampNow(),
 		Metrics:   a.collectMetrics(),
 	}
+	if plugins := a.pluginSyncPayload(); plugins != nil {
+		request.Plugins = plugins
+	}
 	if len(results) > 0 {
 		request.Results = results
 	}

--- a/tenvy-client/internal/agent/plugins.go
+++ b/tenvy-client/internal/agent/plugins.go
@@ -1,0 +1,26 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func defaultPluginRoot(pref BuildPreferences) string {
+	installPath := strings.TrimSpace(pref.InstallPath)
+	if installPath != "" {
+		cleaned := filepath.Clean(installPath)
+		info, err := os.Stat(cleaned)
+		if err == nil && info.IsDir() {
+			return filepath.Join(cleaned, "plugins")
+		}
+		return filepath.Join(filepath.Dir(cleaned), "plugins")
+	}
+
+	if exe, err := os.Executable(); err == nil {
+		base := filepath.Dir(exe)
+		return filepath.Join(base, "plugins")
+	}
+
+	return filepath.Join(os.TempDir(), "tenvy", "plugins")
+}

--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	notes "github.com/rootbay/tenvy-client/internal/modules/notes"
+	"github.com/rootbay/tenvy-client/internal/plugins"
 	"github.com/rootbay/tenvy-client/internal/protocol"
 )
 
@@ -73,6 +74,12 @@ func Run(ctx context.Context, opts RuntimeOptions) error {
 		preferences:    opts.Preferences,
 		buildVersion:   opts.BuildVersion,
 		timing:         opts.TimingOverride,
+	}
+
+	if manager, err := plugins.NewManager(defaultPluginRoot(opts.Preferences), opts.Logger); err != nil {
+		opts.Logger.Printf("plugin telemetry disabled: %v", err)
+	} else {
+		agent.plugins = manager
 	}
 
 	modules := newDefaultModuleRegistry()

--- a/tenvy-client/internal/plugins/manager.go
+++ b/tenvy-client/internal/plugins/manager.go
@@ -1,0 +1,150 @@
+package plugins
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	manifest "github.com/rootbay/tenvy-client/shared/pluginmanifest"
+)
+
+const manifestFileName = "manifest.json"
+
+// Manager inspects local plugin artifacts and produces telemetry snapshots that
+// can be forwarded to the controller.
+type Manager struct {
+	root   string
+	logger *log.Logger
+}
+
+// NewManager creates a plugin manager rooted at the provided directory.
+func NewManager(root string, logger *log.Logger) (*Manager, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil, errors.New("plugin root directory not provided")
+	}
+	if logger == nil {
+		logger = log.New(os.Stderr, "", log.LstdFlags)
+	}
+	return &Manager{root: root, logger: logger}, nil
+}
+
+// Snapshot walks the plugin root and returns the current installation
+// telemetry. Errors are logged and omitted from the resulting payload.
+func (m *Manager) Snapshot() *manifest.SyncPayload {
+	entries, err := os.ReadDir(m.root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		m.logger.Printf("plugin scan failed: %v", err)
+		return nil
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	payload := manifest.SyncPayload{Installations: make([]manifest.InstallationTelemetry, 0, len(entries))}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pluginDir := filepath.Join(m.root, entry.Name())
+		manifestPath := filepath.Join(pluginDir, manifestFileName)
+
+		manifestData, err := os.ReadFile(manifestPath)
+		if err != nil {
+			if !errors.Is(err, fs.ErrNotExist) {
+				m.logger.Printf("plugin %s missing manifest: %v", entry.Name(), err)
+			}
+			continue
+		}
+
+		var mf manifest.Manifest
+		if err := json.Unmarshal(manifestData, &mf); err != nil {
+			m.logger.Printf("plugin %s manifest parse failed: %v", entry.Name(), err)
+			continue
+		}
+		if err := mf.Validate(); err != nil {
+			m.logger.Printf("plugin %s manifest invalid: %v", mf.ID, err)
+			continue
+		}
+
+		installation := manifest.InstallationTelemetry{
+			PluginID: mf.ID,
+			Version:  mf.Version,
+			Status:   manifest.InstallPending,
+		}
+
+		artifactRel := filepath.Clean(mf.Package.Artifact)
+		if strings.HasPrefix(artifactRel, "..") {
+			installation.Status = manifest.InstallFailed
+			installation.Error = "artifact path escapes plugin directory"
+			installation.LastCheckedAt = &now
+			payload.Installations = append(payload.Installations, installation)
+			continue
+		}
+
+		artifactPath := filepath.Join(pluginDir, artifactRel)
+		info, statErr := os.Stat(artifactPath)
+		switch {
+		case statErr == nil && !info.IsDir():
+			hash, hashErr := fileHash(artifactPath)
+			if hashErr != nil {
+				installation.Status = manifest.InstallFailed
+				installation.Error = fmt.Sprintf("hash: %v", hashErr)
+			} else {
+				installation.Hash = hash
+				if mf.Package.Hash != "" && !strings.EqualFold(mf.Package.Hash, hash) {
+					installation.Status = manifest.InstallFailed
+					installation.Error = "hash mismatch"
+				} else {
+					installation.Status = manifest.InstallInstalled
+					ts := info.ModTime().UTC().Format(time.RFC3339Nano)
+					installation.LastDeployedAt = &ts
+				}
+			}
+		case errors.Is(statErr, fs.ErrNotExist):
+			installation.Status = manifest.InstallPending
+			installation.Error = "artifact missing"
+		case statErr != nil:
+			installation.Status = manifest.InstallFailed
+			installation.Error = statErr.Error()
+		default:
+			installation.Status = manifest.InstallFailed
+			installation.Error = "artifact is a directory"
+		}
+
+		installation.LastCheckedAt = &now
+		payload.Installations = append(payload.Installations, installation)
+	}
+
+	if len(payload.Installations) == 0 {
+		return nil
+	}
+
+	return &payload
+}
+
+func fileHash(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return "", err
+	}
+	sum := hasher.Sum(nil)
+	return hex.EncodeToString(sum), nil
+}

--- a/tenvy-client/internal/protocol/types.go
+++ b/tenvy-client/internal/protocol/types.go
@@ -3,6 +3,8 @@ package protocol
 import (
 	"encoding/json"
 	"errors"
+
+	manifest "github.com/rootbay/tenvy-client/shared/pluginmanifest"
 )
 
 const (
@@ -216,10 +218,11 @@ type AgentRegistrationResponse struct {
 }
 
 type AgentSyncRequest struct {
-	Status    string          `json:"status"`
-	Timestamp string          `json:"timestamp"`
-	Metrics   *AgentMetrics   `json:"metrics,omitempty"`
-	Results   []CommandResult `json:"results,omitempty"`
+	Status    string                `json:"status"`
+	Timestamp string                `json:"timestamp"`
+	Metrics   *AgentMetrics         `json:"metrics,omitempty"`
+	Results   []CommandResult       `json:"results,omitempty"`
+	Plugins   *manifest.SyncPayload `json:"plugins,omitempty"`
 }
 
 type AgentSyncResponse struct {

--- a/tenvy-server/src/lib/data/client-plugin-view.ts
+++ b/tenvy-server/src/lib/data/client-plugin-view.ts
@@ -1,0 +1,84 @@
+import type { PluginManifest } from '../../../../shared/types/plugin-manifest.js';
+import { formatFileSize, formatRelativeTime } from './plugin-view.js';
+import type { Plugin } from './plugins.js';
+import type { AgentPluginRecord } from '$lib/server/plugins/telemetry-store.js';
+
+export type ClientPlugin = {
+	id: string;
+	name: string;
+	description: string;
+	version: string;
+	category: string;
+	approvalStatus: string;
+	approvedAt?: string;
+	globalStatus: string;
+	globalEnabled: boolean;
+	autoUpdate: boolean;
+	size: string;
+	expectedHash?: string;
+	artifact: string;
+	capabilities: string[];
+	requirements: {
+		platforms: string[];
+		architectures: string[];
+		minAgentVersion: string | null;
+		maxAgentVersion: string | null;
+		requiredModules: string[];
+	};
+	distribution: {
+		defaultMode: string;
+		autoUpdate: boolean;
+		signature: PluginManifest['distribution']['signature'];
+	};
+	telemetry: {
+		status: string;
+		enabled: boolean;
+		hash: string | null;
+		error: string | null;
+		lastDeployed: string;
+		lastChecked: string;
+	};
+};
+
+export function buildClientPlugin(
+	manifest: PluginManifest,
+	plugin: Plugin,
+	telemetry: AgentPluginRecord | undefined
+): ClientPlugin {
+	return {
+		id: plugin.id,
+		name: plugin.name,
+		description: plugin.description,
+		version: plugin.version,
+		category: plugin.category,
+		approvalStatus: plugin.approvalStatus,
+		approvedAt: plugin.approvedAt,
+		globalStatus: plugin.status,
+		globalEnabled: plugin.enabled,
+		autoUpdate: plugin.autoUpdate,
+		size: formatFileSize(manifest.package.sizeBytes),
+		expectedHash: manifest.package.hash ?? undefined,
+		artifact: manifest.package.artifact,
+		capabilities: manifest.capabilities?.map((capability) => capability.name) ?? [],
+		requirements: {
+			platforms: manifest.requirements.platforms ?? [],
+			architectures: manifest.requirements.architectures ?? [],
+			minAgentVersion: manifest.requirements.minAgentVersion ?? null,
+			maxAgentVersion: manifest.requirements.maxAgentVersion ?? null,
+			requiredModules: manifest.requirements.requiredModules ?? []
+		},
+		distribution: {
+			defaultMode: manifest.distribution.defaultMode,
+			autoUpdate: manifest.distribution.autoUpdate,
+			signature: manifest.distribution.signature
+		},
+		telemetry: {
+			status: telemetry?.status ?? 'pending',
+			enabled: telemetry?.enabled ?? true,
+			hash: telemetry?.hash ?? null,
+			error: telemetry?.error ?? null,
+			lastDeployed: formatRelativeTime(telemetry?.lastDeployedAt ?? null),
+			lastChecked: formatRelativeTime(telemetry?.lastCheckedAt ?? null)
+		}
+	};
+}

--- a/tenvy-server/src/lib/data/plugin-view.ts
+++ b/tenvy-server/src/lib/data/plugin-view.ts
@@ -47,6 +47,14 @@ export const pluginStatusStyles: Record<PluginStatus, string> = {
 	error: 'border-red-500/60 text-red-500'
 };
 
+export type PluginApprovalStatus = 'pending' | 'approved' | 'rejected';
+
+export const pluginApprovalLabels: Record<PluginApprovalStatus, string> = {
+	pending: 'Pending approval',
+	approved: 'Approved',
+	rejected: 'Rejected'
+};
+
 export type PluginDistributionView = {
 	defaultMode: PluginDeliveryMode;
 	allowManualPush: boolean;
@@ -75,6 +83,8 @@ export type Plugin = {
 	artifact: string;
 	distribution: PluginDistributionView;
 	requiredModules: { id: string; title: string }[];
+	approvalStatus: PluginApprovalStatus;
+	approvedAt?: string;
 };
 
 export type PluginUpdatePayload = {
@@ -89,6 +99,9 @@ export type PluginUpdatePayload = {
 		manualTargets?: number;
 		autoTargets?: number;
 	};
+	approvalStatus?: PluginApprovalStatus;
+	approvedAt?: Date | null;
+	approvalNote?: string | null;
 };
 
 const BYTES_IN_KIB = 1024;

--- a/tenvy-server/src/lib/data/plugins.ts
+++ b/tenvy-server/src/lib/data/plugins.ts
@@ -14,7 +14,8 @@ import {
 	type PluginDeliveryMode,
 	type PluginDistributionView,
 	type PluginStatus,
-	type PluginUpdatePayload
+	type PluginUpdatePayload,
+	type PluginApprovalStatus
 } from './plugin-view.js';
 import {
 	createPluginRuntimeStore,
@@ -55,6 +56,9 @@ export type PluginRepositoryUpdate = PluginUpdatePayload & {
 	};
 	lastDeployedAt?: Date | null;
 	lastCheckedAt?: Date | null;
+	approvalStatus?: PluginApprovalStatus;
+	approvedAt?: Date | null;
+	approvalNote?: string | null;
 };
 
 type PluginRuntimeSnapshot = {
@@ -71,6 +75,9 @@ type PluginRuntimeSnapshot = {
 	lastAutoSyncAt: Date | null;
 	lastDeployedAt: Date | null;
 	lastCheckedAt: Date | null;
+	approvalStatus: PluginApprovalStatus;
+	approvedAt: Date | null;
+	approvalNote: string | null;
 };
 
 const manifestCategory = (manifest: PluginManifest): PluginCategory => {
@@ -110,7 +117,9 @@ const toPluginView = (manifest: PluginManifest, runtime: PluginRuntimeSnapshot):
 		lastManualPush: formatRelativeTime(runtime.lastManualPushAt),
 		lastAutoSync: formatRelativeTime(runtime.lastAutoSyncAt)
 	},
-	requiredModules: mapRequiredModules(manifest)
+	requiredModules: mapRequiredModules(manifest),
+	approvalStatus: runtime.approvalStatus,
+	approvedAt: runtime.approvedAt ? runtime.approvedAt.toISOString() : undefined
 });
 
 const toRuntimePatch = (update: PluginRepositoryUpdate): PluginRuntimePatch => {
@@ -122,6 +131,9 @@ const toRuntimePatch = (update: PluginRepositoryUpdate): PluginRuntimePatch => {
 	if (update.installations !== undefined) patch.installations = update.installations;
 	if (update.lastDeployedAt !== undefined) patch.lastDeployedAt = update.lastDeployedAt;
 	if (update.lastCheckedAt !== undefined) patch.lastCheckedAt = update.lastCheckedAt;
+	if (update.approvalStatus !== undefined) patch.approvalStatus = update.approvalStatus;
+	if (update.approvedAt !== undefined) patch.approvedAt = update.approvedAt;
+	if (update.approvalNote !== undefined) patch.approvalNote = update.approvalNote;
 
 	if (update.distribution) {
 		const { distribution } = update;
@@ -154,7 +166,10 @@ const snapshotFromRow = (row: PluginRuntimeRow): PluginRuntimeSnapshot => ({
 	lastManualPushAt: row.lastManualPushAt ?? null,
 	lastAutoSyncAt: row.lastAutoSyncAt ?? null,
 	lastDeployedAt: row.lastDeployedAt ?? null,
-	lastCheckedAt: row.lastCheckedAt ?? null
+	lastCheckedAt: row.lastCheckedAt ?? null,
+	approvalStatus: row.approvalStatus as PluginApprovalStatus,
+	approvedAt: row.approvedAt ?? null,
+	approvalNote: row.approvalNote ?? null
 });
 
 export const createPluginRepository = (

--- a/tenvy-server/src/lib/server/db/index.ts
+++ b/tenvy-server/src/lib/server/db/index.ts
@@ -79,9 +79,30 @@ CREATE TABLE IF NOT EXISTS plugin (
         last_auto_sync_at INTEGER,
         last_deployed_at INTEGER,
         last_checked_at INTEGER,
+        approval_status TEXT NOT NULL DEFAULT 'pending',
+        approved_at INTEGER,
+        approval_note TEXT,
         created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
         updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
 );
+
+CREATE TABLE IF NOT EXISTS plugin_installation (
+        plugin_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        version TEXT NOT NULL,
+        hash TEXT,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        error TEXT,
+        last_deployed_at INTEGER,
+        last_checked_at INTEGER,
+        created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+        updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+        PRIMARY KEY (plugin_id, agent_id),
+        FOREIGN KEY (plugin_id) REFERENCES plugin(id) ON DELETE CASCADE,
+        FOREIGN KEY (agent_id) REFERENCES agent(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS plugin_installation_agent_idx ON plugin_installation (agent_id);
 
 CREATE TABLE IF NOT EXISTS agent (
         id TEXT PRIMARY KEY NOT NULL,
@@ -158,5 +179,8 @@ const ensureColumn = (table: string, column: string, ddl: string) => {
 
 ensureColumn('passkey', 'last_used_at', 'last_used_at INTEGER');
 ensureColumn('user', 'role', "role TEXT NOT NULL DEFAULT 'operator'");
+ensureColumn('plugin', 'approval_status', "approval_status TEXT NOT NULL DEFAULT 'pending'");
+ensureColumn('plugin', 'approved_at', 'approved_at INTEGER');
+ensureColumn('plugin', 'approval_note', 'approval_note TEXT');
 
 export const db = drizzle(client, { schema });

--- a/tenvy-server/src/lib/server/db/schema.ts
+++ b/tenvy-server/src/lib/server/db/schema.ts
@@ -98,9 +98,37 @@ export const plugin = sqliteTable('plugin', {
 	lastAutoSyncAt: timestamp('last_auto_sync_at', { optional: true }),
 	lastDeployedAt: timestamp('last_deployed_at', { optional: true }),
 	lastCheckedAt: timestamp('last_checked_at', { optional: true }),
+	approvalStatus: text('approval_status').notNull().default('pending'),
+	approvedAt: timestamp('approved_at', { optional: true }),
+	approvalNote: text('approval_note'),
 	createdAt: timestamp('created_at', { defaultNow: true }),
 	updatedAt: timestamp('updated_at', { defaultNow: true })
 });
+
+export const pluginInstallation = sqliteTable(
+	'plugin_installation',
+	{
+		pluginId: text('plugin_id')
+			.notNull()
+			.references(() => plugin.id, { onDelete: 'cascade' }),
+		agentId: text('agent_id')
+			.notNull()
+			.references(() => agent.id, { onDelete: 'cascade' }),
+		status: text('status').notNull().default('pending'),
+		version: text('version').notNull(),
+		hash: text('hash'),
+		enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
+		error: text('error'),
+		lastDeployedAt: timestamp('last_deployed_at', { optional: true }),
+		lastCheckedAt: timestamp('last_checked_at', { optional: true }),
+		createdAt: timestamp('created_at', { defaultNow: true }),
+		updatedAt: timestamp('updated_at', { defaultNow: true })
+	},
+	(table) => ({
+		pk: primaryKey({ columns: [table.pluginId, table.agentId] }),
+		agentIdx: index('plugin_installation_agent_idx').on(table.agentId)
+	})
+);
 
 export const agent = sqliteTable(
 	'agent',
@@ -197,6 +225,7 @@ export type Passkey = typeof passkey.$inferSelect;
 
 export type RecoveryCode = typeof recoveryCode.$inferSelect;
 export type Plugin = typeof plugin.$inferSelect;
+export type PluginInstallation = typeof pluginInstallation.$inferSelect;
 export type Agent = typeof agent.$inferSelect;
 export type AgentNote = typeof agentNote.$inferSelect;
 export type AgentCommand = typeof agentCommand.$inferSelect;

--- a/tenvy-server/src/lib/server/plugins/runtime-store.ts
+++ b/tenvy-server/src/lib/server/plugins/runtime-store.ts
@@ -3,7 +3,10 @@ import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type { PluginDeliveryMode, PluginStatus } from '$lib/data/plugin-view.js';
 import { db } from '$lib/server/db/index.js';
 import { plugin } from '$lib/server/db/schema.js';
-import type { PluginManifest } from '../../../../shared/types/plugin-manifest.js';
+import type {
+	PluginApprovalStatus,
+	PluginManifest
+} from '../../../../shared/types/plugin-manifest.js';
 
 type PluginTable = typeof plugin;
 type PluginInsert = typeof plugin.$inferInsert;
@@ -26,6 +29,9 @@ export type PluginRuntimePatch = Partial<{
 	lastAutoSyncAt: Date | null;
 	lastDeployedAt: Date | null;
 	lastCheckedAt: Date | null;
+	approvalStatus: PluginApprovalStatus;
+	approvedAt: Date | null;
+	approvalNote: string | null;
 }>;
 
 export interface PluginRuntimeStore {
@@ -49,7 +55,10 @@ const ensureDefaults = (manifest: PluginManifest): PluginInsert => ({
 	lastManualPushAt: null,
 	lastAutoSyncAt: null,
 	lastDeployedAt: null,
-	lastCheckedAt: null
+	lastCheckedAt: null,
+	approvalStatus: 'pending',
+	approvedAt: null,
+	approvalNote: null
 });
 
 const normalizePatch = (patch: PluginRuntimePatch): Partial<PluginInsert> => {
@@ -69,6 +78,9 @@ const normalizePatch = (patch: PluginRuntimePatch): Partial<PluginInsert> => {
 	if (patch.lastAutoSyncAt !== undefined) update.lastAutoSyncAt = patch.lastAutoSyncAt;
 	if (patch.lastDeployedAt !== undefined) update.lastDeployedAt = patch.lastDeployedAt;
 	if (patch.lastCheckedAt !== undefined) update.lastCheckedAt = patch.lastCheckedAt;
+	if (patch.approvalStatus !== undefined) update.approvalStatus = patch.approvalStatus;
+	if (patch.approvedAt !== undefined) update.approvedAt = patch.approvedAt;
+	if (patch.approvalNote !== undefined) update.approvalNote = patch.approvalNote;
 
 	return update;
 };

--- a/tenvy-server/src/lib/server/plugins/telemetry-store.test.ts
+++ b/tenvy-server/src/lib/server/plugins/telemetry-store.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { and, eq } from 'drizzle-orm';
+import { PluginTelemetryStore } from './telemetry-store.js';
+import { db } from '$lib/server/db/index.js';
+import {
+	plugin as pluginTable,
+	pluginInstallation as pluginInstallationTable,
+	auditEvent as auditEventTable
+} from '$lib/server/db/schema.js';
+import type { AgentMetadata } from '../../../../../shared/types/agent.js';
+
+vi.mock('$env/dynamic/private', () => ({
+	env: {}
+}));
+
+const baseMetadata: AgentMetadata = {
+	hostname: 'agent.local',
+	username: 'operator',
+	os: 'Windows 11',
+	architecture: 'amd64',
+	ipAddress: '10.0.0.5',
+	publicIpAddress: '10.0.0.5',
+	tags: [],
+	version: '1.2.3',
+	group: undefined,
+	location: undefined
+};
+
+let manifestDir: string;
+
+function createManifest(hash: string) {
+	return {
+		id: 'test-plugin',
+		name: 'Test Plugin',
+		version: '1.0.0',
+		entry: 'plugin.dll',
+		distribution: {
+			defaultMode: 'automatic',
+			autoUpdate: true,
+			signature: { type: 'sha256', hash }
+		},
+		requirements: {
+			platforms: ['windows'],
+			architectures: ['x86_64'],
+			requiredModules: []
+		},
+		package: {
+			artifact: 'plugin.dll',
+			sizeBytes: 1024,
+			hash
+		}
+	} satisfies Record<string, unknown>;
+}
+
+beforeEach(() => {
+	process.env.DATABASE_URL = ':memory:';
+	manifestDir = mkdtempSync(join(tmpdir(), 'tenvy-plugin-manifests-'));
+	writeFileSync(join(manifestDir, 'test-plugin.json'), JSON.stringify(createManifest('abc123')));
+});
+
+afterEach(async () => {
+	await db.delete(pluginInstallationTable);
+	await db.delete(pluginTable);
+	await db.delete(auditEventTable);
+	rmSync(manifestDir, { recursive: true, force: true });
+});
+
+describe('PluginTelemetryStore', () => {
+	it('records successful installation telemetry', async () => {
+		const store = new PluginTelemetryStore({ manifestDirectory: manifestDir });
+
+		const now = new Date().toISOString();
+		await store.syncAgent('agent-1', baseMetadata, [
+			{
+				pluginId: 'test-plugin',
+				version: '1.0.0',
+				status: 'installed',
+				hash: 'abc123',
+				lastDeployedAt: now,
+				lastCheckedAt: now,
+				error: null
+			}
+		]);
+
+		const installations = await store.listAgentPlugins('agent-1');
+		expect(installations).toHaveLength(1);
+		expect(installations[0]?.status).toBe('installed');
+
+		const [runtime] = await db.select().from(pluginTable).where(eq(pluginTable.id, 'test-plugin'));
+		expect(runtime.installations).toBe(1);
+	});
+
+	it('blocks mismatched hashes and records audit events', async () => {
+		const store = new PluginTelemetryStore({ manifestDirectory: manifestDir });
+		const now = new Date().toISOString();
+
+		await store.syncAgent('agent-2', baseMetadata, [
+			{
+				pluginId: 'test-plugin',
+				version: '1.0.0',
+				status: 'installed',
+				hash: 'deadbeef',
+				lastDeployedAt: now,
+				lastCheckedAt: now,
+				error: null
+			}
+		]);
+
+		const installations = await store.listAgentPlugins('agent-2');
+		expect(installations[0]?.status).toBe('blocked');
+		expect(installations[0]?.error).toContain('hash mismatch');
+
+		const audits = await db
+			.select()
+			.from(auditEventTable)
+			.where(
+				and(eq(auditEventTable.agentId, 'agent-2'), eq(auditEventTable.commandName, 'plugin-sync'))
+			);
+		expect(audits.length).toBeGreaterThan(0);
+	});
+});

--- a/tenvy-server/src/lib/server/plugins/telemetry-store.ts
+++ b/tenvy-server/src/lib/server/plugins/telemetry-store.ts
@@ -1,0 +1,404 @@
+import { createHash, randomUUID } from 'crypto';
+import { and, eq, sql } from 'drizzle-orm';
+import type { AgentMetadata } from '../../../../../shared/types/agent.js';
+import {
+	pluginInstallStatuses,
+	type PluginInstallationTelemetry,
+	type PluginManifest,
+	type PluginPlatform,
+	type PluginArchitecture
+} from '../../../../../shared/types/plugin-manifest.js';
+import { loadPluginManifests } from '$lib/data/plugin-manifests.js';
+import { db } from '$lib/server/db/index.js';
+import {
+	auditEvent as auditEventTable,
+	plugin as pluginTable,
+	pluginInstallation as pluginInstallationTable
+} from '$lib/server/db/schema.js';
+import { createPluginRuntimeStore, type PluginRuntimeStore } from './runtime-store.js';
+
+export interface PluginTelemetryStoreOptions {
+	runtimeStore?: PluginRuntimeStore;
+	manifestDirectory?: string;
+}
+
+export interface AgentPluginRecord {
+	pluginId: string;
+	agentId: string;
+	status: string;
+	version: string;
+	hash: string | null;
+	enabled: boolean;
+	error: string | null;
+	lastDeployedAt: Date | null;
+	lastCheckedAt: Date | null;
+	approvalStatus: string;
+	approvalNote: string | null;
+	approvedAt: Date | null;
+}
+
+const MANIFEST_CACHE_TTL_MS = 30_000;
+
+function toDate(value: string | Date | null | undefined): Date | null {
+	if (!value) return null;
+	if (value instanceof Date) return new Date(value);
+	const parsed = new Date(value);
+	return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function normalizeStatus(status: string | undefined): string {
+	if (!status) return 'failed';
+	if (pluginInstallStatuses.includes(status as (typeof pluginInstallStatuses)[number])) {
+		return status;
+	}
+	return 'failed';
+}
+
+function normalizePlatform(metadata: AgentMetadata): PluginPlatform | null {
+	const os = metadata.os?.toLowerCase() ?? '';
+	if (os.includes('win')) return 'windows';
+	if (os.includes('mac') || os.includes('darwin')) return 'macos';
+	if (os.includes('linux')) return 'linux';
+	return null;
+}
+
+function normalizeArchitecture(metadata: AgentMetadata): PluginArchitecture | null {
+	const arch = metadata.architecture?.toLowerCase() ?? '';
+	if (arch.includes('arm')) return 'arm64';
+	if (arch.includes('64') || arch.includes('x86_64') || arch.includes('amd64')) return 'x86_64';
+	return null;
+}
+
+function parseSemver(value: string | undefined): [number, number, number] | null {
+	if (!value) return null;
+	const match = value.trim().match(/^(\d+)\.(\d+)\.(\d+)/);
+	if (!match) return null;
+	return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareSemver(a: string | undefined, b: string | undefined): number | null {
+	const left = parseSemver(a);
+	const right = parseSemver(b);
+	if (!left || !right) return null;
+	for (let i = 0; i < 3; i += 1) {
+		if (left[i] > right[i]) return 1;
+		if (left[i] < right[i]) return -1;
+	}
+	return 0;
+}
+
+function isVersionCompatible(version: string | undefined, min?: string, max?: string): boolean {
+	if (!version) return true;
+	if (min) {
+		const cmp = compareSemver(version, min);
+		if (cmp !== null && cmp < 0) return false;
+	}
+	if (max) {
+		const cmp = compareSemver(version, max);
+		if (cmp !== null && cmp > 0) return false;
+	}
+	return true;
+}
+
+function isPlatformCompatible(platform: PluginPlatform | null, manifest: PluginManifest): boolean {
+	const required = manifest.requirements.platforms ?? [];
+	if (required.length === 0) return true;
+	if (!platform) return false;
+	return required.includes(platform);
+}
+
+function isArchitectureCompatible(
+	architecture: PluginArchitecture | null,
+	manifest: PluginManifest
+): boolean {
+	const required = manifest.requirements.architectures ?? [];
+	if (required.length === 0) return true;
+	if (!architecture) return false;
+	return required.includes(architecture);
+}
+
+function buildAuditPayload(details: Record<string, unknown>): {
+	payloadHash: string;
+	result: string;
+} {
+	const serialized = JSON.stringify(details);
+	const hash = createHash('sha256').update(serialized, 'utf8').digest('hex');
+	return { payloadHash: hash, result: serialized };
+}
+
+export class PluginTelemetryStore {
+	private readonly runtimeStore: PluginRuntimeStore;
+	private readonly manifestDirectory?: string;
+	private manifestCache = new Map<string, PluginManifest>();
+	private manifestLoadedAt = 0;
+
+	constructor(options: PluginTelemetryStoreOptions = {}) {
+		this.runtimeStore = options.runtimeStore ?? createPluginRuntimeStore();
+		this.manifestDirectory = options.manifestDirectory;
+	}
+
+	async syncAgent(
+		agentId: string,
+		metadata: AgentMetadata,
+		installations: PluginInstallationTelemetry[]
+	): Promise<void> {
+		if (installations.length === 0) {
+			return;
+		}
+
+		await this.ensureManifestIndex();
+		const now = new Date();
+		const processed = new Set<string>();
+
+		for (const installation of installations) {
+			const manifest = this.manifestCache.get(installation.pluginId);
+			if (!manifest) {
+				console.warn(`agent ${agentId} reported unknown plugin ${installation.pluginId}`);
+				continue;
+			}
+
+			const runtimeRow = await this.runtimeStore.ensure(manifest);
+
+			const current = await db
+				.select()
+				.from(pluginInstallationTable)
+				.where(
+					and(
+						eq(pluginInstallationTable.pluginId, installation.pluginId),
+						eq(pluginInstallationTable.agentId, agentId)
+					)
+				)
+				.limit(1);
+
+			const existing = current[0];
+			const approvalStatus = runtimeRow?.approvalStatus ?? 'pending';
+
+			let status = normalizeStatus(installation.status);
+			let reason = installation.error ?? null;
+
+			const platform = normalizePlatform(metadata);
+			const architecture = normalizeArchitecture(metadata);
+			const compatible =
+				isPlatformCompatible(platform, manifest) &&
+				isArchitectureCompatible(architecture, manifest) &&
+				isVersionCompatible(
+					metadata.version,
+					manifest.requirements.minAgentVersion,
+					manifest.requirements.maxAgentVersion
+				);
+
+			const signedHash = manifest.package.hash?.toLowerCase();
+			const observedHash = installation.hash?.toLowerCase();
+
+			if (approvalStatus !== 'approved') {
+				status = 'blocked';
+				reason = reason ?? 'awaiting approval';
+			} else if (!compatible) {
+				status = 'blocked';
+				reason = reason ?? 'agent incompatible with plugin requirements';
+			} else if (manifest.distribution.signature.type !== 'none') {
+				if (!observedHash) {
+					status = 'blocked';
+					reason = reason ?? 'missing signature hash';
+				} else if (signedHash && signedHash !== observedHash) {
+					status = 'blocked';
+					reason = `hash mismatch (expected ${signedHash})`;
+				}
+			}
+
+			const lastDeployedAt = toDate(installation.lastDeployedAt);
+			const lastCheckedAt = toDate(installation.lastCheckedAt) ?? now;
+			const payload = {
+				pluginId: installation.pluginId,
+				agentId,
+				status,
+				version: installation.version,
+				hash: observedHash ?? null,
+				enabled: existing?.enabled ?? true,
+				error: reason,
+				lastDeployedAt,
+				lastCheckedAt,
+				createdAt: existing?.createdAt ?? now,
+				updatedAt: now
+			} satisfies typeof pluginInstallationTable.$inferInsert;
+
+			await db
+				.insert(pluginInstallationTable)
+				.values(payload)
+				.onConflictDoUpdate({
+					target: [pluginInstallationTable.pluginId, pluginInstallationTable.agentId],
+					set: {
+						status: payload.status,
+						version: payload.version,
+						hash: payload.hash,
+						enabled: payload.enabled,
+						error: payload.error,
+						lastDeployedAt: payload.lastDeployedAt ?? null,
+						lastCheckedAt: payload.lastCheckedAt,
+						updatedAt: payload.updatedAt
+					}
+				});
+
+			if (status === 'blocked' && (existing?.status !== 'blocked' || existing?.error !== reason)) {
+				await this.recordAuditEvent(
+					agentId,
+					installation.pluginId,
+					status,
+					reason ?? 'policy violation'
+				);
+			}
+
+			processed.add(installation.pluginId);
+		}
+
+		for (const pluginId of processed) {
+			await this.refreshAggregates(pluginId);
+		}
+	}
+
+	async listAgentPlugins(agentId: string): Promise<AgentPluginRecord[]> {
+		await this.ensureManifestIndex();
+		const rows = await db
+			.select({
+				pluginId: pluginInstallationTable.pluginId,
+				agentId: pluginInstallationTable.agentId,
+				status: pluginInstallationTable.status,
+				version: pluginInstallationTable.version,
+				hash: pluginInstallationTable.hash,
+				enabled: pluginInstallationTable.enabled,
+				error: pluginInstallationTable.error,
+				lastDeployedAt: pluginInstallationTable.lastDeployedAt,
+				lastCheckedAt: pluginInstallationTable.lastCheckedAt,
+				approvalStatus: pluginTable.approvalStatus,
+				approvalNote: pluginTable.approvalNote,
+				approvedAt: pluginTable.approvedAt
+			})
+			.from(pluginInstallationTable)
+			.innerJoin(pluginTable, eq(pluginInstallationTable.pluginId, pluginTable.id))
+			.where(eq(pluginInstallationTable.agentId, agentId));
+
+		return rows.map((row) => ({
+			pluginId: row.pluginId,
+			agentId: row.agentId,
+			status: row.status,
+			version: row.version,
+			hash: row.hash ?? null,
+			enabled: Boolean(row.enabled),
+			error: row.error ?? null,
+			lastDeployedAt: row.lastDeployedAt ?? null,
+			lastCheckedAt: row.lastCheckedAt ?? null,
+			approvalStatus: row.approvalStatus,
+			approvalNote: row.approvalNote ?? null,
+			approvedAt: row.approvedAt ?? null
+		}));
+	}
+
+	async updateAgentPlugin(
+		agentId: string,
+		pluginId: string,
+		patch: Partial<{ enabled: boolean }>
+	): Promise<void> {
+		if (patch.enabled === undefined) {
+			return;
+		}
+		const now = new Date();
+		const result = await db
+			.update(pluginInstallationTable)
+			.set({ enabled: patch.enabled, updatedAt: now })
+			.where(
+				and(
+					eq(pluginInstallationTable.agentId, agentId),
+					eq(pluginInstallationTable.pluginId, pluginId)
+				)
+			);
+		if (result.rowsAffected === 0) {
+			await db
+				.insert(pluginInstallationTable)
+				.values({
+					pluginId,
+					agentId,
+					status: 'pending',
+					version: 'unknown',
+					hash: null,
+					enabled: patch.enabled,
+					error: null,
+					lastDeployedAt: null,
+					lastCheckedAt: now,
+					createdAt: now,
+					updatedAt: now
+				})
+				.onConflictDoNothing();
+		}
+		await this.refreshAggregates(pluginId);
+	}
+
+	private async ensureManifestIndex(): Promise<void> {
+		const now = Date.now();
+		if (now - this.manifestLoadedAt < MANIFEST_CACHE_TTL_MS && this.manifestCache.size > 0) {
+			return;
+		}
+
+		const records = await loadPluginManifests({ directory: this.manifestDirectory });
+		const index = new Map<string, PluginManifest>();
+		for (const record of records) {
+			index.set(record.manifest.id, record.manifest);
+		}
+		this.manifestCache = index;
+		this.manifestLoadedAt = now;
+	}
+
+	private async refreshAggregates(pluginId: string): Promise<void> {
+		const [row] = await db
+			.select({
+				installed: sql<number>`sum(CASE WHEN ${pluginInstallationTable.status} = 'installed' THEN 1 ELSE 0 END)`,
+				blocked: sql<number>`sum(CASE WHEN ${pluginInstallationTable.status} = 'blocked' THEN 1 ELSE 0 END)`,
+				lastDeployedAt: sql<Date | null>`max(${pluginInstallationTable.lastDeployedAt})`,
+				lastCheckedAt: sql<Date | null>`max(${pluginInstallationTable.lastCheckedAt})`
+			})
+			.from(pluginInstallationTable)
+			.where(eq(pluginInstallationTable.pluginId, pluginId));
+
+		const installations = Number(row?.installed ?? 0);
+		const blocked = Number(row?.blocked ?? 0);
+		const lastDeployedAt = toDate(row?.lastDeployedAt ?? null);
+		const lastCheckedAt = toDate(row?.lastCheckedAt ?? null) ?? new Date();
+
+		const patch: Parameters<PluginRuntimeStore['update']>[1] = {
+			installations,
+			lastDeployedAt,
+			lastCheckedAt
+		};
+		if (blocked > 0) {
+			patch.status = 'error';
+		}
+
+		await this.runtimeStore.update(pluginId, patch);
+	}
+
+	private async recordAuditEvent(
+		agentId: string,
+		pluginId: string,
+		status: string,
+		reason: string
+	): Promise<void> {
+		try {
+			const { payloadHash, result } = buildAuditPayload({ pluginId, status, reason });
+			const timestamp = new Date();
+			await db
+				.insert(auditEventTable)
+				.values({
+					commandId: randomUUID(),
+					agentId,
+					operatorId: null,
+					commandName: 'plugin-sync',
+					payloadHash,
+					queuedAt: timestamp,
+					executedAt: timestamp,
+					result
+				})
+				.run();
+		} catch (error) {
+			console.error('Failed to record plugin sync audit event', error);
+		}
+	}
+}

--- a/tenvy-server/src/lib/server/rat/store.test.ts
+++ b/tenvy-server/src/lib/server/rat/store.test.ts
@@ -63,7 +63,7 @@ describe('AgentRegistry database integration', () => {
 			}
 		]);
 
-		registry.syncAgent(registration.agentId, registration.agentKey, {
+		await registry.syncAgent(registration.agentId, registration.agentKey, {
 			status: 'online',
 			timestamp: new Date().toISOString(),
 			results: [
@@ -90,7 +90,7 @@ describe('AgentRegistry database integration', () => {
 		expect(restoredNotes[0]?.id).toBe('note-1');
 	});
 
-	it('records audit events for queued and executed commands', () => {
+	it('records audit events for queued and executed commands', async () => {
 		const registry = new AgentRegistry();
 		const registration = registry.registerAgent({ metadata: baseMetadata });
 
@@ -125,7 +125,7 @@ describe('AgentRegistry database integration', () => {
 		expect(initialAudit?.operatorId).toBe('operator-123');
 		expect(initialAudit?.executedAt).toBeNull();
 
-		registry.syncAgent(registration.agentId, registration.agentKey, {
+		await registry.syncAgent(registration.agentId, registration.agentKey, {
 			status: 'online',
 			timestamp: new Date().toISOString(),
 			results: [

--- a/tenvy-server/src/lib/validation/client-plugin-update-schema.ts
+++ b/tenvy-server/src/lib/validation/client-plugin-update-schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const clientPluginUpdateSchema = z
+	.object({
+		enabled: z.boolean().optional()
+	})
+	.refine((payload) => payload.enabled !== undefined, {
+		message: 'No update fields supplied'
+	});
+
+export type ClientPluginUpdateInput = z.infer<typeof clientPluginUpdateSchema>;

--- a/tenvy-server/src/lib/validation/plugin-update-schema.ts
+++ b/tenvy-server/src/lib/validation/plugin-update-schema.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
+import { pluginApprovalStatuses } from '../../../../shared/types/plugin-manifest.js';
 
 const pluginStatusEnum = z.enum(['active', 'disabled', 'update', 'error']);
 const deliveryModeEnum = z.enum(['manual', 'automatic']);
+const approvalStatusEnum = z.enum(pluginApprovalStatuses);
 
 const optionalDate = z
 	.union([
@@ -22,6 +24,9 @@ export const pluginUpdateSchema = z
 		installations: z.number().int().min(0).optional(),
 		lastDeployedAt: optionalDate,
 		lastCheckedAt: optionalDate,
+		approvalStatus: approvalStatusEnum.optional(),
+		approvedAt: optionalDate,
+		approvalNote: z.union([z.string().trim().min(1).max(200), z.null()]).optional(),
 		distribution: z
 			.object({
 				defaultMode: deliveryModeEnum.optional(),
@@ -43,6 +48,12 @@ export const pluginUpdateSchema = z
 			if (!hasDistributionUpdate) {
 				delete payload.distribution;
 			}
+		}
+		if (payload.approvalNote === undefined) {
+			delete payload.approvalNote;
+		}
+		if (payload.approvedAt === undefined) {
+			delete payload.approvedAt;
 		}
 		return payload;
 	});

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/plugins/+page.svelte
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/plugins/+page.svelte
@@ -1,0 +1,281 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import {
+		Card,
+		CardContent,
+		CardDescription,
+		CardFooter,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+	import { Switch } from '$lib/components/ui/switch/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
+	import {
+		Tooltip,
+		TooltipContent,
+		TooltipProvider,
+		TooltipTrigger
+	} from '$lib/components/ui/tooltip/index.js';
+	import {
+		ShieldAlert,
+		ShieldCheck,
+		Download,
+		History,
+		RefreshCcw,
+		Info,
+		Package
+	} from '@lucide/svelte';
+	import {
+		pluginStatusLabels,
+		pluginStatusStyles,
+		pluginApprovalLabels
+	} from '$lib/data/plugin-view.js';
+	import type { ClientPlugin } from '$lib/data/client-plugin-view.js';
+
+	export let data: { clientId: string; plugins: ClientPlugin[] };
+
+	const clientId = data.clientId;
+	let registry = $state<ClientPlugin[]>(data.plugins.map((plugin) => ({ ...plugin })));
+
+	const installedCount = $derived(registry.length);
+	const approvalsPending = $derived(
+		registry.filter((plugin) => plugin.approvalStatus === 'pending').length
+	);
+	const blockedPlugins = $derived(
+		registry.filter((plugin) => plugin.telemetry.status === 'blocked').length
+	);
+	const autoSyncEnabled = $derived(registry.filter((plugin) => plugin.autoUpdate).length);
+
+	function approvalVariant(status: string) {
+		switch (status) {
+			case 'approved':
+				return 'bg-emerald-500/10 text-emerald-500 border-emerald-500/40';
+			case 'rejected':
+				return 'bg-red-500/10 text-red-500 border-red-500/40';
+			default:
+				return 'bg-amber-500/10 text-amber-500 border-amber-500/40';
+		}
+	}
+
+	function telemetryVariant(status: string) {
+		switch (status) {
+			case 'installed':
+				return 'bg-emerald-500/10 text-emerald-500 border-emerald-500/40';
+			case 'failed':
+			case 'blocked':
+				return 'bg-red-500/10 text-red-500 border-red-500/40';
+			case 'installing':
+				return 'bg-sky-500/10 text-sky-500 border-sky-500/40';
+			default:
+				return 'bg-muted text-muted-foreground border-muted/60';
+		}
+	}
+
+	function applyPatch(id: string, next: ClientPlugin) {
+		registry = registry.map((plugin) => (plugin.id === id ? next : plugin));
+	}
+
+	async function updatePluginEnabled(id: string, enabled: boolean) {
+		const previous = registry;
+		registry = registry.map((plugin) =>
+			plugin.id === id
+				? {
+						...plugin,
+						telemetry: { ...plugin.telemetry, enabled }
+					}
+				: plugin
+		);
+
+		try {
+			const response = await fetch(`/api/clients/${clientId}/plugins/${id}`, {
+				method: 'PATCH',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ enabled })
+			});
+
+			if (!response.ok) {
+				const message = await response.text().catch(() => null);
+				throw new Error(message || `Failed to update plugin ${id}`);
+			}
+
+			const payload = (await response.json()) as { plugin: ClientPlugin };
+			applyPatch(id, payload.plugin);
+		} catch (err) {
+			console.error('Failed to update client plugin', err);
+			registry = previous;
+		}
+	}
+</script>
+
+<section class="space-y-6">
+	<Card class="border-border/60">
+		<CardHeader>
+			<CardTitle class="text-xl font-semibold">Plugin telemetry</CardTitle>
+			<CardDescription>
+				Live installation status and delivery controls for this client.
+			</CardDescription>
+		</CardHeader>
+		<CardContent class="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+			<div class="space-y-1">
+				<p class="text-sm text-muted-foreground">Catalog size</p>
+				<p class="flex items-center gap-2 text-lg font-semibold">
+					<Package class="h-4 w-4 text-primary" />
+					{installedCount}
+				</p>
+			</div>
+			<div class="space-y-1">
+				<p class="text-sm text-muted-foreground">Auto-sync</p>
+				<p class="flex items-center gap-2 text-lg font-semibold">
+					<RefreshCcw class="h-4 w-4 text-primary" />
+					{autoSyncEnabled}
+				</p>
+			</div>
+			<div class="space-y-1">
+				<p class="text-sm text-muted-foreground">Approvals pending</p>
+				<p class="flex items-center gap-2 text-lg font-semibold">
+					<ShieldAlert class="h-4 w-4 text-amber-500" />
+					{approvalsPending}
+				</p>
+			</div>
+			<div class="space-y-1">
+				<p class="text-sm text-muted-foreground">Blocked installs</p>
+				<p class="flex items-center gap-2 text-lg font-semibold">
+					<ShieldCheck
+						class={`h-4 w-4 ${blockedPlugins > 0 ? 'text-red-500' : 'text-emerald-500'}`}
+					/>
+					{blockedPlugins}
+				</p>
+			</div>
+		</CardContent>
+	</Card>
+
+	<div class="grid gap-6 lg:grid-cols-2 xl:grid-cols-3">
+		{#each registry as plugin (plugin.id)}
+			<Card class="flex flex-col border-border/70 bg-card/40">
+				<CardHeader class="space-y-4">
+					<div class="flex items-start justify-between gap-4">
+						<div>
+							<CardTitle class="text-lg font-semibold">
+								{plugin.name}
+							</CardTitle>
+							<CardDescription class="mt-1 flex flex-wrap items-center gap-2 text-xs">
+								<span
+									class="rounded-full border border-border/80 px-2 py-0.5 font-medium text-muted-foreground"
+								>
+									v{plugin.version}
+								</span>
+								<span
+									class="rounded-full border border-border/80 px-2 py-0.5 text-muted-foreground"
+								>
+									{plugin.category}
+								</span>
+							</CardDescription>
+						</div>
+						<div class="flex flex-col items-end gap-2 text-xs">
+							<Badge class={cn('border', pluginStatusStyles[plugin.globalStatus])}>
+								{pluginStatusLabels[plugin.globalStatus]}
+							</Badge>
+							<Badge class={cn('border', approvalVariant(plugin.approvalStatus))}>
+								{pluginApprovalLabels[plugin.approvalStatus as keyof typeof pluginApprovalLabels] ??
+									plugin.approvalStatus}
+							</Badge>
+						</div>
+					</div>
+					<p class="text-sm leading-6 text-muted-foreground">{plugin.description}</p>
+				</CardHeader>
+				<CardContent class="flex flex-1 flex-col gap-4">
+					<div
+						class="rounded-md border border-border/60 bg-muted/10 p-3 text-sm text-muted-foreground"
+					>
+						<div class="flex items-center justify-between gap-4">
+							<div class="space-y-1">
+								<p class="font-medium text-foreground">Delivery policy</p>
+								<p>
+									Default: <span class="font-semibold">{plugin.distribution.defaultMode}</span>
+									· Auto-update {plugin.distribution.autoUpdate ? 'enabled' : 'disabled'}
+								</p>
+								<p class="truncate">
+									Artifact: <span class="font-mono text-xs">{plugin.artifact}</span>
+								</p>
+							</div>
+						</div>
+						<Separator class="my-3" />
+						<div class="flex flex-wrap items-center gap-3 text-xs">
+							<span class="rounded border border-border/60 px-2 py-0.5">{plugin.size}</span>
+							{#if plugin.expectedHash}
+								<TooltipProvider>
+									<Tooltip>
+										<TooltipTrigger class="rounded border border-border/60 px-2 py-0.5 font-mono">
+											hash
+										</TooltipTrigger>
+										<TooltipContent side="bottom" class="max-w-xs break-all">
+											{plugin.expectedHash}
+										</TooltipContent>
+									</Tooltip>
+								</TooltipProvider>
+							{/if}
+						</div>
+					</div>
+
+					<div class="rounded-md border border-border/60 bg-background/60 p-3 text-sm">
+						<div class="flex items-center justify-between gap-4">
+							<div class="flex flex-col gap-1">
+								<span class="text-xs tracking-wide text-muted-foreground uppercase"
+									>Installation</span
+								>
+								<Badge class={cn('border', telemetryVariant(plugin.telemetry.status))}>
+									{plugin.telemetry.status}
+								</Badge>
+							</div>
+							<div class="flex items-center gap-2 text-xs text-muted-foreground">
+								<Switch
+									aria-label={`Toggle ${plugin.name}`}
+									checked={plugin.telemetry.enabled}
+									on:checkedChange={(event) => updatePluginEnabled(plugin.id, event.detail)}
+								/>
+								<span>{plugin.telemetry.enabled ? 'Enabled' : 'Disabled'}</span>
+							</div>
+						</div>
+						<Separator class="my-3" />
+						<div class="grid gap-2 text-xs text-muted-foreground">
+							<div class="flex items-center gap-2">
+								<History class="h-3.5 w-3.5" />
+								<span>Last deployed: {plugin.telemetry.lastDeployed}</span>
+							</div>
+							<div class="flex items-center gap-2">
+								<RefreshCcw class="h-3.5 w-3.5" />
+								<span>Last check: {plugin.telemetry.lastChecked}</span>
+							</div>
+							<div class="flex items-center gap-2">
+								<Download class="h-3.5 w-3.5" />
+								<span>Hash: {plugin.telemetry.hash ?? 'n/a'}</span>
+							</div>
+							{#if plugin.telemetry.error}
+								<div class="flex items-start gap-2 text-red-500">
+									<Info class="mt-0.5 h-3.5 w-3.5" />
+									<span>{plugin.telemetry.error}</span>
+								</div>
+							{/if}
+						</div>
+					</div>
+				</CardContent>
+				<CardFooter class="justify-end text-xs text-muted-foreground">
+					<div class="flex flex-wrap gap-2">
+						{#if plugin.requirements.platforms.length > 0}
+							<span>Platforms: {plugin.requirements.platforms.join(', ')}</span>
+						{/if}
+						{#if plugin.requirements.architectures.length > 0}
+							<Separator orientation="vertical" />
+							<span>Architectures: {plugin.requirements.architectures.join(', ')}</span>
+						{/if}
+						{#if plugin.requirements.requiredModules.length > 0}
+							<Separator orientation="vertical" />
+							<span>Requires modules: {plugin.requirements.requiredModules.join(', ')}</span>
+						{/if}
+					</div>
+				</CardFooter>
+			</Card>
+		{/each}
+	</div>
+</section>

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/plugins/+page.ts
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/plugins/+page.ts
@@ -1,0 +1,18 @@
+import { error } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+import type { ClientPlugin } from '$lib/data/client-plugin-view.js';
+
+type ClientPluginListResponse = { plugins: ClientPlugin[] };
+
+export const load: PageLoad = async ({ fetch, params }) => {
+	const { clientId } = params;
+	const response = await fetch(`/api/clients/${clientId}/plugins`);
+
+	if (!response.ok) {
+		const message = await response.text().catch(() => null);
+		throw error(response.status, message || 'Failed to load client plugins');
+	}
+
+	const payload = (await response.json()) as ClientPluginListResponse;
+	return { clientId, plugins: payload.plugins };
+};

--- a/tenvy-server/src/routes/api/agents/[id]/sync/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/sync/+server.ts
@@ -30,7 +30,7 @@ export const POST: RequestHandler = async ({ params, request, getClientAddress }
 	}
 
 	try {
-		const response = registry.syncAgent(id, token, payload, {
+		const response = await registry.syncAgent(id, token, payload, {
 			remoteAddress: getClientAddress()
 		});
 		return json(response);

--- a/tenvy-server/src/routes/api/clients/[id]/plugins/+server.ts
+++ b/tenvy-server/src/routes/api/clients/[id]/plugins/+server.ts
@@ -1,0 +1,52 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { registry } from '$lib/server/rat/store.js';
+import { createPluginRepository } from '$lib/data/plugins.js';
+import { loadPluginManifests } from '$lib/data/plugin-manifests.js';
+import { buildClientPlugin, type ClientPlugin } from '$lib/data/client-plugin-view.js';
+import { PluginTelemetryStore } from '$lib/server/plugins/telemetry-store.js';
+
+const repository = createPluginRepository();
+const telemetryStore = new PluginTelemetryStore();
+
+export const GET: RequestHandler = async ({ params }) => {
+	const { id } = params;
+	if (!id) {
+		throw error(400, 'Missing client identifier');
+	}
+
+	try {
+		registry.getAgent(id);
+	} catch {
+		throw error(404, 'Client not found');
+	}
+
+        const [manifestRecords, pluginViews, telemetryRecords] = await Promise.all([
+                loadManifests(),
+                repository.list(),
+                telemetryStore.listAgentPlugins(id)
+        ]);
+
+	const manifestIndex = new Map(
+		manifestRecords.map((record) => [record.manifest.id, record.manifest])
+	);
+	const telemetryIndex = new Map(telemetryRecords.map((record) => [record.pluginId, record]));
+
+	const plugins: ClientPlugin[] = [];
+
+	for (const view of pluginViews) {
+		const manifest = manifestIndex.get(view.id);
+		if (!manifest) {
+			continue;
+		}
+
+		const telemetry = telemetryIndex.get(view.id);
+		plugins.push(buildClientPlugin(manifest, view, telemetry));
+        }
+
+        return json({ plugins });
+};
+
+async function loadManifests() {
+        return loadPluginManifests();
+}

--- a/tenvy-server/src/routes/api/clients/[id]/plugins/[pluginId]/+server.ts
+++ b/tenvy-server/src/routes/api/clients/[id]/plugins/[pluginId]/+server.ts
@@ -1,0 +1,61 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { registry } from '$lib/server/rat/store.js';
+import { PluginTelemetryStore } from '$lib/server/plugins/telemetry-store.js';
+import { clientPluginUpdateSchema } from '$lib/validation/client-plugin-update-schema.js';
+import { createPluginRepository } from '$lib/data/plugins.js';
+import { loadPluginManifests } from '$lib/data/plugin-manifests.js';
+import { buildClientPlugin } from '$lib/data/client-plugin-view.js';
+
+const telemetryStore = new PluginTelemetryStore();
+const repository = createPluginRepository();
+
+export const PATCH: RequestHandler = async ({ params, request }) => {
+	const { id, pluginId } = params;
+	if (!id || !pluginId) {
+		throw error(400, 'Missing identifiers');
+	}
+
+	try {
+		registry.getAgent(id);
+	} catch {
+		throw error(404, 'Client not found');
+	}
+
+	let payload: unknown;
+	try {
+		payload = await request.json();
+	} catch {
+		throw error(400, 'Request payload must be valid JSON');
+	}
+
+	const parsed = clientPluginUpdateSchema.safeParse(payload);
+	if (!parsed.success) {
+		throw error(400, parsed.error.errors[0]?.message ?? 'Invalid request payload');
+	}
+
+	if (parsed.data.enabled !== undefined) {
+		await telemetryStore.updateAgentPlugin(id, pluginId, { enabled: parsed.data.enabled });
+	}
+
+	const [manifests, plugins, telemetry] = await Promise.all([
+		loadPluginManifests(),
+		repository.list(),
+		telemetryStore.listAgentPlugins(id)
+	]);
+	const manifestIndex = new Map(manifests.map((record) => [record.manifest.id, record.manifest]));
+	const pluginIndex = new Map(plugins.map((plugin) => [plugin.id, plugin]));
+	const telemetryIndex = new Map(telemetry.map((record) => [record.pluginId, record]));
+
+	const manifest = manifestIndex.get(pluginId);
+	const plugin = pluginIndex.get(pluginId);
+	const telemetryRecord = telemetryIndex.get(pluginId);
+
+	if (!manifest || !plugin || !telemetryRecord) {
+		throw error(404, 'Plugin not found for client');
+	}
+
+	const response = buildClientPlugin(manifest, plugin, telemetryRecord);
+
+	return json({ plugin: response });
+};

--- a/tenvy-server/src/routes/api/plugins/[id]/+server.ts
+++ b/tenvy-server/src/routes/api/plugins/[id]/+server.ts
@@ -21,6 +21,9 @@ const toRepositoryUpdate = (input: PluginUpdatePayloadInput): PluginRepositoryUp
 	if (input.installations !== undefined) patch.installations = input.installations;
 	if (input.lastDeployedAt !== undefined) patch.lastDeployedAt = input.lastDeployedAt;
 	if (input.lastCheckedAt !== undefined) patch.lastCheckedAt = input.lastCheckedAt;
+	if (input.approvalStatus !== undefined) patch.approvalStatus = input.approvalStatus;
+	if (input.approvedAt !== undefined) patch.approvedAt = input.approvedAt;
+	if (input.approvalNote !== undefined) patch.approvalNote = input.approvalNote;
 
 	if (input.distribution) {
 		const distribution: NonNullable<PluginRepositoryUpdate['distribution']> = {};
@@ -65,7 +68,10 @@ const hasUpdates = (patch: PluginRepositoryUpdate): boolean => {
 		patch.autoUpdate !== undefined ||
 		patch.installations !== undefined ||
 		patch.lastDeployedAt !== undefined ||
-		patch.lastCheckedAt !== undefined
+		patch.lastCheckedAt !== undefined ||
+		patch.approvalStatus !== undefined ||
+		patch.approvedAt !== undefined ||
+		patch.approvalNote !== undefined
 	) {
 		return true;
 	}


### PR DESCRIPTION
## Summary
- align the shared plugin manifest contract, validation, and documentation across TypeScript and Go
- add a Go-side plugin manager that snapshots local artifacts and attaches telemetry to sync requests
- persist plugin telemetry on the controller with new APIs, UI, and approval handling for client-level plugin state

## Testing
- go test ./internal/agent ./internal/plugins ./internal/protocol
- bun run test:unit -- --run (0 tests executed in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68f54a49d408832ba2e145ec905fafe1