### PR TITLE
feat: lazy load build page tabs

### DIFF
--- a/tenvy-server/src/routes/(app)/build/build-page.svelte.spec.ts
+++ b/tenvy-server/src/routes/(app)/build/build-page.svelte.spec.ts
@@ -133,4 +133,19 @@ describe('build page port validation', () => {
 
                 expect(dismissesAfterDestroy).toBeGreaterThan(dismissesBeforeDestroy);
         });
+
+        it('lazy loads tab content when activating a new tab', async () => {
+                const { component } = render(BuildPage);
+
+                const persistenceTab = page.getByRole('tab', { name: 'Persistence' });
+                persistenceTab.click();
+
+                await tick();
+                await tick();
+
+                const installationPathInput = document.getElementById('path');
+                expect(installationPathInput).toBeTruthy();
+
+                component.$destroy();
+        });
 });


### PR DESCRIPTION
## Summary
- load build page tabs lazily with placeholders and cached modules
- prefetch the default tab on mount to keep the initial render responsive
- add a regression test covering lazy tab activation

## Testing
- ENABLE_BROWSER_TESTS=true bun x vitest --browser.headless --browser.name=chromium 'src/routes/(app)/build/build-page.svelte.spec.ts' *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8b1b83a3c832ba38d97607ce7842d