### PR TITLE
Ensure build toasts are dismissed during cleanup

### DIFF
--- a/tenvy-server/src/routes/(app)/build/+page.svelte
+++ b/tenvy-server/src/routes/(app)/build/+page.svelte
@@ -172,8 +172,17 @@
 	let downloadUrl = $state<string | null>(null);
 	let outputPath = $state<string | null>(null);
 
-	const BUILD_STATUS_TOAST_ID = 'build-status-toast';
-	const BUILD_PROGRESS_TOAST_ID = 'build-progress-toast';
+        const BUILD_STATUS_TOAST_ID = 'build-status-toast';
+        const BUILD_PROGRESS_TOAST_ID = 'build-progress-toast';
+
+        function clearBuildToasts() {
+                if (!browser) {
+                        return;
+                }
+
+                toast.dismiss(BUILD_STATUS_TOAST_ID);
+                toast.dismiss(BUILD_PROGRESS_TOAST_ID);
+        }
 
 	let lastToastedStatus: BuildStatus = 'idle';
 	let lastWarningSignature = '';
@@ -308,15 +317,15 @@
 		lastWarningSignature = signature;
 	});
 
-	function resetProgress() {
-		buildStatus = 'idle';
-		buildError = null;
-		downloadUrl = null;
-		outputPath = null;
-		buildWarnings = [];
-		fileIconError = null;
-		toast.dismiss(BUILD_PROGRESS_TOAST_ID);
-	}
+        function resetProgress() {
+                buildStatus = 'idle';
+                buildError = null;
+                downloadUrl = null;
+                outputPath = null;
+                buildWarnings = [];
+                fileIconError = null;
+                clearBuildToasts();
+        }
 
 	function pushProgress(text: string, tone: 'info' | 'success' | 'error' = 'info') {
 		if (!browser) {
@@ -776,9 +785,9 @@
 		}
 	}
 
-	onDestroy(() => {
-		toast.dismiss(BUILD_STATUS_TOAST_ID);
-	});
+        onDestroy(() => {
+                clearBuildToasts();
+        });
 </script>
 
 <div class="mx-auto w-full space-y-6 px-4 pb-10">

--- a/tenvy-server/src/routes/(app)/build/build-page.svelte.spec.ts
+++ b/tenvy-server/src/routes/(app)/build/build-page.svelte.spec.ts
@@ -108,4 +108,29 @@ describe('build page port validation', () => {
 
                 component.$destroy();
         });
+
+        it('dismisses the progress toast when the component is destroyed mid-build', async () => {
+                const pendingFetch = new Promise<never>(() => {});
+                globalThis.fetch = vi.fn(() => pendingFetch as unknown as Promise<Response>);
+
+                const { component } = render(BuildPage);
+
+                const buildButton = page.getByRole('button', { name: 'Build Agent' });
+                buildButton.click();
+
+                await tick();
+                await tick();
+
+                const dismissesBeforeDestroy = toast.dismiss.mock.calls.filter(
+                        ([id]) => id === 'build-progress-toast'
+                ).length;
+
+                component.$destroy();
+
+                const dismissesAfterDestroy = toast.dismiss.mock.calls.filter(
+                        ([id]) => id === 'build-progress-toast'
+                ).length;
+
+                expect(dismissesAfterDestroy).toBeGreaterThan(dismissesBeforeDestroy);
+        });
 });


### PR DESCRIPTION
## Summary
- add a shared helper to clear build status/progress toasts
- reuse the helper when resetting build state and during component destruction
- extend the build page spec to cover dismissing the progress toast on destroy

## Testing
- bun x vitest --browser --run 'src/routes/(app)/build/build-page.svelte.spec.ts' *(fails: Vitest reports that no project has a browser configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68f8a1776204832bb4a656656aa7183a