### PR TITLE
Refactor remote desktop module to use engine interface

### DIFF
--- a/tenvy-client/internal/agent/command_stream_test.go
+++ b/tenvy-client/internal/agent/command_stream_test.go
@@ -289,7 +289,7 @@ func TestCommandStreamRequestsReconnectOnUnauthorized(t *testing.T) {
 func TestStopRemoteDesktopInputWorkerSignalsShutdown(t *testing.T) {
 	agent := &Agent{
 		logger:  log.New(io.Discard, "", 0),
-		modules: &moduleManager{remote: &remoteDesktopModule{}},
+		modules: &moduleManager{remote: newRemoteDesktopModule()},
 	}
 
 	queue := agent.ensureRemoteDesktopInputWorker()
@@ -314,7 +314,7 @@ func TestStopRemoteDesktopInputWorkerSignalsShutdown(t *testing.T) {
 func TestHandleRemoteDesktopInputAfterStopReturnsImmediately(t *testing.T) {
 	agent := &Agent{
 		logger:  log.New(io.Discard, "", 0),
-		modules: &moduleManager{remote: &remoteDesktopModule{}},
+		modules: &moduleManager{remote: newRemoteDesktopModule()},
 	}
 
 	if agent.ensureRemoteDesktopInputWorker() == nil {
@@ -341,7 +341,7 @@ func TestHandleRemoteDesktopInputAfterStopReturnsImmediately(t *testing.T) {
 func TestStopRemoteDesktopInputWorkerBeforeStart(t *testing.T) {
 	agent := &Agent{
 		logger:  log.New(io.Discard, "", 0),
-		modules: &moduleManager{remote: &remoteDesktopModule{}},
+		modules: &moduleManager{remote: newRemoteDesktopModule()},
 	}
 
 	agent.stopRemoteDesktopInputWorker()

--- a/tenvy-client/internal/modules/control/remotedesktop/types.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/types.go
@@ -376,9 +376,20 @@ type remoteMonitor struct {
 	bounds image.Rectangle
 }
 
+type Engine interface {
+	Configure(Config) error
+	StartSession(context.Context, RemoteDesktopCommandPayload) error
+	StopSession(string) error
+	UpdateSession(RemoteDesktopCommandPayload) error
+	HandleInput(context.Context, RemoteDesktopCommandPayload) error
+	Shutdown()
+}
+
 type RemoteDesktopStreamer struct {
 	controller *remoteDesktopSessionController
 }
+
+var _ Engine = (*RemoteDesktopStreamer)(nil)
 
 type remoteDesktopSessionController struct {
 	cfg            atomic.Value // stores Config


### PR DESCRIPTION
## Summary
- add a dedicated Engine interface for the remote desktop subsystem and have the streamer satisfy it
- refactor the remote desktop module to resolve engines through a factory and operate through the interface
- adjust remote desktop command decoding and tests to use the new module constructor

## Testing
- go test ./internal/agent -run TestStopRemoteDesktopInputWorkerSignalsShutdown -count=1


------
https://chatgpt.com/codex/tasks/task_e_68f7eb3d1758832bbc9c632b4ccd9fed