### PR TITLE
Enforce build port range validation

### DIFF
--- a/tenvy-server/src/routes/(app)/build/+page.svelte
+++ b/tenvy-server/src/routes/(app)/build/+page.svelte
@@ -464,12 +464,21 @@
 			buildStatus = 'error';
 			return;
 		}
-		if (trimmedPort && !/^\d+$/.test(trimmedPort)) {
-			buildError = 'Port must be numeric.';
-			pushProgress(buildError, 'error');
-			buildStatus = 'error';
-			return;
-		}
+                if (trimmedPort && !/^\d+$/.test(trimmedPort)) {
+                        buildError = 'Port must be numeric.';
+                        pushProgress(buildError, 'error');
+                        buildStatus = 'error';
+                        return;
+                }
+                if (trimmedPort) {
+                        const numericPort = Number.parseInt(trimmedPort, 10);
+                        if (numericPort < 1 || numericPort > 65535) {
+                                buildError = 'Port must be between 1 and 65535.';
+                                pushProgress(buildError, 'error');
+                                buildStatus = 'error';
+                                return;
+                        }
+                }
 		if (trimmedPollInterval) {
 			const pollValue = Number(trimmedPollInterval);
 			if (!Number.isFinite(pollValue) || pollValue < 1000 || pollValue > 3_600_000) {

--- a/tenvy-server/src/routes/(app)/build/build-page.svelte.spec.ts
+++ b/tenvy-server/src/routes/(app)/build/build-page.svelte.spec.ts
@@ -1,0 +1,64 @@
+import { page } from '@vitest/browser/context';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { tick } from 'svelte';
+
+vi.mock('$app/environment', () => ({ browser: true }));
+
+const toast = Object.assign(vi.fn(), {
+        success: vi.fn(),
+        error: vi.fn(),
+        dismiss: vi.fn()
+});
+
+vi.mock('svelte-sonner', () => ({ toast }));
+
+import BuildPage from './+page.svelte';
+
+const originalFetch = globalThis.fetch;
+
+describe('build page port validation', () => {
+        beforeEach(() => {
+                globalThis.fetch = vi.fn();
+                toast.mockClear();
+                toast.success.mockClear();
+                toast.error.mockClear();
+                toast.dismiss.mockClear();
+        });
+
+        afterEach(() => {
+                if (originalFetch) {
+                        globalThis.fetch = originalFetch;
+                } else {
+                        // @ts-expect-error - cleaning up test shim
+                        delete globalThis.fetch;
+                }
+        });
+
+        it('prevents build requests when the port falls outside the allowed range', async () => {
+                const { component } = render(BuildPage);
+
+                const portInput = document.getElementById('port') as HTMLInputElement | null;
+                expect(portInput).toBeTruthy();
+                if (!portInput) {
+                        throw new Error('Port input not found');
+                }
+
+                portInput.value = '70000';
+                portInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+                const buildButton = page.getByRole('button', { name: 'Build Agent' });
+                buildButton.click();
+
+                await tick();
+                await tick();
+
+                expect(globalThis.fetch).not.toHaveBeenCalled();
+                expect(toast.error).toHaveBeenCalledWith(
+                        'Port must be between 1 and 65535.',
+                        expect.objectContaining({ position: 'bottom-right' })
+                );
+
+                component.$destroy();
+        });
+});

--- a/tenvy-server/src/routes/api/build/normalizer.ts
+++ b/tenvy-server/src/routes/api/build/normalizer.ts
@@ -252,10 +252,16 @@ export function normalizeBuildRequestPayload(body: unknown): NormalizedBuildRequ
 		throw error(400, 'Host cannot contain whitespace');
 	}
 
-	const port = parsed.port !== undefined ? parsed.port.toString().trim() : '2332';
-	if (!/^\d+$/.test(port)) {
-		throw error(400, 'Port must be numeric');
-	}
+        let port = parsed.port !== undefined ? parsed.port.toString().trim() : '2332';
+        if (!/^\d+$/.test(port)) {
+                throw error(400, 'Port must be numeric');
+        }
+
+        const numericPort = Number.parseInt(port, 10);
+        if (numericPort < 1 || numericPort > 65535) {
+                throw error(400, 'Port must be between 1 and 65535');
+        }
+        port = String(numericPort);
 
 	const targetOS = resolveTargetOS(parsed.targetOS);
 	const targetArch = resolveTargetArch(parsed.targetArch, targetOS);

--- a/tenvy-server/tests/build-api.test.ts
+++ b/tenvy-server/tests/build-api.test.ts
@@ -51,21 +51,39 @@ describe('normalizeBuildRequestPayload', () => {
 		}
 	});
 
-	it('rejects payloads containing unsupported fields', () => {
-		try {
-			normalizeBuildRequestPayload({
-				host: 'example.local',
-				binder: { enabled: true }
-			});
-			throw new Error('Expected payload validation to fail');
-		} catch (error) {
-			const err = error as HttpError;
-			expect(err.status).toBe(400);
-			const message =
-				typeof err.body === 'object' && err.body && 'message' in err.body
-					? String(err.body.message)
-					: String(err);
-			expect(message).toContain('binder');
-		}
-	});
+        it('rejects payloads containing unsupported fields', () => {
+                try {
+                        normalizeBuildRequestPayload({
+                                host: 'example.local',
+                                binder: { enabled: true }
+                        });
+                        throw new Error('Expected payload validation to fail');
+                } catch (error) {
+                        const err = error as HttpError;
+                        expect(err.status).toBe(400);
+                        const message =
+                                typeof err.body === 'object' && err.body && 'message' in err.body
+                                        ? String(err.body.message)
+                                        : String(err);
+                        expect(message).toContain('binder');
+                }
+        });
+
+        it('rejects ports outside the allowed range', () => {
+                try {
+                        normalizeBuildRequestPayload({
+                                host: 'example.local',
+                                port: 70000
+                        });
+                        throw new Error('Expected payload validation to fail');
+                } catch (error) {
+                        const err = error as HttpError;
+                        expect(err.status).toBe(400);
+                        const message =
+                                typeof err.body === 'object' && err.body && 'message' in err.body
+                                        ? String(err.body.message)
+                                        : String(err);
+                        expect(message).toContain('Port must be between 1 and 65535');
+                }
+        });
 });


### PR DESCRIPTION
## Summary
- tighten the build page validation to reject ports outside 1-65535 and show a clear error toast
- enforce the same port range on the build API normalizer so out-of-range values return 400s
- extend Vitest suites with API and browser-side coverage for the new validation

## Testing
- bun test:unit -- --run tests/build-api.test.ts 'src/routes/(app)/build/build-page.svelte.spec.ts'
- ENABLE_BROWSER_TESTS=true bun test:unit -- --run 'src/routes/(app)/build/build-page.svelte.spec.ts' *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f7eb4964e4832b8fcbfc0e1f8d0dd6