### PR TITLE
Validate integer inputs for build timing controls

### DIFF
--- a/tenvy-server/src/routes/(app)/build/+page.svelte
+++ b/tenvy-server/src/routes/(app)/build/+page.svelte
@@ -481,33 +481,54 @@
                                 return;
                         }
                 }
-		if (trimmedPollInterval) {
-			const pollValue = Number(trimmedPollInterval);
-			if (!Number.isFinite(pollValue) || pollValue < 1000 || pollValue > 3_600_000) {
-				buildError = 'Poll interval must be between 1,000 and 3,600,000 milliseconds.';
-				pushProgress(buildError, 'error');
-				buildStatus = 'error';
-				return;
-			}
-		}
-		if (trimmedMaxBackoff) {
-			const backoffValue = Number(trimmedMaxBackoff);
-			if (!Number.isFinite(backoffValue) || backoffValue < 1000 || backoffValue > 86_400_000) {
-				buildError = 'Max backoff must be between 1,000 and 86,400,000 milliseconds.';
-				pushProgress(buildError, 'error');
-				buildStatus = 'error';
-				return;
-			}
-		}
-		if (trimmedShellTimeout) {
-			const timeoutValue = Number(trimmedShellTimeout);
-			if (!Number.isFinite(timeoutValue) || timeoutValue < 5 || timeoutValue > 7_200) {
-				buildError = 'Shell timeout must be between 5 and 7,200 seconds.';
-				pushProgress(buildError, 'error');
-				buildStatus = 'error';
-				return;
-			}
-		}
+                if (trimmedPollInterval) {
+                        if (!/^\d+$/.test(trimmedPollInterval)) {
+                                buildError = 'Poll interval must be a positive integer.';
+                                pushProgress(buildError, 'error');
+                                buildStatus = 'error';
+                                return;
+                        }
+
+                        const pollValue = Number.parseInt(trimmedPollInterval, 10);
+                        if (Number.isNaN(pollValue) || pollValue < 1000 || pollValue > 3_600_000) {
+                                buildError = 'Poll interval must be between 1,000 and 3,600,000 milliseconds.';
+                                pushProgress(buildError, 'error');
+                                buildStatus = 'error';
+                                return;
+                        }
+                }
+                if (trimmedMaxBackoff) {
+                        if (!/^\d+$/.test(trimmedMaxBackoff)) {
+                                buildError = 'Max backoff must be a positive integer.';
+                                pushProgress(buildError, 'error');
+                                buildStatus = 'error';
+                                return;
+                        }
+
+                        const backoffValue = Number.parseInt(trimmedMaxBackoff, 10);
+                        if (Number.isNaN(backoffValue) || backoffValue < 1000 || backoffValue > 86_400_000) {
+                                buildError = 'Max backoff must be between 1,000 and 86,400,000 milliseconds.';
+                                pushProgress(buildError, 'error');
+                                buildStatus = 'error';
+                                return;
+                        }
+                }
+                if (trimmedShellTimeout) {
+                        if (!/^\d+$/.test(trimmedShellTimeout)) {
+                                buildError = 'Shell timeout must be a positive integer.';
+                                pushProgress(buildError, 'error');
+                                buildStatus = 'error';
+                                return;
+                        }
+
+                        const timeoutValue = Number.parseInt(trimmedShellTimeout, 10);
+                        if (Number.isNaN(timeoutValue) || timeoutValue < 5 || timeoutValue > 7_200) {
+                                buildError = 'Shell timeout must be between 5 and 7,200 seconds.';
+                                pushProgress(buildError, 'error');
+                                buildStatus = 'error';
+                                return;
+                        }
+                }
 
 		const sanitizedHeaders = customHeaders
 			.map((header) => ({

--- a/tenvy-server/src/routes/(app)/build/build-page.svelte.spec.ts
+++ b/tenvy-server/src/routes/(app)/build/build-page.svelte.spec.ts
@@ -62,6 +62,33 @@ describe('build page port validation', () => {
                 component.$destroy();
         });
 
+        it('blocks builds when the poll interval is not a positive integer', async () => {
+                const { component } = render(BuildPage);
+
+                const pollIntervalInput = document.getElementById('poll-interval') as HTMLInputElement | null;
+                expect(pollIntervalInput).toBeTruthy();
+                if (!pollIntervalInput) {
+                        throw new Error('Poll interval input not found');
+                }
+
+                pollIntervalInput.value = '1000.5';
+                pollIntervalInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+                const buildButton = page.getByRole('button', { name: 'Build Agent' });
+                buildButton.click();
+
+                await tick();
+                await tick();
+
+                expect(globalThis.fetch).not.toHaveBeenCalled();
+                expect(toast.error).toHaveBeenCalledWith(
+                        'Poll interval must be a positive integer.',
+                        expect.objectContaining({ position: 'bottom-right' })
+                );
+
+                component.$destroy();
+        });
+
         it('generates sanitized mutex names when requested', async () => {
                 const { component } = render(BuildPage);
 


### PR DESCRIPTION
## Summary
- enforce positive-integer validation for the build page poll interval, max backoff, and shell timeout inputs before running range checks
- add a browser spec that confirms decimal poll intervals are rejected client-side

## Testing
- ENABLE_BROWSER_TESTS=true bun test:unit -- --run build-page.svelte.spec.ts *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f89c809f0c832bbcc1770f54f4fa0c