### PR TITLE
Add remote desktop engine staging and lifecycle support

### DIFF
--- a/tenvy-client/internal/agent/modules_test.go
+++ b/tenvy-client/internal/agent/modules_test.go
@@ -297,7 +297,7 @@ func TestRemoteDesktopModuleDelegatesCommandsToEngine(t *testing.T) {
 	burstErr := module.HandleInputBurst(ctx, protocol.RemoteDesktopInputBurst{
 		SessionID: "session-1",
 		Events: []protocol.RemoteDesktopInputEvent{{
-			Type:   string(remotedesktop.RemoteInputMouseMove),
+			Type:   protocol.RemoteDesktopInputType(remotedesktop.RemoteInputMouseMove),
 			X:      1,
 			Y:      2,
 			Repeat: false,

--- a/tenvy-client/internal/modules/control/remotedesktop/remotedesktop.go
+++ b/tenvy-client/internal/modules/control/remotedesktop/remotedesktop.go
@@ -75,7 +75,8 @@ const (
 )
 
 var (
-	SetClipEncoderProfiler   = engine.SetClipEncoderProfiler
-	NewRemoteDesktopStreamer = engine.NewRemoteDesktopStreamer
-	DecodeCommandPayload     = engine.DecodeCommandPayload
+	SetClipEncoderProfiler        = engine.SetClipEncoderProfiler
+	NewRemoteDesktopStreamer      = engine.NewRemoteDesktopStreamer
+	NewManagedRemoteDesktopEngine = engine.NewManagedRemoteDesktopEngine
+	DecodeCommandPayload          = engine.DecodeCommandPayload
 )

--- a/tenvy-client/internal/plugins/engines/remotedesktop/external.go
+++ b/tenvy-client/internal/plugins/engines/remotedesktop/external.go
@@ -1,0 +1,340 @@
+package remotedesktopengine
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rootbay/tenvy-client/internal/plugins"
+	manifest "github.com/rootbay/tenvy-client/shared/pluginmanifest"
+)
+
+type managedEngine struct {
+	inner   Engine
+	process *engineProcess
+}
+
+// NewManagedRemoteDesktopEngine wraps the provided engine implementation with a
+// lifecycle manager that ensures the external remote desktop engine binary is
+// launched when sessions start and torn down when they conclude. If the plugin
+// entry path is empty or the manager is nil, the underlying engine is returned
+// unchanged.
+func NewManagedRemoteDesktopEngine(inner Engine, entryPath, version string, manager *plugins.Manager, logger Logger) Engine {
+	entryPath = strings.TrimSpace(entryPath)
+	if entryPath == "" || manager == nil {
+		return inner
+	}
+	process := newEngineProcess(entryPath, version, manager, logger)
+	return &managedEngine{inner: inner, process: process}
+}
+
+func (e *managedEngine) Configure(cfg Config) error {
+	if e == nil || e.inner == nil {
+		return errors.New("remote desktop subsystem not initialized")
+	}
+	return e.inner.Configure(cfg)
+}
+
+func (e *managedEngine) StartSession(ctx context.Context, payload RemoteDesktopCommandPayload) error {
+	if e == nil || e.inner == nil {
+		return errors.New("remote desktop subsystem not initialized")
+	}
+	if err := e.process.start(payload.SessionID); err != nil {
+		return err
+	}
+	if err := e.inner.StartSession(ctx, payload); err != nil {
+		_ = e.process.stop()
+		return err
+	}
+	return nil
+}
+
+func (e *managedEngine) StopSession(sessionID string) error {
+	if e == nil || e.inner == nil {
+		return errors.New("remote desktop subsystem not initialized")
+	}
+	var stopErr error
+	if err := e.inner.StopSession(sessionID); err != nil {
+		stopErr = err
+	}
+	if err := e.process.stop(); err != nil && stopErr == nil {
+		stopErr = err
+	}
+	return stopErr
+}
+
+func (e *managedEngine) UpdateSession(payload RemoteDesktopCommandPayload) error {
+	if e == nil || e.inner == nil {
+		return errors.New("remote desktop subsystem not initialized")
+	}
+	return e.inner.UpdateSession(payload)
+}
+
+func (e *managedEngine) HandleInput(ctx context.Context, payload RemoteDesktopCommandPayload) error {
+	if e == nil || e.inner == nil {
+		return errors.New("remote desktop subsystem not initialized")
+	}
+	return e.inner.HandleInput(ctx, payload)
+}
+
+func (e *managedEngine) DeliverFrame(ctx context.Context, frame RemoteDesktopFramePacket) error {
+	if e == nil || e.inner == nil {
+		return errors.New("remote desktop subsystem not initialized")
+	}
+	return e.inner.DeliverFrame(ctx, frame)
+}
+
+func (e *managedEngine) Shutdown() {
+	if e == nil {
+		return
+	}
+	if e.inner != nil {
+		e.inner.Shutdown()
+	}
+	e.process.shutdown()
+}
+
+type engineProcess struct {
+	path    string
+	version string
+	manager *plugins.Manager
+	logger  Logger
+
+	mu       sync.Mutex
+	cmd      *exec.Cmd
+	cancel   context.CancelFunc
+	done     chan error
+	stopping bool
+	output   *processOutputBuffer
+}
+
+func newEngineProcess(path, version string, manager *plugins.Manager, logger Logger) *engineProcess {
+	return &engineProcess{
+		path:    strings.TrimSpace(path),
+		version: strings.TrimSpace(version),
+		manager: manager,
+		logger:  logger,
+	}
+}
+
+func (p *engineProcess) start(sessionID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cmd != nil {
+		if p.done != nil {
+			select {
+			case <-p.done:
+				p.resetLocked()
+			default:
+				return nil
+			}
+		} else {
+			return nil
+		}
+	}
+
+	if strings.TrimSpace(p.path) == "" {
+		message := "engine entry path not configured"
+		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallFailed, message)
+		return errors.New(message)
+	}
+
+	if info, err := os.Stat(p.path); err != nil {
+		message := fmt.Sprintf("engine binary unavailable: %v", err)
+		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallFailed, message)
+		return errors.New(message)
+	} else if info.IsDir() {
+		message := "engine entry path resolves to a directory"
+		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallFailed, message)
+		return errors.New(message)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, p.path)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("TENVY_REMOTE_DESKTOP_SESSION_ID=%s", strings.TrimSpace(sessionID)))
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		message := fmt.Sprintf("engine stdout pipe: %v", err)
+		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallFailed, message)
+		return errors.New(message)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		stdout.Close()
+		cancel()
+		message := fmt.Sprintf("engine stderr pipe: %v", err)
+		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallFailed, message)
+		return errors.New(message)
+	}
+
+	if err := cmd.Start(); err != nil {
+		stdout.Close()
+		stderr.Close()
+		cancel()
+		message := fmt.Sprintf("engine launch failed: %v", err)
+		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallFailed, message)
+		return fmt.Errorf("remote desktop engine launch: %w", err)
+	}
+
+	plugins.ClearInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID)
+
+	p.cmd = cmd
+	p.cancel = cancel
+	p.done = make(chan error, 1)
+	p.stopping = false
+	p.output = newProcessOutputBuffer(4096)
+
+	go p.captureStream("stdout", stdout)
+	go p.captureStream("stderr", stderr)
+	go p.wait(cmd)
+
+	return nil
+}
+
+func (p *engineProcess) stop() error {
+	p.mu.Lock()
+	cmd := p.cmd
+	cancel := p.cancel
+	done := p.done
+	if cmd == nil {
+		p.mu.Unlock()
+		return nil
+	}
+	p.stopping = true
+	p.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+
+	var waitErr error
+	if done != nil {
+		select {
+		case waitErr = <-done:
+		case <-time.After(5 * time.Second):
+			p.mu.Lock()
+			if p.cmd != nil && p.cmd.Process != nil {
+				_ = p.cmd.Process.Kill()
+			}
+			p.mu.Unlock()
+			if done != nil {
+				waitErr = <-done
+			}
+		}
+	}
+
+	plugins.ClearInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID)
+	return waitErr
+}
+
+func (p *engineProcess) shutdown() {
+	_ = p.stop()
+}
+
+func (p *engineProcess) wait(cmd *exec.Cmd) {
+	err := cmd.Wait()
+
+	p.mu.Lock()
+	done := p.done
+	stopping := p.stopping
+	buffer := p.output
+	logger := p.logger
+	version := p.version
+	p.resetLocked()
+	p.mu.Unlock()
+
+	if done != nil {
+		done <- err
+	}
+
+	if stopping {
+		return
+	}
+
+	output := ""
+	if buffer != nil {
+		output = buffer.String()
+	}
+
+	var message string
+	if err != nil {
+		message = fmt.Sprintf("engine process exited: %v", err)
+	} else {
+		message = "engine process exited unexpectedly"
+	}
+	if output != "" {
+		message = fmt.Sprintf("%s; output: %s", message, output)
+	}
+
+	plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, version, manifest.InstallFailed, message)
+	if logger != nil {
+		logger.Printf("remote desktop engine: %s", message)
+	}
+}
+
+func (p *engineProcess) captureStream(stream string, reader io.Reader) {
+	scanner := bufio.NewScanner(reader)
+	buf := make([]byte, 0, 4096)
+	scanner.Buffer(buf, 1<<20)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if p.output != nil {
+			p.output.append(line)
+		}
+		if p.logger != nil {
+			p.logger.Printf("remote desktop engine %s: %s", stream, line)
+		}
+	}
+}
+
+func (p *engineProcess) resetLocked() {
+	p.cmd = nil
+	p.cancel = nil
+	p.done = nil
+	p.output = nil
+	p.stopping = false
+}
+
+type processOutputBuffer struct {
+	mu    sync.Mutex
+	data  []byte
+	limit int
+}
+
+func newProcessOutputBuffer(limit int) *processOutputBuffer {
+	return &processOutputBuffer{limit: limit}
+}
+
+func (b *processOutputBuffer) append(line string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.limit <= 0 {
+		return
+	}
+	payload := append([]byte(line), '\n')
+	if len(payload) >= b.limit {
+		b.data = append([]byte(nil), payload[len(payload)-b.limit:]...)
+		return
+	}
+	if len(b.data)+len(payload) > b.limit {
+		overflow := len(b.data) + len(payload) - b.limit
+		b.data = b.data[overflow:]
+	}
+	b.data = append(b.data, payload...)
+}
+
+func (b *processOutputBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return strings.TrimSpace(string(b.data))
+}

--- a/tenvy-client/internal/plugins/remotedesktop.go
+++ b/tenvy-client/internal/plugins/remotedesktop.go
@@ -1,0 +1,373 @@
+package plugins
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	manifest "github.com/rootbay/tenvy-client/shared/pluginmanifest"
+)
+
+// RemoteDesktopEnginePluginID identifies the managed remote desktop engine plugin.
+const RemoteDesktopEnginePluginID = "remote-desktop-engine"
+
+// HTTPDoer represents a minimal HTTP client.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// RemoteDesktopStageResult describes the outcome of a staging attempt for the
+// remote desktop engine.
+type RemoteDesktopStageResult struct {
+	EntryPath string
+	Manifest  manifest.Manifest
+	Updated   bool
+}
+
+// StageRemoteDesktopEngine ensures the remote desktop engine plugin is staged on
+// disk, verifying signatures and hashes before unpacking the artifact into the
+// plugin root. The returned result describes the installed manifest and the
+// resolved entry path for launching the engine binary.
+func StageRemoteDesktopEngine(
+	ctx context.Context,
+	manager *Manager,
+	client HTTPDoer,
+	baseURL, agentID, authKey, userAgent string,
+) (RemoteDesktopStageResult, error) {
+	var result RemoteDesktopStageResult
+
+	if manager == nil {
+		return result, errors.New("plugin manager not initialized")
+	}
+	if client == nil {
+		return result, errors.New("http client not provided")
+	}
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		return result, errors.New("controller base url not provided")
+	}
+	agentID = strings.TrimSpace(agentID)
+	if agentID == "" {
+		return result, errors.New("agent identifier not provided")
+	}
+
+	logger := manager.logger
+	manager.stageMu.Lock()
+	defer manager.stageMu.Unlock()
+
+	if err := os.MkdirAll(manager.root, 0o755); err != nil {
+		return result, fmt.Errorf("ensure plugin root: %w", err)
+	}
+
+	pluginDir := filepath.Join(manager.root, RemoteDesktopEnginePluginID)
+	manifestURL, artifactURL := remoteDesktopEndpoints(baseURL, agentID)
+
+	manifestData, mf, err := fetchRemoteDesktopManifest(ctx, client, manifestURL, authKey, userAgent)
+	if err != nil {
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, "", manifest.InstallFailed, err.Error())
+		return result, err
+	}
+
+	result.Manifest = mf
+
+	verificationResult, verifyErr := manifest.VerifySignature(mf, manager.verificationOptions())
+	if verifyErr != nil {
+		message := fmt.Sprintf("signature verification failed: %s", signatureErrorMessage(verifyErr))
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallBlocked, message)
+		return result, fmt.Errorf(message)
+	}
+	if verificationResult == nil || !verificationResult.Trusted {
+		message := fmt.Sprintf("signature not trusted: %s", signatureUntrustedReason(mf, verificationResult))
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallBlocked, message)
+		return result, errors.New(message)
+	}
+
+	artifactRel := filepath.Clean(filepath.FromSlash(mf.Package.Artifact))
+	if artifactRel == "" || strings.HasPrefix(artifactRel, "..") {
+		message := "manifest artifact path is invalid"
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallFailed, message)
+		return result, errors.New(message)
+	}
+	entryRel := filepath.Clean(filepath.FromSlash(mf.Entry))
+	if entryRel == "" || strings.HasPrefix(entryRel, "..") {
+		message := "manifest entry path is invalid"
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallFailed, message)
+		return result, errors.New(message)
+	}
+
+	manifestPath := filepath.Join(pluginDir, manifestFileName)
+	artifactPath := filepath.Join(pluginDir, artifactRel)
+	entryPath := filepath.Join(pluginDir, entryRel)
+
+	if upToDate, err := installationUpToDate(manifestPath, artifactPath, entryPath, manifestData, mf); err == nil && upToDate {
+		result.EntryPath = entryPath
+		result.Updated = false
+		return result, nil
+	}
+
+	stagingDir, err := os.MkdirTemp(manager.root, "remote-desktop-engine-")
+	if err != nil {
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallFailed, fmt.Sprintf("create staging directory: %v", err))
+		return result, fmt.Errorf("create staging directory: %w", err)
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			os.RemoveAll(stagingDir)
+		}
+	}()
+
+	stagingManifest := filepath.Join(stagingDir, manifestFileName)
+	if err := os.WriteFile(stagingManifest, manifestData, 0o644); err != nil {
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallFailed, fmt.Sprintf("write manifest: %v", err))
+		return result, fmt.Errorf("write manifest: %w", err)
+	}
+
+	stagingArtifact := filepath.Join(stagingDir, artifactRel)
+	if err := os.MkdirAll(filepath.Dir(stagingArtifact), 0o755); err != nil {
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallFailed, fmt.Sprintf("prepare artifact directory: %v", err))
+		return result, fmt.Errorf("prepare artifact directory: %w", err)
+	}
+
+	if err := downloadRemoteDesktopArtifact(ctx, client, artifactURL, authKey, userAgent, stagingArtifact); err != nil {
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallFailed, err.Error())
+		return result, err
+	}
+
+	if hash := strings.TrimSpace(mf.Package.Hash); hash != "" {
+		sum, hashErr := fileHash(stagingArtifact)
+		if hashErr != nil {
+			manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallFailed, fmt.Sprintf("compute artifact hash: %v", hashErr))
+			return result, fmt.Errorf("compute artifact hash: %w", hashErr)
+		}
+		if !strings.EqualFold(hash, sum) {
+			message := "artifact hash mismatch"
+			manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallFailed, message)
+			return result, errors.New(message)
+		}
+	}
+
+	if err := unpackRemoteDesktopArchive(stagingArtifact, stagingDir); err != nil {
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallFailed, err.Error())
+		return result, err
+	}
+
+	stagedEntry := filepath.Join(stagingDir, entryRel)
+	if info, err := os.Stat(stagedEntry); err != nil || info.IsDir() {
+		message := "engine entry binary missing from artifact"
+		if err != nil {
+			message = fmt.Sprintf("engine entry verification failed: %v", err)
+		}
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallFailed, message)
+		return result, errors.New(message)
+	}
+
+	if err := os.RemoveAll(pluginDir); err != nil && !errors.Is(err, os.ErrNotExist) {
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallFailed, fmt.Sprintf("remove previous installation: %v", err))
+		return result, fmt.Errorf("remove previous installation: %w", err)
+	}
+
+	if err := os.Rename(stagingDir, pluginDir); err != nil {
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallFailed, fmt.Sprintf("activate staged plugin: %v", err))
+		return result, fmt.Errorf("activate staged plugin: %w", err)
+	}
+	cleanup = false
+
+	if err := manager.clearInstallStatusLocked(RemoteDesktopEnginePluginID); err != nil && logger != nil {
+		logger.Printf("remote desktop: failed to clear plugin status: %v", err)
+	}
+
+	result.EntryPath = filepath.Join(pluginDir, entryRel)
+	result.Updated = true
+	return result, nil
+}
+
+func remoteDesktopEndpoints(baseURL, agentID string) (string, string) {
+	trimmed := strings.TrimRight(baseURL, "/")
+	encodedAgent := url.PathEscape(agentID)
+	manifestURL := fmt.Sprintf("%s/api/agents/%s/plugins/%s", trimmed, encodedAgent, url.PathEscape(RemoteDesktopEnginePluginID))
+	artifactURL := fmt.Sprintf("%s/artifact", manifestURL)
+	return manifestURL, artifactURL
+}
+
+func fetchRemoteDesktopManifest(ctx context.Context, client HTTPDoer, endpoint, authKey, userAgent string) ([]byte, manifest.Manifest, error) {
+	var mf manifest.Manifest
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, mf, fmt.Errorf("create manifest request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if userAgent = strings.TrimSpace(userAgent); userAgent != "" {
+		req.Header.Set("User-Agent", userAgent)
+	}
+	if auth := strings.TrimSpace(authKey); auth != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", auth))
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, mf, fmt.Errorf("fetch manifest: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		message := strings.TrimSpace(string(body))
+		if message == "" {
+			message = fmt.Sprintf("status %d", resp.StatusCode)
+		}
+		return nil, mf, fmt.Errorf("fetch manifest: %s", message)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, mf, fmt.Errorf("read manifest response: %w", err)
+	}
+	if err := json.Unmarshal(data, &mf); err != nil {
+		return nil, mf, fmt.Errorf("decode manifest: %w", err)
+	}
+	if err := mf.Validate(); err != nil {
+		return nil, mf, fmt.Errorf("manifest validation failed: %w", err)
+	}
+	return data, mf, nil
+}
+
+func downloadRemoteDesktopArtifact(ctx context.Context, client HTTPDoer, endpoint, authKey, userAgent, dest string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("create artifact request: %w", err)
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+	if userAgent = strings.TrimSpace(userAgent); userAgent != "" {
+		req.Header.Set("User-Agent", userAgent)
+	}
+	if auth := strings.TrimSpace(authKey); auth != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", auth))
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download artifact: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		message := strings.TrimSpace(string(body))
+		if message == "" {
+			message = fmt.Sprintf("status %d", resp.StatusCode)
+		}
+		return fmt.Errorf("download artifact: %s", message)
+	}
+
+	file, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("create artifact file: %w", err)
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(file, resp.Body); err != nil {
+		return fmt.Errorf("write artifact: %w", err)
+	}
+	return nil
+}
+
+func unpackRemoteDesktopArchive(path, dest string) error {
+	reader, err := zip.OpenReader(path)
+	if err != nil {
+		return fmt.Errorf("open artifact archive: %w", err)
+	}
+	defer reader.Close()
+
+	for _, file := range reader.File {
+		if err := extractZipEntry(file, dest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func extractZipEntry(entry *zip.File, dest string) error {
+	cleaned := filepath.Clean(entry.Name)
+	if cleaned == "." || cleaned == "" {
+		return nil
+	}
+	target := filepath.Join(dest, cleaned)
+	if !strings.HasPrefix(target, dest+string(os.PathSeparator)) && target != dest {
+		return fmt.Errorf("artifact entry escapes destination: %s", entry.Name)
+	}
+
+	if entry.FileInfo().IsDir() {
+		if err := os.MkdirAll(target, 0o755); err != nil {
+			return fmt.Errorf("create artifact directory: %w", err)
+		}
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("prepare artifact path: %w", err)
+	}
+
+	reader, err := entry.Open()
+	if err != nil {
+		return fmt.Errorf("open artifact entry: %w", err)
+	}
+	defer reader.Close()
+
+	temp, err := os.CreateTemp(filepath.Dir(target), "entry-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create artifact temp file: %w", err)
+	}
+	tempPath := temp.Name()
+	if _, err := io.Copy(temp, reader); err != nil {
+		temp.Close()
+		os.Remove(tempPath)
+		return fmt.Errorf("write artifact entry: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("close artifact entry: %w", err)
+	}
+	if err := os.Rename(tempPath, target); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("finalize artifact entry: %w", err)
+	}
+	if mode := entry.Mode(); mode != 0 {
+		os.Chmod(target, mode)
+	}
+	return nil
+}
+
+func installationUpToDate(manifestPath, artifactPath, entryPath string, expectedManifest []byte, mf manifest.Manifest) (bool, error) {
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return false, err
+	}
+	if !bytes.Equal(manifestData, expectedManifest) {
+		return false, nil
+	}
+	if _, err := os.Stat(entryPath); err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(mf.Package.Hash) == "" {
+		if _, err := os.Stat(artifactPath); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	currentHash, err := fileHash(artifactPath)
+	if err != nil {
+		return false, err
+	}
+	return strings.EqualFold(currentHash, mf.Package.Hash), nil
+}

--- a/tenvy-client/internal/plugins/remotedesktop_test.go
+++ b/tenvy-client/internal/plugins/remotedesktop_test.go
@@ -1,0 +1,158 @@
+package plugins_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	plugins "github.com/rootbay/tenvy-client/internal/plugins"
+	manifest "github.com/rootbay/tenvy-client/shared/pluginmanifest"
+)
+
+func TestStageRemoteDesktopEngineSuccess(t *testing.T) {
+	t.Parallel()
+
+	artifactData := buildRemoteDesktopArtifact(t, map[string][]byte{
+		"remote-desktop-engine/remote-desktop-engine": []byte("engine payload"),
+	})
+	hash := sha256.Sum256(artifactData)
+	hashHex := fmt.Sprintf("%x", hash[:])
+
+	manifestJSON := fmt.Sprintf(`{
+                "id": "remote-desktop-engine",
+                "name": "Remote Desktop Engine",
+                "version": "9.9.9",
+                "entry": "remote-desktop-engine/remote-desktop-engine",
+                "repositoryUrl": "https://github.com/rootbay/tenvy-client",
+                "license": { "spdxId": "MIT" },
+                "requirements": {},
+                "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": {"type": "sha256", "hash": "%[1]s", "signature": "%[1]s"}},
+                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip", "hash": "%s"}
+        }`, hashHex, hashHex)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/artifact") {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			if _, err := w.Write(artifactData); err != nil {
+				t.Fatalf("write artifact: %v", err)
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := io.WriteString(w, manifestJSON); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	root := t.TempDir()
+	opts := manifest.VerifyOptions{SHA256AllowList: []string{hashHex}}
+	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	ctx := context.Background()
+	result, err := plugins.StageRemoteDesktopEngine(ctx, manager, server.Client(), server.URL, "agent-1", "", "stage-test")
+	if err != nil {
+		t.Fatalf("stage engine: %v", err)
+	}
+	if !result.Updated {
+		t.Fatalf("expected install to be marked updated")
+	}
+	if strings.TrimSpace(result.EntryPath) == "" {
+		t.Fatalf("expected entry path, got empty string")
+	}
+
+	entryPayload, err := os.ReadFile(result.EntryPath)
+	if err != nil {
+		t.Fatalf("read entry payload: %v", err)
+	}
+	if string(entryPayload) != "engine payload" {
+		t.Fatalf("unexpected entry payload %q", string(entryPayload))
+	}
+
+	artifactPath := filepath.Join(manager.Root(), plugins.RemoteDesktopEnginePluginID, "remote-desktop-engine", "remote-desktop-engine.zip")
+	if _, err := os.Stat(artifactPath); err != nil {
+		t.Fatalf("expected artifact persisted: %v", err)
+	}
+
+	snapshot := manager.Snapshot()
+	if snapshot == nil || len(snapshot.Installations) != 1 {
+		t.Fatalf("expected snapshot entry, got %#v", snapshot)
+	}
+	if snapshot.Installations[0].Status != manifest.InstallInstalled {
+		t.Fatalf("expected installed status, got %s", snapshot.Installations[0].Status)
+	}
+
+	// Subsequent staging should be a no-op.
+	result2, err := plugins.StageRemoteDesktopEngine(ctx, manager, server.Client(), server.URL, "agent-1", "", "stage-test")
+	if err != nil {
+		t.Fatalf("restage engine: %v", err)
+	}
+	if result2.Updated {
+		t.Fatalf("expected restage to be no-op")
+	}
+}
+
+func TestStageRemoteDesktopEngineRecordsFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	root := t.TempDir()
+	opts := manifest.VerifyOptions{AllowUnsigned: true}
+	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	_, err = plugins.StageRemoteDesktopEngine(context.Background(), manager, server.Client(), server.URL, "agent-1", "", "stage-test")
+	if err == nil {
+		t.Fatal("expected staging to fail")
+	}
+
+	snapshot := manager.Snapshot()
+	if snapshot == nil || len(snapshot.Installations) != 1 {
+		t.Fatalf("expected failure snapshot entry, got %#v", snapshot)
+	}
+	install := snapshot.Installations[0]
+	if install.Status != manifest.InstallFailed {
+		t.Fatalf("expected failure status, got %s", install.Status)
+	}
+	if !strings.Contains(install.Error, "boom") {
+		t.Fatalf("expected controller error message, got %q", install.Error)
+	}
+}
+
+func buildRemoteDesktopArtifact(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := zip.NewWriter(&buf)
+	for name, payload := range files {
+		entry, err := writer.Create(name)
+		if err != nil {
+			t.Fatalf("create zip entry: %v", err)
+		}
+		if _, err := entry.Write(payload); err != nil {
+			t.Fatalf("write zip entry: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close zip writer: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/tenvy-client/internal/plugins/status.go
+++ b/tenvy-client/internal/plugins/status.go
@@ -1,0 +1,144 @@
+package plugins
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	manifest "github.com/rootbay/tenvy-client/shared/pluginmanifest"
+)
+
+const statusFileName = ".status.json"
+
+type installationStatusRecord struct {
+	ID            string                       `json:"pluginId,omitempty"`
+	Version       string                       `json:"version,omitempty"`
+	Status        manifest.PluginInstallStatus `json:"status,omitempty"`
+	Error         string                       `json:"error,omitempty"`
+	LastCheckedAt string                       `json:"lastCheckedAt,omitempty"`
+}
+
+func (r *installationStatusRecord) PluginID(defaultID string) string {
+	if r == nil {
+		return strings.TrimSpace(defaultID)
+	}
+	if id := strings.TrimSpace(r.ID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(defaultID)
+}
+
+func loadInstallationStatus(dir string) *installationStatusRecord {
+	path := filepath.Join(dir, statusFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var record installationStatusRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil
+	}
+	return &record
+}
+
+func writeInstallationStatus(dir string, record installationStatusRecord) error {
+	if strings.TrimSpace(dir) == "" {
+		return errors.New("plugin status directory not provided")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("ensure plugin status directory: %w", err)
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshal installation status: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, "status-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary status file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("write status data: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("close status file: %w", err)
+	}
+	target := filepath.Join(dir, statusFileName)
+	if err := os.Rename(tmpPath, target); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("persist status file: %w", err)
+	}
+	return nil
+}
+
+func removeInstallationStatus(dir string) error {
+	if strings.TrimSpace(dir) == "" {
+		return errors.New("plugin status directory not provided")
+	}
+	path := filepath.Join(dir, statusFileName)
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove status file: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) recordInstallStatusLocked(pluginID, version string, status manifest.PluginInstallStatus, message string) error {
+	if m == nil {
+		return errors.New("plugins manager is nil")
+	}
+	pluginID = strings.TrimSpace(pluginID)
+	if pluginID == "" {
+		return errors.New("plugin id not provided")
+	}
+	dir := filepath.Join(m.root, pluginID)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	record := installationStatusRecord{
+		ID:            pluginID,
+		Version:       strings.TrimSpace(version),
+		Status:        status,
+		Error:         strings.TrimSpace(message),
+		LastCheckedAt: now,
+	}
+	return writeInstallationStatus(dir, record)
+}
+
+func (m *Manager) clearInstallStatusLocked(pluginID string) error {
+	if m == nil {
+		return nil
+	}
+	pluginID = strings.TrimSpace(pluginID)
+	if pluginID == "" {
+		return nil
+	}
+	dir := filepath.Join(m.root, pluginID)
+	return removeInstallationStatus(dir)
+}
+
+// RecordInstallStatus persists a plugin installation status update to disk so that
+// telemetry snapshots can surface the latest failure or health state to the
+// controller.
+func RecordInstallStatus(m *Manager, pluginID, version string, status manifest.PluginInstallStatus, message string) error {
+	if m == nil {
+		return errors.New("plugins manager not initialized")
+	}
+	m.stageMu.Lock()
+	defer m.stageMu.Unlock()
+	return m.recordInstallStatusLocked(pluginID, version, status, message)
+}
+
+// ClearInstallStatus removes any persisted status overrides for the provided plugin.
+func ClearInstallStatus(m *Manager, pluginID string) error {
+	if m == nil {
+		return nil
+	}
+	m.stageMu.Lock()
+	defer m.stageMu.Unlock()
+	return m.clearInstallStatusLocked(pluginID)
+}


### PR DESCRIPTION
## Summary
- add plugin status persistence and staging utilities for the remote desktop engine, including artifact download, verification, and extraction
- integrate engine staging into the remote desktop module factory and wrap the streamer with a managed process launcher
- capture process failures for telemetry and expand unit coverage for staging logic and status reporting

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f7fb952930832bbc0be561e8578c3b