### PR TITLE
Handle missing user context on plugins page

### DIFF
--- a/tenvy-server/src/routes/(app)/plugins/+page.svelte
+++ b/tenvy-server/src/routes/(app)/plugins/+page.svelte
@@ -65,7 +65,7 @@
 		listing: MarketplaceListing;
 	};
 
-	type AuthenticatedUser = { id: string; role: UserRole };
+        type AuthenticatedUser = { id: string; role: UserRole } | null;
 
 	let {
 		data
@@ -101,7 +101,7 @@
 	let marketplaceEntitlements = $state<MarketplaceEntitlement[]>(
 		data.entitlements.map((entitlement) => ({ ...entitlement }))
 	);
-	const currentUser = $state<AuthenticatedUser>(data.user);
+        const currentUser = $state<AuthenticatedUser>(data.user ?? null);
 	let searchTerm = $state('');
 	let statusFilter = $state<'all' | PluginStatus>('all');
 	let categoryFilter = $state<'all' | PluginCategory>('all');
@@ -241,11 +241,13 @@
 		return marketplaceEntitlements.some((entry) => entry.listingId === listingId);
 	}
 
-	const canPurchase = $derived(currentUser.role === 'admin' || currentUser.role === 'operator');
+        const canPurchase = $derived(
+                currentUser?.role === 'admin' || currentUser?.role === 'operator'
+        );
 
-	const canSubmitMarketplace = $derived(
-		currentUser.role === 'admin' || currentUser.role === 'developer'
-	);
+        const canSubmitMarketplace = $derived(
+                currentUser?.role === 'admin' || currentUser?.role === 'developer'
+        );
 
 	async function purchaseListing(listing: MarketplaceListing) {
 		if (!canPurchase) {

--- a/tenvy-server/src/routes/(app)/plugins/+page.ts
+++ b/tenvy-server/src/routes/(app)/plugins/+page.ts
@@ -33,8 +33,12 @@ type MarketplaceEntitlement = {
 
 type MarketplaceEntitlementsResponse = { entitlements: MarketplaceEntitlement[] };
 
+type MinimalUser = { id: string; role: UserRole };
+
 export const load: PageLoad = async ({ fetch, parent }) => {
-	const parentData = await parent();
+        const parentData = await parent<{ user?: MinimalUser | null }>();
+
+        const minimalUser = parentData.user ? { id: parentData.user.id, role: parentData.user.role } : null;
 
 	const [pluginsResponse, listingsResponse, entitlementsResponse] = await Promise.all([
 		fetch('/api/plugins'),
@@ -65,7 +69,7 @@ export const load: PageLoad = async ({ fetch, parent }) => {
 	return {
 		plugins: pluginsPayload.plugins,
 		listings: listingsPayload.listings,
-		entitlements: entitlementsPayload.entitlements,
-		user: parentData.user as { id: string; role: UserRole }
-	};
+                entitlements: entitlementsPayload.entitlements,
+                user: minimalUser
+        };
 };


### PR DESCRIPTION
## Summary
- guard the plugins page load against missing parent user data
- make the marketplace UI treat the current user as optional before checking roles

## Testing
- bun check *(fails: existing type and Svelte warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f6556945e0832baed0c9b79cff5518