### PR TITLE
Optimize build page icon upload encoding

### DIFF
--- a/tenvy-server/src/routes/(app)/build/+page.svelte
+++ b/tenvy-server/src/routes/(app)/build/+page.svelte
@@ -435,13 +435,30 @@
 		}
 
 		try {
-			const buffer = await file.arrayBuffer();
-			const bytes = new Uint8Array(buffer);
-			let binary = '';
-			for (const byte of bytes) {
-				binary += String.fromCharCode(byte);
-			}
-			fileIconData = btoa(binary);
+			const dataUrl = await new Promise<string>((resolve, reject) => {
+				const reader = new FileReader();
+
+				reader.onerror = () => {
+					const error = reader.error;
+					reject(error ?? new Error('Failed to read icon file.'));
+				};
+
+				reader.onload = () => {
+					const result = reader.result;
+
+					if (typeof result !== 'string') {
+						reject(new Error('Failed to read icon file.'));
+						return;
+					}
+
+					const base64 = result.replace(/^data:[^;]*;base64,/, '');
+					resolve(base64);
+				};
+
+				reader.readAsDataURL(file);
+			});
+
+			fileIconData = dataUrl;
 			fileIconName = file.name;
 		} catch (err) {
 			fileIconError = err instanceof Error ? err.message : 'Failed to read icon file.';


### PR DESCRIPTION
## Summary
- replace the manual byte-to-base64 conversion in the build page icon handler with FileReader-based processing
- keep existing validation and error handling paths while assigning the icon name/data

## Testing
- not run (UI verification not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68f8a4f06258832b8ec5c6db82433ed0