### PR TITLE
Align mutex generation with backend sanitization

### DIFF
--- a/tenvy-server/src/routes/(app)/build/+page.svelte
+++ b/tenvy-server/src/routes/(app)/build/+page.svelte
@@ -35,17 +35,18 @@
 	import {
 		addCustomCookie as createCustomCookie,
 		addCustomHeader as createCustomHeader,
-		generateMutexName as randomMutexSuffix,
-		normalizeSpoofExtension,
-		parseListInput,
-		removeCustomCookie as deleteCustomCookie,
-		removeCustomHeader as deleteCustomHeader,
-		sanitizeFileInformation as sanitizeFileInformationPayload,
-		toIsoDateTime,
-		updateCustomCookie as writeCustomCookie,
-		updateCustomHeader as writeCustomHeader,
-		validateSpoofExtension,
-		withPresetSpoofExtension
+                generateMutexName as randomMutexSuffix,
+                normalizeSpoofExtension,
+                parseListInput,
+                removeCustomCookie as deleteCustomCookie,
+                removeCustomHeader as deleteCustomHeader,
+                sanitizeFileInformation as sanitizeFileInformationPayload,
+                sanitizeMutexName,
+                toIsoDateTime,
+                updateCustomCookie as writeCustomCookie,
+                updateCustomHeader as writeCustomHeader,
+                validateSpoofExtension,
+                withPresetSpoofExtension
 	} from './lib/utils.js';
 	import type { BuildRequest } from '../../../../../shared/types/build';
 
@@ -401,9 +402,10 @@
 		customCookies = updated.length > 0 ? updated : [{ name: '', value: '' }];
 	}
 
-	function assignMutexName(length = 16) {
-		mutexName = `Global\\tenvy-${randomMutexSuffix(length).toUpperCase()}`;
-	}
+        function assignMutexName(length = 16) {
+                const suffix = randomMutexSuffix(length).toUpperCase();
+                mutexName = sanitizeMutexName(`Global\\tenvy-${suffix}`);
+        }
 
 	async function handleIconSelection(event: Event) {
 		const input = event.target as HTMLInputElement;

--- a/tenvy-server/src/routes/(app)/build/build-page.svelte.spec.ts
+++ b/tenvy-server/src/routes/(app)/build/build-page.svelte.spec.ts
@@ -61,4 +61,24 @@ describe('build page port validation', () => {
 
                 component.$destroy();
         });
+
+        it('generates sanitized mutex names when requested', async () => {
+                const { component } = render(BuildPage);
+
+                const generateButton = page.getByRole('button', { name: /generate/i });
+                generateButton.click();
+
+                await tick();
+
+                const mutexInput = document.getElementById('mutex') as HTMLInputElement | null;
+                expect(mutexInput).toBeTruthy();
+                if (!mutexInput) {
+                        throw new Error('Mutex input not found');
+                }
+
+                expect(mutexInput.value).not.toBe('');
+                expect(mutexInput.value).toMatch(/^[A-Za-z0-9._-]+$/);
+
+                component.$destroy();
+        });
 });

--- a/tenvy-server/src/routes/(app)/build/lib/utils.ts
+++ b/tenvy-server/src/routes/(app)/build/lib/utils.ts
@@ -1,9 +1,12 @@
 import {
-	DEFAULT_FILE_INFORMATION,
-	EXTENSION_SPOOF_PRESETS,
-	type CookieKV,
-	type HeaderKV
+        DEFAULT_FILE_INFORMATION,
+        EXTENSION_SPOOF_PRESETS,
+        type CookieKV,
+        type HeaderKV
 } from './constants';
+
+const mutexSanitizer = /[^A-Za-z0-9._-]/g;
+const maxMutexLength = 120;
 
 export function normalizeSpoofExtension(value: string): string | null {
 	const trimmed = value.trim();
@@ -96,9 +99,9 @@ export function toIsoDateTime(value: string): string | null {
 }
 
 export function generateMutexName(length = 16): string {
-	const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-	let result = '';
-	const cryptoObject: Crypto | undefined = typeof crypto !== 'undefined' ? crypto : undefined;
+        const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        let result = '';
+        const cryptoObject: Crypto | undefined = typeof crypto !== 'undefined' ? crypto : undefined;
 
 	if (cryptoObject?.getRandomValues) {
 		const values = new Uint32Array(length);
@@ -114,7 +117,21 @@ export function generateMutexName(length = 16): string {
 		result += charset[randomIndex];
 	}
 
-	return result;
+        return result;
+}
+
+export function sanitizeMutexName(value: string): string {
+        if (!value) {
+                return '';
+        }
+
+        const trimmed = value.trim();
+        if (!trimmed) {
+                return '';
+        }
+
+        const sanitized = trimmed.replace(mutexSanitizer, '_');
+        return sanitized.slice(0, maxMutexLength);
 }
 
 export function withPresetSpoofExtension(


### PR DESCRIPTION
## Summary
- add a frontend `sanitizeMutexName` helper that matches the backend mutex rules
- ensure generated mutex names in the build page are sanitized before display
- cover mutex generation with a browser test that checks allowed characters

## Testing
- bun test --browser src/routes/(app)/build/build-page.svelte.spec.ts *(fails: @vitest/browser/context can be imported only inside the Browser Mode)*

------
https://chatgpt.com/codex/tasks/task_e_68f89b646960832b970402706751cd1a