### PR TITLE
Enforce HTTPS and harden QUIC trust anchors

### DIFF
--- a/tenvy-client/cmd/config.go
+++ b/tenvy-client/cmd/config.go
@@ -76,9 +76,9 @@ func defaultServerURL() string {
 		port = "2332"
 	}
 
-	scheme := "http"
-	if port == "443" {
-		scheme = "https"
+	scheme := "https"
+	if port == "80" {
+		scheme = "http"
 	}
 
 	return scheme + "://" + host + ":" + port

--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -151,6 +151,16 @@ func canonicalizeServerURL(raw string) (string, error) {
 	host := parsed.Hostname()
 	port := parsed.Port()
 
+	scheme := strings.ToLower(parsed.Scheme)
+	switch scheme {
+	case "https":
+		// secure by default
+	case "http":
+		return "", fmt.Errorf("server url must use https scheme: %s", trimmed)
+	default:
+		return "", fmt.Errorf("unsupported server url scheme: %s", parsed.Scheme)
+	}
+
 	if strings.EqualFold(host, "localhost") {
 		host = "127.0.0.1"
 	}

--- a/tenvy-client/internal/agent/runtime_test.go
+++ b/tenvy-client/internal/agent/runtime_test.go
@@ -13,8 +13,8 @@ func TestCanonicalizeServerURL(t *testing.T) {
 	}{
 		{
 			name:  "localhost with port",
-			input: "http://localhost:2332",
-			want:  "http://127.0.0.1:2332",
+			input: "https://localhost:2332",
+			want:  "https://127.0.0.1:2332",
 		},
 		{
 			name:  "localhost without port",
@@ -27,9 +27,14 @@ func TestCanonicalizeServerURL(t *testing.T) {
 			want:  "https://controller.example.com",
 		},
 		{
-			name:  "ipv6 loopback",
-			input: "http://[::1]:8080",
-			want:  "http://[::1]:8080",
+			name:    "http disallowed",
+			input:   "http://[::1]:8080",
+			wantErr: true,
+		},
+		{
+			name:    "unsupported scheme",
+			input:   "ftp://controller.example.com",
+			wantErr: true,
 		},
 		{
 			name:    "invalid url",

--- a/tenvy-client/internal/modules/control/remotedesktop/types.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/types.go
@@ -2,6 +2,7 @@ package remotedesktop
 
 import (
 	"context"
+	"crypto/x509"
 	"image"
 	"net/http"
 	"sync"
@@ -75,6 +76,8 @@ const (
 	RemoteTransportHTTP   RemoteDesktopTransport = "http"
 	RemoteTransportWebRTC RemoteDesktopTransport = "webrtc"
 )
+
+const spkiHashLength = 32
 
 const (
 	RemoteHardwareAuto   RemoteDesktopHardwarePreference = "auto"
@@ -238,17 +241,21 @@ type QUICInputConfig struct {
 	ConnectTimeout     time.Duration `json:"connectTimeout,omitempty"`
 	RetryInterval      time.Duration `json:"retryInterval,omitempty"`
 	InsecureSkipVerify bool          `json:"insecureSkipVerify,omitempty"`
+	RootCAFiles        []string      `json:"rootCaFiles,omitempty"`
+	RootCAPEMs         []string      `json:"rootCaPems,omitempty"`
+	PinnedSPKIHashes   []string      `json:"pinnedSpkiHashes,omitempty"`
 }
 
 type sanitizedQUICInput struct {
-	enabled            bool
-	address            string
-	serverName         string
-	alpn               string
-	token              string
-	connectTimeout     time.Duration
-	retryInterval      time.Duration
-	insecureSkipVerify bool
+	enabled        bool
+	address        string
+	serverName     string
+	alpn           string
+	token          string
+	connectTimeout time.Duration
+	retryInterval  time.Duration
+	rootCAs        *x509.CertPool
+	spkiPins       [][]byte
 }
 
 type RemoteDesktopInputQuicConfig struct {


### PR DESCRIPTION
## Summary
- require HTTPS server URLs during agent bootstrap and update the default configuration
- log and ignore the deprecated QUIC insecure toggle while adding CA bundle and SPKI pin configuration
- build QUIC TLS contexts with managed trust anchors and certificate pinning instead of disabling verification

## Testing
- go test ./... -run TestCanonicalizeServerURL -count=1

------
https://chatgpt.com/codex/tasks/task_e_68f67663521c832b92f54fe3cc9d21ba