### PR TITLE
Implement IPC-backed remote desktop engine plugin

### DIFF
--- a/tenvy-client/cmd/remote-desktop-engine/main.go
+++ b/tenvy-client/cmd/remote-desktop-engine/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
+	"log"
+	"net/http"
 	"os"
+	"time"
 
 	engine "github.com/rootbay/tenvy-client/internal/plugins/engines/remotedesktop"
 )
@@ -17,10 +21,25 @@ func main() {
 		return
 	}
 
-	// Instantiate an engine instance to ensure all capture and encoding
-	// dependencies are linked into the standalone binary. Runtime
-	// configuration is provided by the host process when executed.
-	_ = engine.NewRemoteDesktopStreamer(engine.Config{})
+	logger := log.New(os.Stderr, "remote-desktop-engine: ", log.LstdFlags|log.Lmicroseconds)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	fmt.Fprintln(os.Stderr, "remote-desktop-engine plugin build artifact")
+	streamer := engine.NewRemoteDesktopStreamer(engine.Config{Logger: logger})
+
+	// The plugin hosts the remote desktop engine and exposes it over a JSON
+	// message channel transported through stdio. An HTTP client is
+	// constructed on demand when configuration payloads are received.
+	httpFactory := func(timeout time.Duration) *http.Client {
+		client := &http.Client{}
+		if timeout > 0 {
+			client.Timeout = timeout
+		}
+		return client
+	}
+
+	if err := engine.ServeEngineIPC(ctx, streamer, os.Stdin, os.Stdout, logger, httpFactory); err != nil {
+		fmt.Fprintf(os.Stderr, "remote-desktop-engine: ipc server error: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/tenvy-client/docs/remote-desktop-engine-ipc.md
+++ b/tenvy-client/docs/remote-desktop-engine-ipc.md
@@ -1,0 +1,39 @@
+# Remote Desktop Engine IPC Contract
+
+The remote desktop engine plugin is now hosted out-of-process and communicates
+with the agent over a newline-delimited JSON protocol carried across the
+plugin's stdin/stdout streams. Each message is an object containing an `id`
+field, a `method` string, and an optional `params` payload. Responses reuse the
+identifier and either provide a `result` object or an `error` payload with a
+human-readable message.
+
+## Supported Methods
+
+| Method          | Direction | Payload                                      | Description |
+|-----------------|-----------|----------------------------------------------|-------------|
+| `configure`     | Agent → Plugin | `configEnvelope` (engine.Config minus logger/client) | Applies the latest controller configuration. The plugin is responsible for instantiating its own HTTP client using the provided timeout. |
+| `startSession`  | Agent → Plugin | `RemoteDesktopCommandPayload`               | Begins a streaming session. |
+| `updateSession` | Agent → Plugin | `RemoteDesktopCommandPayload`               | Applies runtime session changes (quality, encoder hints, etc.). |
+| `handleInput`   | Agent → Plugin | `RemoteDesktopCommandPayload`               | Forwards aggregated input events to the active session. |
+| `deliverFrame`  | Agent → Plugin | `RemoteDesktopFramePacket`                  | Sends captured frame data for transport to the controller. |
+| `stopSession`   | Agent → Plugin | `{ "sessionId": string }`                  | Terminates the active session. |
+| `shutdown`      | Agent → Plugin | _none_                                      | Signals graceful shutdown; the plugin must flush state, respond, and exit. |
+
+The plugin must respond to each request with a success result (`{"status":"ok"}`)
+or an error object (`{"error":{"message":"..."}}`). Any log output should be
+written to stderr to avoid interfering with the JSON channel.
+
+## Error Handling
+
+If the agent detects that the plugin process exited unexpectedly, it records
+the exit status using the plugin manager and surfaces the buffered stderr output
+in the agent logs. Subsequent engine calls will restart the plugin. Conversely,
+the plugin should treat malformed requests as fatal and return an error so the
+agent can propagate the failure to the controller.
+
+## Testing
+
+Integration coverage lives under `internal/agent/remote_desktop_ipc_test.go` and
+uses a fake plugin binary that exercises the full JSON pipeline. Any change to
+this protocol should update the test fixtures and documentation to avoid
+regressions.

--- a/tenvy-client/internal/agent/remote_desktop_ipc_test.go
+++ b/tenvy-client/internal/agent/remote_desktop_ipc_test.go
@@ -1,0 +1,130 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	remotedesktop "github.com/rootbay/tenvy-client/internal/modules/control/remotedesktop"
+)
+
+func TestRemoteDesktopIPCClientIntegration(t *testing.T) {
+        workDir, err := os.Getwd()
+        if err != nil {
+                t.Fatalf("get working directory: %v", err)
+	}
+
+	outputDir := t.TempDir()
+	pluginPath := filepath.Join(outputDir, "fake-plugin")
+
+	build := exec.Command("go", "build", "-o", pluginPath, "./testdata/fakeplugin")
+	build.Dir = workDir
+	build.Env = os.Environ()
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build fake plugin: %v: %s", err, out)
+	}
+
+	logPath := filepath.Join(outputDir, "plugin-log.jsonl")
+	t.Setenv("FAKE_REMOTE_DESKTOP_PLUGIN_LOG", logPath)
+
+	logger := log.New(io.Discard, "", 0)
+	engine := remotedesktop.NewManagedRemoteDesktopEngine(pluginPath, "test-version", nil, logger)
+
+	cfg := remotedesktop.Config{
+		AgentID: "agent-123",
+		BaseURL: "https://controller.example",
+		AuthKey: "test-key",
+	}
+
+	if err := engine.Configure(cfg); err != nil {
+		t.Fatalf("configure engine: %v", err)
+	}
+
+	ctx := context.Background()
+	startPayload := remotedesktop.RemoteDesktopCommandPayload{Action: "start", SessionID: "session-1"}
+	if err := engine.StartSession(ctx, startPayload); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+
+	updatePayload := remotedesktop.RemoteDesktopCommandPayload{Action: "configure", SessionID: "session-1"}
+	if err := engine.UpdateSession(updatePayload); err != nil {
+		t.Fatalf("update session: %v", err)
+	}
+
+	inputPayload := remotedesktop.RemoteDesktopCommandPayload{
+		Action:    "input",
+		SessionID: "session-1",
+		Events: []remotedesktop.RemoteDesktopInputEvent{
+			{
+				Type:       remotedesktop.RemoteInputMouseMove,
+				CapturedAt: time.Now().UnixNano(),
+				X:          10,
+				Y:          5,
+			},
+		},
+	}
+	if err := engine.HandleInput(ctx, inputPayload); err != nil {
+		t.Fatalf("handle input: %v", err)
+	}
+
+	frame := remotedesktop.RemoteDesktopFramePacket{
+		SessionID: "session-1",
+		Width:     1,
+		Height:    1,
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		Encoding:  "raw",
+	}
+	if err := engine.DeliverFrame(ctx, frame); err != nil {
+		t.Fatalf("deliver frame: %v", err)
+	}
+
+	if err := engine.StopSession("session-1"); err != nil {
+		t.Fatalf("stop session: %v", err)
+	}
+
+	engine.Shutdown()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read plugin log: %v", err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	var methods []string
+	for decoder.More() {
+		var entry struct {
+			Method string `json:"method"`
+		}
+		if err := decoder.Decode(&entry); err != nil {
+			t.Fatalf("decode log entry: %v", err)
+		}
+		methods = append(methods, entry.Method)
+	}
+
+	expected := []string{
+		"configure",
+		"startSession",
+		"updateSession",
+		"handleInput",
+		"deliverFrame",
+		"stopSession",
+		"shutdown",
+	}
+
+	if len(methods) != len(expected) {
+		t.Fatalf("unexpected method count: got %d want %d (%v)", len(methods), len(expected), methods)
+	}
+
+	for i, method := range methods {
+		if method != expected[i] {
+			t.Fatalf("method %d mismatch: got %s want %s", i, method, expected[i])
+		}
+	}
+}

--- a/tenvy-client/internal/agent/testdata/fakeplugin/main.go
+++ b/tenvy-client/internal/agent/testdata/fakeplugin/main.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+const (
+	methodConfigure     = "configure"
+	methodStartSession  = "startSession"
+	methodStopSession   = "stopSession"
+	methodUpdateSession = "updateSession"
+	methodHandleInput   = "handleInput"
+	methodDeliverFrame  = "deliverFrame"
+	methodShutdown      = "shutdown"
+)
+
+type ipcRequest struct {
+	ID     uint64          `json:"id"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+type ipcResponse struct {
+	ID     uint64                 `json:"id"`
+	Result map[string]interface{} `json:"result,omitempty"`
+	Error  *ipcError              `json:"error,omitempty"`
+}
+
+type ipcError struct {
+	Message string `json:"message"`
+}
+
+type logEntry struct {
+	Method    string          `json:"method"`
+	Timestamp string          `json:"timestamp"`
+	Params    json.RawMessage `json:"params,omitempty"`
+}
+
+func main() {
+	logPath := os.Getenv("FAKE_REMOTE_DESKTOP_PLUGIN_LOG")
+	var logEncoder *json.Encoder
+	if logPath != "" {
+		file, err := os.Create(logPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fake plugin: open log: %v\n", err)
+			os.Exit(1)
+		}
+		defer file.Close()
+		logEncoder = json.NewEncoder(file)
+	}
+
+	decoder := json.NewDecoder(os.Stdin)
+	writer := bufio.NewWriter(os.Stdout)
+	encoder := json.NewEncoder(writer)
+
+	for {
+		var req ipcRequest
+		if err := decoder.Decode(&req); err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			fmt.Fprintf(os.Stderr, "fake plugin: decode request: %v\n", err)
+			return
+		}
+
+		if logEncoder != nil {
+			entry := logEntry{
+				Method:    req.Method,
+				Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+				Params:    append(json.RawMessage(nil), req.Params...),
+			}
+			_ = logEncoder.Encode(entry)
+		}
+
+		resp := ipcResponse{ID: req.ID, Result: map[string]interface{}{"status": "ok"}}
+		if err := encoder.Encode(resp); err != nil {
+			fmt.Fprintf(os.Stderr, "fake plugin: encode response: %v\n", err)
+			return
+		}
+		if err := writer.Flush(); err != nil {
+			fmt.Fprintf(os.Stderr, "fake plugin: flush response: %v\n", err)
+			return
+		}
+
+		if req.Method == methodShutdown {
+			return
+		}
+	}
+}

--- a/tenvy-client/internal/plugins/engines/remotedesktop/ipc_host.go
+++ b/tenvy-client/internal/plugins/engines/remotedesktop/ipc_host.go
@@ -1,0 +1,156 @@
+package remotedesktopengine
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// HTTPClientFactory constructs HTTP clients for the hosted engine based on the
+// request timeout communicated by the agent. The factory enables the plugin to
+// remain decoupled from the agent's HTTP stack while still honoring the
+// controller's timing expectations.
+type HTTPClientFactory func(timeout time.Duration) *http.Client
+
+// ServeEngineIPC hosts an Engine over a JSON message channel. Requests and
+// responses are newline delimited JSON objects written to the supplied reader
+// and writer, respectively. The server exits when the context is cancelled, the
+// underlying stream is closed, or a shutdown request is processed.
+func ServeEngineIPC(ctx context.Context, engine Engine, reader io.Reader, writer io.Writer, logger Logger, clients HTTPClientFactory) error {
+	if engine == nil {
+		return errors.New("remote desktop engine not provided")
+	}
+	if reader == nil || writer == nil {
+		return errors.New("ipc transport not configured")
+	}
+	if clients == nil {
+		clients = func(timeout time.Duration) *http.Client {
+			client := &http.Client{}
+			if timeout > 0 {
+				client.Timeout = timeout
+			}
+			return client
+		}
+	}
+
+	dec := json.NewDecoder(reader)
+	bufWriter := bufio.NewWriter(writer)
+	enc := json.NewEncoder(bufWriter)
+
+	type pendingResponse struct {
+		id  uint64
+		err error
+	}
+
+	var mu sync.Mutex
+	handle := func(req ipcRequest) ipcResponse {
+		mu.Lock()
+		defer mu.Unlock()
+
+		respond := ipcResponse{ID: req.ID}
+
+		switch req.Method {
+		case methodConfigure:
+			var payload configEnvelope
+			if err := json.Unmarshal(req.Params, &payload); err != nil {
+				respond.Error = &ipcError{Message: fmt.Sprintf("decode configure payload: %v", err)}
+				return respond
+			}
+			cfg := payload.toConfig(logger)
+			cfg.Client = clients(cfg.RequestTimeout)
+			if err := engine.Configure(cfg); err != nil {
+				respond.Error = &ipcError{Message: err.Error()}
+			}
+		case methodStartSession:
+			var payload RemoteDesktopCommandPayload
+			if err := json.Unmarshal(req.Params, &payload); err != nil {
+				respond.Error = &ipcError{Message: fmt.Sprintf("decode start payload: %v", err)}
+				return respond
+			}
+			if err := engine.StartSession(ctx, payload); err != nil {
+				respond.Error = &ipcError{Message: err.Error()}
+			}
+		case methodStopSession:
+			var payload stopSessionRequest
+			if err := json.Unmarshal(req.Params, &payload); err != nil {
+				respond.Error = &ipcError{Message: fmt.Sprintf("decode stop payload: %v", err)}
+				return respond
+			}
+			if err := engine.StopSession(payload.SessionID); err != nil {
+				respond.Error = &ipcError{Message: err.Error()}
+			}
+		case methodUpdateSession:
+			var payload RemoteDesktopCommandPayload
+			if err := json.Unmarshal(req.Params, &payload); err != nil {
+				respond.Error = &ipcError{Message: fmt.Sprintf("decode update payload: %v", err)}
+				return respond
+			}
+			if err := engine.UpdateSession(payload); err != nil {
+				respond.Error = &ipcError{Message: err.Error()}
+			}
+		case methodHandleInput:
+			var payload RemoteDesktopCommandPayload
+			if err := json.Unmarshal(req.Params, &payload); err != nil {
+				respond.Error = &ipcError{Message: fmt.Sprintf("decode input payload: %v", err)}
+				return respond
+			}
+			if err := engine.HandleInput(ctx, payload); err != nil {
+				respond.Error = &ipcError{Message: err.Error()}
+			}
+		case methodDeliverFrame:
+			var payload RemoteDesktopFramePacket
+			if err := json.Unmarshal(req.Params, &payload); err != nil {
+				respond.Error = &ipcError{Message: fmt.Sprintf("decode frame payload: %v", err)}
+				return respond
+			}
+			if err := engine.DeliverFrame(ctx, payload); err != nil {
+				respond.Error = &ipcError{Message: err.Error()}
+			}
+		case methodShutdown:
+			engine.Shutdown()
+			respond.Result = json.RawMessage(`{"status":"ok"}`)
+			return respond
+		default:
+			respond.Error = &ipcError{Message: fmt.Sprintf("unknown method: %s", req.Method)}
+		}
+
+		if respond.Error == nil && respond.Result == nil {
+			respond.Result = json.RawMessage(`{"status":"ok"}`)
+		}
+		return respond
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		var req ipcRequest
+		if err := dec.Decode(&req); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("decode ipc request: %w", err)
+		}
+
+		resp := handle(req)
+		if err := enc.Encode(resp); err != nil {
+			return fmt.Errorf("encode ipc response: %w", err)
+		}
+		if err := bufWriter.Flush(); err != nil {
+			return fmt.Errorf("flush ipc response: %w", err)
+		}
+
+		if req.Method == methodShutdown {
+			return nil
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- host the remote desktop streamer inside the plugin binary and expose it via a JSON IPC server on stdio
- replace the agent-side proxy with an IPC client, stage the plugin only when available, and document the new protocol
- add integration coverage with a fake plugin and reuse the built plugin binary in existing managed-engine tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f88fe8f138832bbb5aeec8caf4e077