### PR TITLE
Stream file manager resources instead of base64 blobs

### DIFF
--- a/shared/types/file-manager.ts
+++ b/shared/types/file-manager.ts
@@ -1,82 +1,92 @@
-export type FileSystemEntryType = 'file' | 'directory' | 'symlink' | 'other';
+export type FileSystemEntryType = "file" | "directory" | "symlink" | "other";
 
 export interface FileSystemEntry {
-        name: string;
-        path: string;
-        type: FileSystemEntryType;
-        size: number | null;
-        modifiedAt: string;
-        isHidden: boolean;
+  name: string;
+  path: string;
+  type: FileSystemEntryType;
+  size: number | null;
+  modifiedAt: string;
+  isHidden: boolean;
 }
 
 export interface DirectoryListing {
-        type: 'directory';
-        root: string;
-        path: string;
-        parent: string | null;
-        entries: FileSystemEntry[];
+  type: "directory";
+  root: string;
+  path: string;
+  parent: string | null;
+  entries: FileSystemEntry[];
 }
 
-export type FileEncoding = 'utf-8' | 'base64';
+export type FileEncoding = "utf-8" | "base64";
 
 export interface FileContent {
-        type: 'file';
-        root: string;
-        path: string;
-        name: string;
-        size: number;
-        modifiedAt: string;
-        encoding: FileEncoding;
-        content: string;
+  type: "file";
+  root: string;
+  path: string;
+  name: string;
+  size: number;
+  modifiedAt: string;
+  encoding: FileEncoding;
+  content?: string;
+  stream?: FileContentStream;
 }
 
 export type FileManagerResource = DirectoryListing | FileContent;
 
+export interface FileContentStream {
+  id: string;
+  part: string;
+  index: number;
+  count: number;
+  offset: number;
+  length: number;
+}
+
 export interface FileOperationResponse {
-        success: boolean;
-        message?: string;
-        entry?: FileSystemEntry;
-        path?: string;
+  success: boolean;
+  message?: string;
+  entry?: FileSystemEntry;
+  path?: string;
 }
 
 export type FileManagerCommandPayload =
-        | {
-                        action: 'list-directory';
-                        path?: string;
-                        requestId?: string;
-                        includeHidden?: boolean;
-          }
-        | {
-                        action: 'read-file';
-                        path: string;
-                        requestId?: string;
-                        encoding?: FileEncoding;
-          }
-        | {
-                        action: 'create-entry';
-                        directory: string;
-                        name: string;
-                        entryType: 'file' | 'directory';
-                        content?: string;
-          }
-        | {
-                        action: 'rename-entry';
-                        path: string;
-                        name: string;
-          }
-        | {
-                        action: 'move-entry';
-                        path: string;
-                        destination: string;
-                        name?: string;
-          }
-        | {
-                        action: 'delete-entry';
-                        path: string;
-          }
-        | {
-                        action: 'update-file';
-                        path: string;
-                        content: string;
-                        encoding?: FileEncoding;
-          };
+  | {
+      action: "list-directory";
+      path?: string;
+      requestId?: string;
+      includeHidden?: boolean;
+    }
+  | {
+      action: "read-file";
+      path: string;
+      requestId?: string;
+      encoding?: FileEncoding;
+    }
+  | {
+      action: "create-entry";
+      directory: string;
+      name: string;
+      entryType: "file" | "directory";
+      content?: string;
+    }
+  | {
+      action: "rename-entry";
+      path: string;
+      name: string;
+    }
+  | {
+      action: "move-entry";
+      path: string;
+      destination: string;
+      name?: string;
+    }
+  | {
+      action: "delete-entry";
+      path: string;
+    }
+  | {
+      action: "update-file";
+      path: string;
+      content: string;
+      encoding?: FileEncoding;
+    };

--- a/tenvy-client/internal/modules/management/filemanager/manager.go
+++ b/tenvy-client/internal/modules/management/filemanager/manager.go
@@ -3,13 +3,18 @@ package filemanager
 import (
 	"bytes"
 	"context"
+	"crypto/sha1"
 	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -53,7 +58,11 @@ const (
 	requestTimeout        = 10 * time.Second
 	defaultDirectoryPerms = 0o755
 	defaultFilePerms      = 0o644
+	inlineTextLimit       = 128 * 1024
+	streamChunkSize       = 512 * 1024
 )
+
+var errInvalidUTF8Content = errors.New("file content is not valid utf-8")
 
 func NewManager(cfg Config) *Manager {
 	manager := &Manager{}
@@ -174,14 +183,21 @@ func (m *Manager) handleReadFile(ctx context.Context, payload FileManagerCommand
 		return err
 	}
 	encoding := payload.Encoding
-	resource, err := buildFileContent(filePath, encoding)
+	contents, err := buildFileContent(filePath, encoding)
 	if err != nil {
 		return err
 	}
-	if err := m.dispatchResources(ctx, resource); err != nil {
+	if len(contents) == 0 {
+		return fmt.Errorf("no content produced for %s", filePath)
+	}
+	resources := make([]Resource, 0, len(contents))
+	for _, content := range contents {
+		resources = append(resources, content)
+	}
+	if err := m.dispatchResources(ctx, resources...); err != nil {
 		return err
 	}
-	result.Output = fmt.Sprintf("read %s", resource.Path)
+	result.Output = fmt.Sprintf("read %s", contents[0].Path)
 	return nil
 }
 
@@ -229,8 +245,10 @@ func (m *Manager) handleCreateEntry(ctx context.Context, payload FileManagerComm
 		m.logf("file-manager: failed to build directory listing for %s: %v", directoryPath, err)
 	}
 	if entryType == "file" {
-		if content, err := buildFileContent(targetPath, EncodingUTF8); err == nil {
-			resources = append(resources, content)
+		if contents, err := buildFileContent(targetPath, EncodingUTF8); err == nil {
+			for _, content := range contents {
+				resources = append(resources, content)
+			}
 		} else {
 			m.logf("file-manager: failed to build file content for %s: %v", targetPath, err)
 		}
@@ -269,8 +287,10 @@ func (m *Manager) handleRenameEntry(ctx context.Context, payload FileManagerComm
 		m.logf("file-manager: failed to rebuild directory listing for %s: %v", parentDir, err)
 	}
 	if info, err := os.Lstat(newPath); err == nil && info.Mode().IsRegular() {
-		if content, err := buildFileContent(newPath, EncodingUTF8); err == nil {
-			resources = append(resources, content)
+		if contents, err := buildFileContent(newPath, EncodingUTF8); err == nil {
+			for _, content := range contents {
+				resources = append(resources, content)
+			}
 		}
 	}
 	if err := m.dispatchResources(ctx, resources...); err != nil {
@@ -323,8 +343,10 @@ func (m *Manager) handleMoveEntry(ctx context.Context, payload FileManagerComman
 		m.logf("file-manager: failed to build directory listing for %s: %v", destPath, err)
 	}
 	if info, err := os.Lstat(newPath); err == nil && info.Mode().IsRegular() {
-		if content, err := buildFileContent(newPath, EncodingUTF8); err == nil {
-			resources = append(resources, content)
+		if contents, err := buildFileContent(newPath, EncodingUTF8); err == nil {
+			for _, content := range contents {
+				resources = append(resources, content)
+			}
 		}
 	}
 	if err := m.dispatchResources(ctx, resources...); err != nil {
@@ -376,8 +398,10 @@ func (m *Manager) handleUpdateFile(ctx context.Context, payload FileManagerComma
 		return fmt.Errorf("update file: %w", err)
 	}
 	resources := []Resource{}
-	if content, err := buildFileContent(filePath, encoding); err == nil {
-		resources = append(resources, content)
+	if contents, err := buildFileContent(filePath, encoding); err == nil {
+		for _, content := range contents {
+			resources = append(resources, content)
+		}
 	} else {
 		m.logf("file-manager: failed to rebuild file content for %s: %v", filePath, err)
 	}
@@ -412,21 +436,100 @@ func (m *Manager) dispatchResources(ctx context.Context, resources ...Resource) 
 	} else {
 		payload["resources"] = resources
 	}
+
+	streamables := make([]*FileContent, 0)
+	for _, resource := range resources {
+		switch value := resource.(type) {
+		case *FileContent:
+			if value.Stream != nil {
+				streamables = append(streamables, value)
+			}
+		case FileContent:
+			if value.Stream != nil {
+				copy := value
+				streamables = append(streamables, &copy)
+			}
+		}
+	}
+
 	data, err := json.Marshal(payload)
 	if err != nil {
+		closeStreamReaders(streamables)
 		return err
 	}
+
 	reqCtx := ctx
 	if deadline, ok := ctx.Deadline(); !ok || time.Until(deadline) <= 0 {
 		var cancel context.CancelFunc
 		reqCtx, cancel = context.WithTimeout(context.Background(), requestTimeout)
 		defer cancel()
 	}
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, endpoint, bytes.NewReader(data))
+
+	var body io.Reader
+	var contentType string
+	var pipeReader *io.PipeReader
+
+	if len(streamables) == 0 {
+		body = bytes.NewReader(data)
+		contentType = "application/json"
+	} else {
+		pr, pw := io.Pipe()
+		pipeReader = pr
+		multipartWriter := multipart.NewWriter(pw)
+
+		go func() {
+			defer closeStreamReaders(streamables)
+			defer multipartWriter.Close()
+			defer pw.Close()
+
+			metaPart, err := multipartWriter.CreateFormField("metadata")
+			if err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+			if _, err := metaPart.Write(data); err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+			for _, content := range streamables {
+				descriptor := content.Stream
+				if descriptor == nil {
+					pw.CloseWithError(fmt.Errorf("file-manager: missing stream descriptor for %s", content.Path))
+					return
+				}
+				reader := content.streamReader()
+				if reader == nil {
+					pw.CloseWithError(fmt.Errorf("file-manager: missing stream reader for %s", content.Path))
+					return
+				}
+				header := textproto.MIMEHeader{}
+				header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, descriptor.Part, content.Name))
+				header.Set("Content-Type", "application/octet-stream")
+				part, err := multipartWriter.CreatePart(header)
+				if err != nil {
+					pw.CloseWithError(err)
+					return
+				}
+				if _, err := io.Copy(part, reader); err != nil {
+					pw.CloseWithError(err)
+					return
+				}
+			}
+		}()
+
+		body = pipeReader
+		contentType = multipartWriter.FormDataContentType()
+	}
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, endpoint, body)
 	if err != nil {
+		if pipeReader != nil {
+			pipeReader.CloseWithError(err)
+		}
+		closeStreamReaders(streamables)
 		return err
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Accept", "application/json")
 	if ua := strings.TrimSpace(m.userAgent()); ua != "" {
 		req.Header.Set("User-Agent", ua)
@@ -436,6 +539,9 @@ func (m *Manager) dispatchResources(ctx context.Context, resources ...Resource) 
 	}
 	resp, err := cfg.Client.Do(req)
 	if err != nil {
+		if pipeReader != nil {
+			pipeReader.CloseWithError(err)
+		}
 		return err
 	}
 	defer resp.Body.Close()
@@ -599,50 +705,161 @@ func buildDirectoryListing(path string, includeHidden bool) (DirectoryListing, e
 	return listing, nil
 }
 
-func buildFileContent(path string, preferredEncoding FileEncoding) (FileContent, error) {
+func buildFileContent(path string, preferredEncoding FileEncoding) ([]*FileContent, error) {
 	info, err := os.Stat(path)
 	if err != nil {
-		return FileContent{}, err
+		return nil, err
 	}
 	if info.IsDir() {
-		return FileContent{}, fmt.Errorf("path is a directory: %s", path)
+		return nil, fmt.Errorf("path is a directory: %s", path)
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return FileContent{}, err
-	}
-	encoding := preferredEncoding
-	if encoding == "" {
-		if shouldUseTextEncoding(data) {
-			encoding = EncodingUTF8
-		} else {
-			encoding = EncodingBase64
-		}
-	}
-	var content string
-	switch encoding {
-	case EncodingUTF8:
-		if !utf8.Valid(data) {
-			return FileContent{}, errors.New("file content is not valid utf-8")
-		}
-		content = string(data)
-	case EncodingBase64:
-		content = base64.StdEncoding.EncodeToString(data)
-	default:
-		return FileContent{}, fmt.Errorf("unsupported file encoding: %s", encoding)
-	}
+
 	normalizedPath := normalizePath(path)
-	resource := FileContent{
+	base := FileContent{
 		Type:       "file",
 		Root:       deriveRoot(normalizedPath),
 		Path:       normalizedPath,
 		Name:       filepath.Base(normalizedPath),
 		Size:       info.Size(),
 		ModifiedAt: info.ModTime().UTC().Format(time.RFC3339Nano),
-		Encoding:   encoding,
-		Content:    content,
 	}
-	return resource, nil
+
+	encoding := preferredEncoding
+	if encoding == "" {
+		encoding = EncodingUTF8
+	}
+
+	if encoding == EncodingUTF8 {
+		if info.Size() <= inlineTextLimit {
+			content, inlineErr := readUTF8Content(path, info.Size())
+			if inlineErr == nil {
+				inline := base
+				inline.Encoding = EncodingUTF8
+				inline.Content = content
+				return []*FileContent{&inline}, nil
+			}
+			if errors.Is(inlineErr, errInvalidUTF8Content) {
+				encoding = EncodingBase64
+			} else if inlineErr != nil {
+				return nil, inlineErr
+			}
+		} else {
+			encoding = EncodingBase64
+		}
+	}
+
+	if encoding != EncodingBase64 {
+		return nil, fmt.Errorf("unsupported file encoding: %s", encoding)
+	}
+
+	return buildStreamedFileContents(path, base, info)
+}
+
+func readUTF8Content(path string, size int64) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	var buf bytes.Buffer
+	if size > 0 && size <= inlineTextLimit {
+		buf.Grow(int(size))
+	}
+	if _, err := io.CopyN(&buf, file, size); err != nil {
+		if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			return "", err
+		}
+	}
+	data := buf.Bytes()
+	if !shouldUseTextEncoding(data) {
+		return "", errInvalidUTF8Content
+	}
+	return buf.String(), nil
+}
+
+func buildStreamedFileContents(path string, base FileContent, info fs.FileInfo) ([]*FileContent, error) {
+	size := info.Size()
+	chunkCount := int((size + int64(streamChunkSize) - 1) / int64(streamChunkSize))
+	if chunkCount == 0 {
+		chunkCount = 1
+	}
+	streamID := generateStreamID(base.Path, info.ModTime(), size)
+	resources := make([]*FileContent, 0, chunkCount)
+	for i := 0; i < chunkCount; i++ {
+		offset := int64(i) * int64(streamChunkSize)
+		length := int64(streamChunkSize)
+		remaining := size - offset
+		if remaining < int64(streamChunkSize) {
+			length = remaining
+		}
+		reader, err := newFileChunkReader(path, offset, length)
+		if err != nil {
+			closeStreamReaders(resources)
+			return nil, err
+		}
+		chunk := base
+		chunk.Encoding = EncodingBase64
+		chunk.Stream = &FileStream{
+			ID:     streamID,
+			Part:   fmt.Sprintf("chunk-%s-%d", streamID, i),
+			Index:  i,
+			Count:  chunkCount,
+			Offset: offset,
+			Length: length,
+		}
+		chunk.setStreamReader(reader)
+		resources = append(resources, &chunk)
+	}
+	return resources, nil
+}
+
+func closeStreamReaders(resources []*FileContent) {
+	for _, resource := range resources {
+		if reader := resource.streamReader(); reader != nil {
+			reader.Close()
+		}
+	}
+}
+
+func generateStreamID(path string, modTime time.Time, size int64) string {
+	hash := sha1.New()
+	hash.Write([]byte(strings.ToLower(path)))
+	hash.Write([]byte{0})
+	hash.Write([]byte(modTime.UTC().Format(time.RFC3339Nano)))
+	hash.Write([]byte{0})
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(size))
+	hash.Write(length[:])
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func newFileChunkReader(path string, offset, length int64) (io.ReadCloser, error) {
+	if length == 0 {
+		return io.NopCloser(bytes.NewReader(nil)), nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := file.Seek(offset, io.SeekStart); err != nil {
+		file.Close()
+		return nil, err
+	}
+	return &fileChunkReader{file: file, reader: io.LimitReader(file, length)}, nil
+}
+
+type fileChunkReader struct {
+	file   *os.File
+	reader io.Reader
+}
+
+func (r *fileChunkReader) Read(p []byte) (int, error) {
+	return r.reader.Read(p)
+}
+
+func (r *fileChunkReader) Close() error {
+	return r.file.Close()
 }
 
 func determineEntryType(info fs.FileInfo) FileSystemEntryType {

--- a/tenvy-client/internal/modules/management/filemanager/types.go
+++ b/tenvy-client/internal/modules/management/filemanager/types.go
@@ -1,5 +1,7 @@
 package filemanager
 
+import "io"
+
 type FileSystemEntryType string
 
 const (
@@ -41,7 +43,19 @@ type FileContent struct {
 	Size       int64        `json:"size"`
 	ModifiedAt string       `json:"modifiedAt"`
 	Encoding   FileEncoding `json:"encoding"`
-	Content    string       `json:"content"`
+	Content    string       `json:"content,omitempty"`
+	Stream     *FileStream  `json:"stream,omitempty"`
+
+	reader io.ReadCloser `json:"-"`
+}
+
+type FileStream struct {
+	ID     string `json:"id"`
+	Part   string `json:"part"`
+	Index  int    `json:"index"`
+	Count  int    `json:"count"`
+	Offset int64  `json:"offset"`
+	Length int64  `json:"length"`
 }
 
 type FileManagerCommandPayload struct {
@@ -63,3 +77,11 @@ type Resource interface {
 
 func (DirectoryListing) isFileManagerResource() {}
 func (FileContent) isFileManagerResource()      {}
+
+func (f *FileContent) setStreamReader(r io.ReadCloser) {
+	f.reader = r
+}
+
+func (f *FileContent) streamReader() io.ReadCloser {
+	return f.reader
+}

--- a/tenvy-server/src/lib/server/rat/file-manager.test.ts
+++ b/tenvy-server/src/lib/server/rat/file-manager.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach, vi, afterEach } from 'vitest';
 import { FileManagerStore, FileManagerError } from './file-manager';
 import type { DirectoryListing } from '$lib/types/file-manager';
+import type { FileContent } from '$lib/types/file-manager';
 
 const baseDirectory = (path: string): DirectoryListing => ({
 	type: 'directory',
@@ -47,5 +48,98 @@ describe('FileManagerStore', () => {
 
 		const resource = store.getResource(agentId);
 		expect(resource).toMatchObject({ path: first.path });
+	});
+
+	it('assembles streamed file chunks before storing the file resource', () => {
+		const store = new FileManagerStore({ expirationMs: -1 });
+		const agentId = 'agent-stream';
+		const path = '/tmp/data.bin';
+
+		const firstChunk: FileContent = {
+			type: 'file',
+			root: '/',
+			path,
+			name: 'data.bin',
+			size: 6,
+			modifiedAt: '2024-01-01T00:00:00Z',
+			encoding: 'base64',
+			stream: {
+				id: 'stream-1',
+				part: 'chunk-stream-1-0',
+				index: 0,
+				count: 2,
+				offset: 0,
+				length: 3
+			}
+		};
+
+		store.ingestResource(agentId, firstChunk, Buffer.from([0x00, 0x01, 0x02]));
+		expect(() => store.getResource(agentId, path)).toThrow(FileManagerError);
+
+		const secondChunk: FileContent = {
+			...firstChunk,
+			stream: {
+				id: 'stream-1',
+				part: 'chunk-stream-1-1',
+				index: 1,
+				count: 2,
+				offset: 3,
+				length: 3
+			}
+		};
+
+		store.ingestResource(agentId, secondChunk, Buffer.from([0x03, 0x04, 0x05]));
+
+		const stored = store.getResource(agentId, path) as FileContent;
+		expect(stored.stream).toBeUndefined();
+		expect(stored.content).toBe(Buffer.from([0, 1, 2, 3, 4, 5]).toString('base64'));
+	});
+
+	it('allows resuming streamed uploads by re-sending completed chunks', () => {
+		const store = new FileManagerStore({ expirationMs: -1 });
+		const agentId = 'agent-resume';
+		const path = '/tmp/payload.bin';
+
+		const chunk: FileContent = {
+			type: 'file',
+			root: '/',
+			path,
+			name: 'payload.bin',
+			size: 4,
+			modifiedAt: '2024-01-01T00:00:00Z',
+			encoding: 'base64',
+			stream: {
+				id: 'stream-2',
+				part: 'chunk-stream-2-0',
+				index: 0,
+				count: 2,
+				offset: 0,
+				length: 2
+			}
+		};
+
+		const nextChunk: FileContent = {
+			...chunk,
+			stream: {
+				id: 'stream-2',
+				part: 'chunk-stream-2-1',
+				index: 1,
+				count: 2,
+				offset: 2,
+				length: 2
+			}
+		};
+
+		const firstPayload = Buffer.from([0xaa, 0xbb]);
+		store.ingestResource(agentId, chunk, firstPayload);
+
+		// Retry the first chunk (e.g., after a transient error) and ensure it is ignored without throwing.
+		expect(() => store.ingestResource(agentId, chunk, firstPayload)).not.toThrow();
+
+		const secondPayload = Buffer.from([0xcc, 0xdd]);
+		store.ingestResource(agentId, nextChunk, secondPayload);
+
+		const stored = store.getResource(agentId, path) as FileContent;
+		expect(stored.content).toBe(Buffer.concat([firstPayload, secondPayload]).toString('base64'));
 	});
 });

--- a/tenvy-server/src/routes/api/agents/[id]/file-manager/state/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/file-manager/state/+server.ts
@@ -9,10 +9,75 @@ interface FileManagerStatePayload {
 	clear?: boolean;
 }
 
+function collectResources(payload: FileManagerStatePayload): FileManagerResource[] {
+	const items: FileManagerResource[] = [];
+	if (payload.resource) {
+		items.push(payload.resource);
+	}
+	if (payload.resources?.length) {
+		items.push(...payload.resources);
+	}
+	return items;
+}
+
 export const POST: RequestHandler = async ({ params, request }) => {
 	const id = params.id;
 	if (!id) {
 		throw error(400, 'Missing agent identifier');
+	}
+
+	const contentType = request.headers.get('content-type') ?? '';
+
+	if (contentType.toLowerCase().includes('multipart/form-data')) {
+		const formData = await request.formData();
+		const metadata = formData.get('metadata');
+		if (typeof metadata !== 'string') {
+			throw error(400, 'File manager metadata part is required');
+		}
+
+		let payload: FileManagerStatePayload;
+		try {
+			payload = JSON.parse(metadata) as FileManagerStatePayload;
+		} catch {
+			throw error(400, 'Invalid file manager payload');
+		}
+
+		if (!payload || typeof payload !== 'object') {
+			throw error(400, 'File manager payload must be an object');
+		}
+
+		if (payload.clear) {
+			fileManagerStore.clearAgent(id);
+		}
+
+		const resources = collectResources(payload);
+		if (resources.length === 0) {
+			return json({ accepted: true, ingested: 0 });
+		}
+
+		const packages = await Promise.all(
+			resources.map(async (resource) => {
+				if (resource.type === 'file' && resource.stream) {
+					const part = formData.get(resource.stream.part);
+					if (!part || typeof (part as Blob).arrayBuffer !== 'function') {
+						throw error(400, `Missing file stream chunk: ${resource.stream.part}`);
+					}
+					const arrayBuffer = await (part as Blob).arrayBuffer();
+					return { resource, chunk: Buffer.from(arrayBuffer) };
+				}
+				return { resource };
+			})
+		);
+
+		try {
+			const ingested = fileManagerStore.ingestResources(id, packages);
+			return json({ accepted: true, ingested: ingested.length });
+		} catch (err) {
+			if (err instanceof FileManagerError) {
+				throw error(err.status, err.message);
+			}
+			throw error(500, 'Failed to ingest file manager resources');
+		}
 	}
 
 	let payload: FileManagerStatePayload;
@@ -30,20 +95,17 @@ export const POST: RequestHandler = async ({ params, request }) => {
 		fileManagerStore.clearAgent(id);
 	}
 
-	const items: FileManagerResource[] = [];
-	if (payload.resource) {
-		items.push(payload.resource);
-	}
-	if (payload.resources?.length) {
-		items.push(...payload.resources);
-	}
+	const items = collectResources(payload);
 
 	if (items.length === 0) {
 		return json({ accepted: true, ingested: 0 });
 	}
 
 	try {
-		const ingested = items.map((item) => fileManagerStore.ingestResource(id, item));
+		const ingested = fileManagerStore.ingestResources(
+			id,
+			items.map((resource) => ({ resource }))
+		);
 		return json({ accepted: true, ingested: ingested.length });
 	} catch (err) {
 		if (err instanceof FileManagerError) {


### PR DESCRIPTION
## Summary
- refactor the Go file manager module to stream file contents over multipart uploads and generate chunk metadata for large files
- extend the shared file manager schema and server-side store to validate stream descriptors, assemble chunked uploads, and track resumable transfers
- update the file manager state endpoint to accept multipart payloads and add store tests that cover chunk assembly and retry behaviour

## Testing
- `go test ./internal/modules/management/filemanager`
- `bun test` *(fails: requires vitest browser/timers support in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f7c1c56714832b876d1fc2c205d60e