### PR TITLE
Introduce module lifecycle registry

### DIFF
--- a/tenvy-client/internal/agent/lifecycle.go
+++ b/tenvy-client/internal/agent/lifecycle.go
@@ -123,6 +123,11 @@ func (a *Agent) sync(ctx context.Context, status string) error {
 	}
 
 	a.config = payload.Config
+	if a.modules != nil {
+		if err := a.modules.UpdateConfig(ctx, a.moduleRuntime()); err != nil {
+			a.logger.Printf("module configuration update failed: %v", err)
+		}
+	}
 	a.processCommands(ctx, payload.Commands)
 
 	if a.notes != nil {
@@ -221,7 +226,7 @@ func (a *Agent) reRegister(ctx context.Context) error {
 	a.resultMu.Unlock()
 
 	if a.modules != nil {
-		if err := a.modules.Update(a.moduleRuntime()); err != nil {
+		if err := a.modules.UpdateConfig(ctx, a.moduleRuntime()); err != nil {
 			return fmt.Errorf("update modules: %w", err)
 		}
 	}

--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -83,7 +83,7 @@ func Run(ctx context.Context, opts RuntimeOptions) error {
 	}
 
 	modules := newDefaultModuleRegistry()
-	if err := modules.Update(agent.moduleRuntime()); err != nil {
+	if err := modules.Init(ctx, agent.moduleRuntime()); err != nil {
 		return fmt.Errorf("initialize modules: %w", err)
 	}
 	agent.modules = modules


### PR DESCRIPTION
## Summary
- introduce a Module interface with Init, Handle, UpdateConfig, and Shutdown hooks alongside a shared ModuleRuntime payload
- update the module registry to drive initialization and configuration refreshes while keeping remote-desktop accessors intact
- refresh modules whenever the agent synchronizes or re-registers to keep runtime and configuration data aligned

## Testing
- go test ./internal/agent -run TestStopRemoteDesktopInputWorker -count=1


------
https://chatgpt.com/codex/tasks/task_e_68f64eabed50832bac39ba8802f61689