### PR TITLE
Add persistence-backed plugin repository tests

### DIFF
--- a/tenvy-server/src/lib/data/plugins.ts
+++ b/tenvy-server/src/lib/data/plugins.ts
@@ -196,18 +196,19 @@ export const createPluginRepository = (
 		return record;
 	};
 
-	return {
-		async list() {
-			const records = await loadManifests();
-			const plugins = [] as Plugin[];
+        return {
+                async list() {
+                        const records = await loadManifests();
+                        if (records.length === 0) return [];
 
-			for (const record of records) {
-				const runtimeRow = await runtimeStore.ensure(record.manifest);
-				plugins.push(toPluginView(record.manifest, snapshotFromRow(runtimeRow)));
-			}
+                        const runtimeRows = await Promise.all(
+                                records.map((record) => runtimeStore.ensure(record.manifest))
+                        );
 
-			return plugins;
-		},
+                        return records.map((record, index) =>
+                                toPluginView(record.manifest, snapshotFromRow(runtimeRows[index]!))
+                        );
+                },
 		async get(id: string) {
 			const { manifest } = await getManifest(id);
 			const runtimeRow = await runtimeStore.ensure(manifest);

--- a/tenvy-server/src/lib/server/plugins/runtime-store.test.ts
+++ b/tenvy-server/src/lib/server/plugins/runtime-store.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createPluginRuntimeStore } from './runtime-store.js';
+import { plugin as pluginTable } from '$lib/server/db/schema.js';
+import type { PluginManifest } from '../../../../../shared/types/plugin-manifest.js';
+
+const PLUGIN_TABLE_DDL = `
+CREATE TABLE IF NOT EXISTS plugin (
+        id TEXT PRIMARY KEY NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        enabled INTEGER NOT NULL DEFAULT 1,
+        auto_update INTEGER NOT NULL DEFAULT 0,
+        installations INTEGER NOT NULL DEFAULT 0,
+        manual_targets INTEGER NOT NULL DEFAULT 0,
+        auto_targets INTEGER NOT NULL DEFAULT 0,
+        default_delivery_mode TEXT NOT NULL DEFAULT 'manual',
+        allow_manual_push INTEGER NOT NULL DEFAULT 1,
+        allow_auto_sync INTEGER NOT NULL DEFAULT 0,
+        last_manual_push_at INTEGER,
+        last_auto_sync_at INTEGER,
+        last_deployed_at INTEGER,
+        last_checked_at INTEGER,
+        approval_status TEXT NOT NULL DEFAULT 'pending',
+        approved_at INTEGER,
+        approval_note TEXT,
+        created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+        updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+);
+`;
+
+const baseManifest: PluginManifest = {
+        id: 'runtime-test',
+        name: 'Runtime Test',
+        version: '1.0.0',
+        description: 'Fixture plugin manifest used for runtime store tests.',
+        entry: 'runtime-test.dll',
+        author: 'Tenvy',
+        repositoryUrl: 'https://github.com/rootbay/runtime-test',
+        license: { spdxId: 'MIT', name: 'MIT License', url: 'https://opensource.org/license/mit' },
+        requirements: {
+                platforms: ['windows'],
+                architectures: ['x86_64'],
+                requiredModules: []
+        },
+        distribution: {
+                defaultMode: 'automatic',
+                autoUpdate: true,
+                signature: { type: 'none' }
+        },
+        package: { artifact: 'runtime-test.dll', sizeBytes: 1024, hash: 'abc123' }
+};
+
+let tempDir: string;
+let dbPath: string;
+
+const openRuntimeStore = () => {
+        const sqlite = new Database(dbPath);
+        sqlite.exec(PLUGIN_TABLE_DDL);
+        const drizzleDb = drizzle(sqlite, { schema: { plugin: pluginTable } });
+        return { store: createPluginRuntimeStore(drizzleDb), sqlite };
+};
+
+beforeEach(() => {
+        tempDir = mkdtempSync(join(tmpdir(), 'tenvy-runtime-store-'));
+        dbPath = join(tempDir, 'runtime.sqlite');
+});
+
+afterEach(() => {
+        rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('PluginRuntimeStore', () => {
+        it('creates runtime rows with manifest defaults', async () => {
+                const { store, sqlite } = openRuntimeStore();
+
+                try {
+                        const row = await store.ensure(baseManifest);
+                        expect(row.id).toBe(baseManifest.id);
+                        expect(row.autoUpdate).toBe(true);
+                        expect(row.defaultDeliveryMode).toBe('automatic');
+                        expect(row.allowAutoSync).toBe(true);
+                        expect(row.approvalStatus).toBe('pending');
+                        expect(row.approvedAt).toBeNull();
+                } finally {
+                        sqlite.close();
+                }
+        });
+
+        it('persists runtime updates across store instances', async () => {
+                const first = openRuntimeStore();
+                const timestamp = new Date('2024-05-19T15:45:00.000Z');
+
+                try {
+                        await first.store.ensure(baseManifest);
+                        await first.store.update(baseManifest.id, {
+                                status: 'disabled',
+                                enabled: false,
+                                autoUpdate: false,
+                                manualTargets: 5,
+                                autoTargets: 2,
+                                defaultDeliveryMode: 'manual',
+                                allowManualPush: false,
+                                allowAutoSync: false,
+                                lastManualPushAt: timestamp,
+                                lastAutoSyncAt: timestamp,
+                                lastDeployedAt: timestamp,
+                                lastCheckedAt: timestamp,
+                                approvalStatus: 'approved',
+                                approvedAt: timestamp,
+                                approvalNote: 'ready for launch'
+                        });
+                } finally {
+                        first.sqlite.close();
+                }
+
+                const second = openRuntimeStore();
+
+                try {
+                        const row = await second.store.ensure(baseManifest);
+                        expect(row.status).toBe('disabled');
+                        expect(row.enabled).toBe(false);
+                        expect(row.autoUpdate).toBe(false);
+                        expect(row.manualTargets).toBe(5);
+                        expect(row.autoTargets).toBe(2);
+                        expect(row.defaultDeliveryMode).toBe('manual');
+                        expect(row.allowManualPush).toBe(false);
+                        expect(row.allowAutoSync).toBe(false);
+                        expect(row.lastManualPushAt?.toISOString()).toBe(timestamp.toISOString());
+                        expect(row.lastAutoSyncAt?.toISOString()).toBe(timestamp.toISOString());
+                        expect(row.lastDeployedAt?.toISOString()).toBe(timestamp.toISOString());
+                        expect(row.lastCheckedAt?.toISOString()).toBe(timestamp.toISOString());
+                        expect(row.approvalStatus).toBe('approved');
+                        expect(row.approvedAt?.toISOString()).toBe(timestamp.toISOString());
+                        expect(row.approvalNote).toBe('ready for launch');
+                } finally {
+                        second.sqlite.close();
+                }
+        });
+});

--- a/tenvy-server/src/lib/server/plugins/telemetry-store.test.ts
+++ b/tenvy-server/src/lib/server/plugins/telemetry-store.test.ts
@@ -4,17 +4,18 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { and, eq } from 'drizzle-orm';
 import { PluginTelemetryStore } from './telemetry-store.js';
+import { createPluginRuntimeStore } from './runtime-store.js';
 import { db } from '$lib/server/db/index.js';
 import {
-	plugin as pluginTable,
-	pluginInstallation as pluginInstallationTable,
-	auditEvent as auditEventTable
+        agent as agentTable,
+        plugin as pluginTable,
+        pluginInstallation as pluginInstallationTable,
+        auditEvent as auditEventTable
 } from '$lib/server/db/schema.js';
 import type { AgentMetadata } from '../../../../../shared/types/agent.js';
+import type { PluginManifest } from '../../../../../shared/types/plugin-manifest.js';
 
-vi.mock('$env/dynamic/private', () => ({
-	env: {}
-}));
+vi.mock('$env/dynamic/private', () => import('../../../../tests/mocks/env-dynamic-private'));
 
 const baseMetadata: AgentMetadata = {
 	hostname: 'agent.local',
@@ -31,46 +32,93 @@ const baseMetadata: AgentMetadata = {
 
 let manifestDir: string;
 
-function createManifest(hash: string) {
-	return {
-		id: 'test-plugin',
-		name: 'Test Plugin',
-		version: '1.0.0',
-		entry: 'plugin.dll',
-		distribution: {
-			defaultMode: 'automatic',
-			autoUpdate: true,
-			signature: { type: 'sha256', hash }
-		},
-		requirements: {
-			platforms: ['windows'],
-			architectures: ['x86_64'],
+function createManifest(hash: string): PluginManifest {
+        return {
+                id: 'test-plugin',
+                name: 'Test Plugin',
+                version: '1.0.0',
+                entry: 'plugin.dll',
+                repositoryUrl: 'https://github.com/rootbay/test-plugin',
+                license: {
+                        spdxId: 'MIT',
+                        name: 'MIT License'
+                },
+                distribution: {
+                        defaultMode: 'automatic',
+                        autoUpdate: true,
+                        signature: { type: 'sha256', hash, signature: 'signed' }
+                },
+                requirements: {
+                        platforms: ['windows'],
+                        architectures: ['x86_64'],
 			requiredModules: []
 		},
-		package: {
-			artifact: 'plugin.dll',
-			sizeBytes: 1024,
-			hash
-		}
-	} satisfies Record<string, unknown>;
+                package: {
+                        artifact: 'plugin.dll',
+                        sizeBytes: 1024,
+                        hash
+                }
+        };
 }
 
-beforeEach(() => {
-	process.env.DATABASE_URL = ':memory:';
-	manifestDir = mkdtempSync(join(tmpdir(), 'tenvy-plugin-manifests-'));
-	writeFileSync(join(manifestDir, 'test-plugin.json'), JSON.stringify(createManifest('abc123')));
+beforeEach(async () => {
+        process.env.DATABASE_URL = ':memory:';
+        manifestDir = mkdtempSync(join(tmpdir(), 'tenvy-plugin-manifests-'));
+        writeFileSync(join(manifestDir, 'test-plugin.json'), JSON.stringify(createManifest('abc123')));
+
+        const now = new Date();
+        await db.insert(agentTable).values([
+                {
+                        id: 'agent-1',
+                        keyHash: 'hash-agent-1',
+                        metadata: JSON.stringify(baseMetadata),
+                        status: 'online',
+                        connectedAt: now,
+                        lastSeen: now,
+                        metrics: JSON.stringify({}),
+                        config: JSON.stringify({}),
+                        fingerprint: 'fingerprint-agent-1',
+                        createdAt: now,
+                        updatedAt: now
+                },
+                {
+                        id: 'agent-2',
+                        keyHash: 'hash-agent-2',
+                        metadata: JSON.stringify(baseMetadata),
+                        status: 'online',
+                        connectedAt: now,
+                        lastSeen: now,
+                        metrics: JSON.stringify({}),
+                        config: JSON.stringify({}),
+                        fingerprint: 'fingerprint-agent-2',
+                        createdAt: now,
+                        updatedAt: now
+                }
+        ]);
 });
 
 afterEach(async () => {
-	await db.delete(pluginInstallationTable);
-	await db.delete(pluginTable);
-	await db.delete(auditEventTable);
-	rmSync(manifestDir, { recursive: true, force: true });
+        await db.delete(pluginInstallationTable);
+        await db.delete(pluginTable);
+        await db.delete(auditEventTable);
+        await db.delete(agentTable);
+        rmSync(manifestDir, { recursive: true, force: true });
 });
 
 describe('PluginTelemetryStore', () => {
-	it('records successful installation telemetry', async () => {
-		const store = new PluginTelemetryStore({ manifestDirectory: manifestDir });
+        it('records successful installation telemetry', async () => {
+                const runtimeStore = createPluginRuntimeStore();
+                const manifest = createManifest('abc123');
+                await runtimeStore.ensure(manifest);
+                await runtimeStore.update(manifest.id, {
+                        approvalStatus: 'approved',
+                        approvedAt: new Date()
+                });
+
+                const store = new PluginTelemetryStore({
+                        runtimeStore,
+                        manifestDirectory: manifestDir
+                });
 
 		const now = new Date().toISOString();
 		await store.syncAgent('agent-1', baseMetadata, [
@@ -93,8 +141,19 @@ describe('PluginTelemetryStore', () => {
 		expect(runtime.installations).toBe(1);
 	});
 
-	it('blocks mismatched hashes and records audit events', async () => {
-		const store = new PluginTelemetryStore({ manifestDirectory: manifestDir });
+        it('blocks mismatched hashes and records audit events', async () => {
+                const runtimeStore = createPluginRuntimeStore();
+                const manifest = createManifest('abc123');
+                await runtimeStore.ensure(manifest);
+                await runtimeStore.update(manifest.id, {
+                        approvalStatus: 'approved',
+                        approvedAt: new Date()
+                });
+
+                const store = new PluginTelemetryStore({
+                        runtimeStore,
+                        manifestDirectory: manifestDir
+                });
 		const now = new Date().toISOString();
 
 		await store.syncAgent('agent-2', baseMetadata, [

--- a/tenvy-server/tests/plugin-manifests.test.ts
+++ b/tenvy-server/tests/plugin-manifests.test.ts
@@ -17,25 +17,32 @@ describe('loadPluginManifests', () => {
 
 	it('skips files that do not satisfy the manifest schema', async () => {
 		const directory = mkdtempSync(join(tmpdir(), 'tenvy-manifests-'));
-		const validManifest = {
-			id: 'test-valid',
-			name: 'Test Plugin',
-			version: '0.1.0',
-			entry: 'test.dll',
-			description: 'A manifest used in tests',
-			author: 'Unit Tests',
-			distribution: {
-				defaultMode: 'manual',
-				autoUpdate: false,
-				signature: { type: 'none' }
-			},
-			requirements: {
-				requiredModules: ['clipboard']
-			},
-			package: {
-				artifact: 'test.dll',
-				sizeBytes: 1024
-			}
+                const validManifest = {
+                        id: 'test-valid',
+                        name: 'Test Plugin',
+                        version: '0.1.0',
+                        entry: 'test.dll',
+                        description: 'A manifest used in tests',
+                        author: 'Unit Tests',
+                        repositoryUrl: 'https://github.com/rootbay/test-plugin',
+                        license: {
+                                spdxId: 'MIT',
+                                name: 'MIT License'
+                        },
+                        distribution: {
+                                defaultMode: 'manual',
+                                autoUpdate: false,
+                                signature: { type: 'none' }
+                        },
+                        requirements: {
+                                platforms: ['windows'],
+                                architectures: ['x86_64'],
+                                requiredModules: ['clipboard']
+                        },
+                        package: {
+                                artifact: 'test.dll',
+                                sizeBytes: 1024
+                        }
 		} satisfies Record<string, unknown>;
 
 		writeFileSync(join(directory, 'valid.json'), JSON.stringify(validManifest));

--- a/tenvy-server/tests/plugins-repository.test.ts
+++ b/tenvy-server/tests/plugins-repository.test.ts
@@ -1,15 +1,53 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { join } from 'node:path';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { createPluginRepository } from '../src/lib/data/plugins.js';
 import { createPluginRuntimeStore } from '../src/lib/server/plugins/runtime-store.js';
 import { plugin as pluginTable } from '../src/lib/server/db/schema.js';
 
-const manifestDirectory = join(process.cwd(), 'resources/plugin-manifests');
+const manifestFixture = {
+        id: 'clipboard-sync',
+        name: 'Clipboard Sync',
+        version: '1.4.2',
+        description: 'Synchronize clipboard activity across operator sessions.',
+        entry: 'clipboard-sync.dll',
+        author: 'Tenvy Labs',
+        repositoryUrl: 'https://github.com/rootbay/tenvy-clipboard-sync',
+        license: {
+                spdxId: 'MIT',
+                name: 'MIT License',
+                url: 'https://opensource.org/license/mit'
+        },
+        categories: ['collection'],
+        capabilities: [
+                {
+                        name: 'clipboard.capture',
+                        module: 'clipboard',
+                        description: 'Capture remote clipboard history and relay updates in real time.'
+                }
+        ],
+        requirements: {
+                minAgentVersion: '1.2.0',
+                platforms: ['windows'],
+                architectures: ['x86_64'],
+                requiredModules: ['clipboard']
+        },
+        distribution: {
+                defaultMode: 'automatic',
+                autoUpdate: true,
+                signature: { type: 'none' }
+        },
+        package: {
+                artifact: 'clipboard-sync-1.4.2.dll',
+                sizeBytes: 18_743_296
+        }
+};
 
 const PLUGIN_TABLE_DDL = `
-CREATE TABLE plugin (
+CREATE TABLE IF NOT EXISTS plugin (
         id TEXT PRIMARY KEY NOT NULL,
         status TEXT NOT NULL DEFAULT 'active',
         enabled INTEGER NOT NULL DEFAULT 1,
@@ -24,57 +62,117 @@ CREATE TABLE plugin (
         last_auto_sync_at INTEGER,
         last_deployed_at INTEGER,
         last_checked_at INTEGER,
-        created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
+        approval_status TEXT NOT NULL DEFAULT 'pending',
+        approved_at INTEGER,
+        approval_note TEXT,
+        created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+        updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
 );
 `;
 
-const createRepository = () => {
-	const sqlite = new Database(':memory:');
-	sqlite.exec(PLUGIN_TABLE_DDL);
-	const drizzleDb = drizzle(sqlite, { schema: { plugin: pluginTable } });
-	const runtimeStore = createPluginRuntimeStore(drizzleDb);
-	const repository = createPluginRepository({ runtimeStore, directory: manifestDirectory });
-	return { repository };
+let tempDir: string;
+let dbPath: string;
+let manifestDir: string;
+
+const openRepository = () => {
+        const sqlite = new Database(dbPath);
+        sqlite.exec(PLUGIN_TABLE_DDL);
+        const drizzleDb = drizzle(sqlite, { schema: { plugin: pluginTable } });
+        const runtimeStore = createPluginRuntimeStore(drizzleDb);
+        const repository = createPluginRepository({ runtimeStore, directory: manifestDir });
+        return { repository, runtimeStore, sqlite };
 };
 
+beforeEach(() => {
+        tempDir = mkdtempSync(join(tmpdir(), 'tenvy-plugin-repo-'));
+        dbPath = join(tempDir, 'runtime.sqlite');
+        manifestDir = join(tempDir, 'manifests');
+        mkdirSync(manifestDir, { recursive: true });
+        writeFileSync(join(manifestDir, `${manifestFixture.id}.json`), JSON.stringify(manifestFixture));
+});
+
+afterEach(() => {
+        rmSync(tempDir, { recursive: true, force: true });
+});
+
 describe('plugin repository', () => {
-	it('derives plugin views from manifests and runtime state', async () => {
-		const { repository } = createRepository();
-		const plugins = await repository.list();
+        it('derives plugin views from manifests and runtime state', async () => {
+                const { repository, sqlite } = openRepository();
 
-		expect(plugins.length).toBeGreaterThan(0);
-		const clipboard = plugins.find((plugin) => plugin.id === 'clipboard-sync');
-		expect(clipboard).toBeDefined();
-		expect(clipboard?.artifact).toContain('clipboard');
-		expect(clipboard?.distribution.defaultMode).toBeTypeOf('string');
-	});
+                try {
+                        const plugins = await repository.list();
+                        expect(plugins.length).toBeGreaterThan(0);
 
-	it('persists updates across reads', async () => {
-		const { repository } = createRepository();
+                        const clipboard = plugins.find((plugin) => plugin.id === 'clipboard-sync');
+                        expect(clipboard?.name).toBe('Clipboard Sync');
+                        expect(clipboard?.artifact).toContain('clipboard');
+                        expect(clipboard?.distribution.defaultMode).toBe('automatic');
+                        expect(clipboard?.distribution.allowAutoSync).toBe(true);
+                        expect(clipboard?.requiredModules.map((module) => module.id)).toContain(
+                                'clipboard'
+                        );
+                } finally {
+                        sqlite.close();
+                }
+        });
 
-		await repository.update('clipboard-sync', {
-			enabled: false,
-			status: 'disabled'
-		});
+        it('persists runtime updates across repository instances', async () => {
+                const first = openRepository();
+                const timestamp = new Date('2024-05-18T10:30:00.000Z');
 
-		const disabled = await repository.get('clipboard-sync');
-		expect(disabled.enabled).toBe(false);
-		expect(disabled.status).toBe('disabled');
+                try {
+                        await first.repository.update('clipboard-sync', {
+                                status: 'disabled',
+                                enabled: false,
+                                autoUpdate: false,
+                                lastDeployedAt: timestamp,
+                                lastCheckedAt: timestamp,
+                                approvalStatus: 'approved',
+                                approvedAt: timestamp,
+                                approvalNote: 'ship it',
+                                distribution: {
+                                        defaultMode: 'manual',
+                                        allowManualPush: false,
+                                        allowAutoSync: false,
+                                        manualTargets: 3,
+                                        autoTargets: 1,
+                                        lastManualPushAt: timestamp,
+                                        lastAutoSyncAt: timestamp
+                                }
+                        });
+                } finally {
+                        first.sqlite.close();
+                }
 
-		await repository.update('clipboard-sync', {
-			enabled: true,
-			status: 'active',
-			distribution: {
-				allowAutoSync: true,
-				autoTargets: 12
-			}
-		});
+                const second = openRepository();
 
-		const reenabled = await repository.get('clipboard-sync');
-		expect(reenabled.enabled).toBe(true);
-		expect(reenabled.status).toBe('active');
-		expect(reenabled.distribution.allowAutoSync).toBe(true);
-		expect(reenabled.distribution.autoTargets).toBe(12);
-	});
+                try {
+                        const plugin = await second.repository.get('clipboard-sync');
+                        expect(plugin.status).toBe('disabled');
+                        expect(plugin.enabled).toBe(false);
+                        expect(plugin.distribution.allowAutoSync).toBe(false);
+                        expect(plugin.distribution.allowManualPush).toBe(false);
+                        expect(plugin.distribution.manualTargets).toBe(3);
+                        expect(plugin.distribution.autoTargets).toBe(1);
+                        expect(plugin.approvalStatus).toBe('approved');
+                        expect(plugin.approvedAt).toBe(timestamp.toISOString());
+
+                        const runtimeRow = await second.runtimeStore.find('clipboard-sync');
+                        expect(runtimeRow?.lastManualPushAt?.toISOString()).toBe(
+                                timestamp.toISOString()
+                        );
+                        expect(runtimeRow?.lastAutoSyncAt?.toISOString()).toBe(
+                                timestamp.toISOString()
+                        );
+                        expect(runtimeRow?.lastDeployedAt?.toISOString()).toBe(
+                                timestamp.toISOString()
+                        );
+                        expect(runtimeRow?.lastCheckedAt?.toISOString()).toBe(
+                                timestamp.toISOString()
+                        );
+                        expect(runtimeRow?.approvalNote).toBe('ship it');
+                } finally {
+                        second.sqlite.close();
+                }
+        });
 });


### PR DESCRIPTION
## Summary
- parallelize plugin runtime hydration when listing manifests
- add runtime store persistence coverage and update telemetry tests for approved plugins
- replace repository tests with file-backed manifests to verify persisted metadata

## Testing
- bun test:unit -- --run

------
https://chatgpt.com/codex/tasks/task_e_68f66d4abe24832b80493a70cf7205bd