### PR TITLE
Refactor remote desktop engine abstraction

### DIFF
--- a/tenvy-client/internal/agent/command_stream_test.go
+++ b/tenvy-client/internal/agent/command_stream_test.go
@@ -12,9 +12,28 @@ import (
 	"testing"
 	"time"
 
+	remotedesktop "github.com/rootbay/tenvy-client/internal/modules/control/remotedesktop"
 	"github.com/rootbay/tenvy-client/internal/protocol"
 	"nhooyr.io/websocket"
 )
+
+type stubRemoteDesktopEngine struct{}
+
+func (stubRemoteDesktopEngine) Configure(remotedesktop.Config) error { return nil }
+func (stubRemoteDesktopEngine) StartSession(context.Context, remotedesktop.RemoteDesktopCommandPayload) error {
+	return nil
+}
+func (stubRemoteDesktopEngine) StopSession(string) error { return nil }
+func (stubRemoteDesktopEngine) UpdateSession(remotedesktop.RemoteDesktopCommandPayload) error {
+	return nil
+}
+func (stubRemoteDesktopEngine) HandleInput(context.Context, remotedesktop.RemoteDesktopCommandPayload) error {
+	return nil
+}
+func (stubRemoteDesktopEngine) DeliverFrame(context.Context, remotedesktop.RemoteDesktopFramePacket) error {
+	return nil
+}
+func (stubRemoteDesktopEngine) Shutdown() {}
 
 func makeTestAgent(baseURL string, client *http.Client, router *commandRouter) *Agent {
 	return &Agent{
@@ -289,7 +308,7 @@ func TestCommandStreamRequestsReconnectOnUnauthorized(t *testing.T) {
 func TestStopRemoteDesktopInputWorkerSignalsShutdown(t *testing.T) {
 	agent := &Agent{
 		logger:  log.New(io.Discard, "", 0),
-		modules: &moduleManager{remote: newRemoteDesktopModule()},
+		modules: &moduleManager{remote: newRemoteDesktopModule(stubRemoteDesktopEngine{})},
 	}
 
 	queue := agent.ensureRemoteDesktopInputWorker()
@@ -314,7 +333,7 @@ func TestStopRemoteDesktopInputWorkerSignalsShutdown(t *testing.T) {
 func TestHandleRemoteDesktopInputAfterStopReturnsImmediately(t *testing.T) {
 	agent := &Agent{
 		logger:  log.New(io.Discard, "", 0),
-		modules: &moduleManager{remote: newRemoteDesktopModule()},
+		modules: &moduleManager{remote: newRemoteDesktopModule(stubRemoteDesktopEngine{})},
 	}
 
 	if agent.ensureRemoteDesktopInputWorker() == nil {
@@ -341,7 +360,7 @@ func TestHandleRemoteDesktopInputAfterStopReturnsImmediately(t *testing.T) {
 func TestStopRemoteDesktopInputWorkerBeforeStart(t *testing.T) {
 	agent := &Agent{
 		logger:  log.New(io.Discard, "", 0),
-		modules: &moduleManager{remote: newRemoteDesktopModule()},
+		modules: &moduleManager{remote: newRemoteDesktopModule(stubRemoteDesktopEngine{})},
 	}
 
 	agent.stopRemoteDesktopInputWorker()

--- a/tenvy-client/internal/agent/modules.go
+++ b/tenvy-client/internal/agent/modules.go
@@ -127,7 +127,7 @@ type moduleManager struct {
 func newDefaultModuleManager() *moduleManager {
 	registry := newModuleManager()
 	registry.register(&appVncModule{})
-	registry.register(newRemoteDesktopModule())
+	registry.register(newRemoteDesktopModule(nil))
 	registry.register(&audioModule{})
 	registry.register(&clipboardModule{})
 	registry.register(&fileManagerModule{})
@@ -336,8 +336,12 @@ type remoteDesktopModule struct {
 	factory      remoteDesktopEngineFactory
 }
 
-func newRemoteDesktopModule() *remoteDesktopModule {
-	return &remoteDesktopModule{factory: defaultRemoteDesktopEngineFactory}
+func newRemoteDesktopModule(engine remotedesktop.Engine) *remoteDesktopModule {
+	module := &remoteDesktopModule{factory: defaultRemoteDesktopEngineFactory}
+	if engine != nil {
+		module.engine = engine
+	}
+	return module
 }
 
 func (m *remoteDesktopModule) Metadata() ModuleMetadata {

--- a/tenvy-client/internal/agent/modules_test.go
+++ b/tenvy-client/internal/agent/modules_test.go
@@ -2,10 +2,12 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 
+	remotedesktop "github.com/rootbay/tenvy-client/internal/modules/control/remotedesktop"
 	"github.com/rootbay/tenvy-client/internal/protocol"
 )
 
@@ -153,5 +155,163 @@ func TestModuleManagerLifecycle(t *testing.T) {
 	}
 	if metadata[0].ID != "module-a" || metadata[1].ID != "module-b" {
 		t.Fatalf("unexpected metadata ordering: %+v", metadata)
+	}
+}
+
+type fakeRemoteDesktopEngine struct {
+	configureCalls []remotedesktop.Config
+	startCalls     []remotedesktop.RemoteDesktopCommandPayload
+	stopCalls      []string
+	updateCalls    []remotedesktop.RemoteDesktopCommandPayload
+	inputCalls     []remotedesktop.RemoteDesktopCommandPayload
+	deliverCalls   []remotedesktop.RemoteDesktopFramePacket
+	shutdownCalled bool
+
+	configureErr error
+	startErr     error
+	stopErr      error
+	updateErr    error
+	inputErr     error
+	deliverErr   error
+}
+
+func (f *fakeRemoteDesktopEngine) Configure(cfg remotedesktop.Config) error {
+	f.configureCalls = append(f.configureCalls, cfg)
+	return f.configureErr
+}
+
+func (f *fakeRemoteDesktopEngine) StartSession(ctx context.Context, payload remotedesktop.RemoteDesktopCommandPayload) error {
+	f.startCalls = append(f.startCalls, payload)
+	return f.startErr
+}
+
+func (f *fakeRemoteDesktopEngine) StopSession(sessionID string) error {
+	f.stopCalls = append(f.stopCalls, sessionID)
+	return f.stopErr
+}
+
+func (f *fakeRemoteDesktopEngine) UpdateSession(payload remotedesktop.RemoteDesktopCommandPayload) error {
+	f.updateCalls = append(f.updateCalls, payload)
+	return f.updateErr
+}
+
+func (f *fakeRemoteDesktopEngine) HandleInput(ctx context.Context, payload remotedesktop.RemoteDesktopCommandPayload) error {
+	f.inputCalls = append(f.inputCalls, payload)
+	return f.inputErr
+}
+
+func (f *fakeRemoteDesktopEngine) DeliverFrame(ctx context.Context, frame remotedesktop.RemoteDesktopFramePacket) error {
+	f.deliverCalls = append(f.deliverCalls, frame)
+	return f.deliverErr
+}
+
+func (f *fakeRemoteDesktopEngine) Shutdown() {
+	f.shutdownCalled = true
+}
+
+func TestRemoteDesktopModuleInitUsesInjectedEngine(t *testing.T) {
+	t.Parallel()
+
+	engine := &fakeRemoteDesktopEngine{}
+	module := newRemoteDesktopModule(engine)
+
+	runtime := ModuleRuntime{AgentID: "agent-1", BaseURL: "https://controller.example"}
+	if err := module.Init(context.Background(), runtime); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+	if len(engine.configureCalls) != 1 {
+		t.Fatalf("expected configure to be called once, got %d", len(engine.configureCalls))
+	}
+
+	runtime.AuthKey = "key"
+	if err := module.UpdateConfig(context.Background(), runtime); err != nil {
+		t.Fatalf("UpdateConfig returned error: %v", err)
+	}
+	if len(engine.configureCalls) != 2 {
+		t.Fatalf("expected configure to be called twice, got %d", len(engine.configureCalls))
+	}
+}
+
+func TestRemoteDesktopModuleDelegatesCommandsToEngine(t *testing.T) {
+	t.Parallel()
+
+	engine := &fakeRemoteDesktopEngine{}
+	module := newRemoteDesktopModule(engine)
+
+	runtime := ModuleRuntime{AgentID: "agent-1"}
+	if err := module.Init(context.Background(), runtime); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+
+	ctx := context.Background()
+
+	startPayload := remotedesktop.RemoteDesktopCommandPayload{Action: "start", SessionID: "session-1"}
+	rawStart, err := json.Marshal(startPayload)
+	if err != nil {
+		t.Fatalf("marshal start payload: %v", err)
+	}
+	result := module.Handle(ctx, protocol.Command{ID: "start", Name: "remote-desktop", Payload: rawStart})
+	if !result.Success {
+		t.Fatalf("expected start to succeed, got result: %+v", result)
+	}
+	if len(engine.startCalls) != 1 || engine.startCalls[0].SessionID != "session-1" {
+		t.Fatalf("expected start payload to be forwarded, got %+v", engine.startCalls)
+	}
+
+	stopPayload := remotedesktop.RemoteDesktopCommandPayload{Action: "stop", SessionID: "session-1"}
+	rawStop, err := json.Marshal(stopPayload)
+	if err != nil {
+		t.Fatalf("marshal stop payload: %v", err)
+	}
+	_ = module.Handle(ctx, protocol.Command{ID: "stop", Name: "remote-desktop", Payload: rawStop})
+	if len(engine.stopCalls) != 1 || engine.stopCalls[0] != "session-1" {
+		t.Fatalf("expected stop payload to be forwarded, got %+v", engine.stopCalls)
+	}
+
+	updatePayload := remotedesktop.RemoteDesktopCommandPayload{Action: "configure", SessionID: "session-1"}
+	rawUpdate, err := json.Marshal(updatePayload)
+	if err != nil {
+		t.Fatalf("marshal configure payload: %v", err)
+	}
+	_ = module.Handle(ctx, protocol.Command{ID: "configure", Name: "remote-desktop", Payload: rawUpdate})
+	if len(engine.updateCalls) != 1 {
+		t.Fatalf("expected configure payload to be forwarded, got %d calls", len(engine.updateCalls))
+	}
+
+	inputPayload := remotedesktop.RemoteDesktopCommandPayload{
+		Action:    "input",
+		SessionID: "session-1",
+		Events: []remotedesktop.RemoteDesktopInputEvent{{
+			Type: remotedesktop.RemoteInputMouseMove,
+		}},
+	}
+	rawInput, err := json.Marshal(inputPayload)
+	if err != nil {
+		t.Fatalf("marshal input payload: %v", err)
+	}
+	_ = module.Handle(ctx, protocol.Command{ID: "input", Name: "remote-desktop", Payload: rawInput})
+	if len(engine.inputCalls) != 1 {
+		t.Fatalf("expected input payload to be forwarded once, got %d calls", len(engine.inputCalls))
+	}
+
+	burstErr := module.HandleInputBurst(ctx, protocol.RemoteDesktopInputBurst{
+		SessionID: "session-1",
+		Events: []protocol.RemoteDesktopInputEvent{{
+			Type:   string(remotedesktop.RemoteInputMouseMove),
+			X:      1,
+			Y:      2,
+			Repeat: false,
+		}},
+	})
+	if burstErr != nil {
+		t.Fatalf("HandleInputBurst returned error: %v", burstErr)
+	}
+	if len(engine.inputCalls) != 2 {
+		t.Fatalf("expected burst to forward input payload, got %d calls", len(engine.inputCalls))
+	}
+
+	module.Shutdown(ctx)
+	if !engine.shutdownCalled {
+		t.Fatal("expected Shutdown to invoke engine")
 	}
 }

--- a/tenvy-client/internal/modules/control/remotedesktop/types.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/types.go
@@ -382,6 +382,7 @@ type Engine interface {
 	StopSession(string) error
 	UpdateSession(RemoteDesktopCommandPayload) error
 	HandleInput(context.Context, RemoteDesktopCommandPayload) error
+	DeliverFrame(context.Context, RemoteDesktopFramePacket) error
 	Shutdown()
 }
 


### PR DESCRIPTION
## Summary
- extend the remote desktop engine contract to cover frame delivery and implement the adapter on top of the existing controller
- allow the agent remote desktop module to accept an injected engine and update command stream tests to rely on a stub implementation
- add unit coverage asserting the module forwards actions and input bursts to the injected engine

## Testing
- `go test ./internal/agent` *(fails: command hung in the CI sandbox)*
- `go test ./internal/modules/control/remotedesktop -run TestRemoteDesktopModuleDelegatesCommandsToEngine -count=1` *(fails: command hung in the CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68f7f1051484832b8c3071c4db1a9222