### PR TITLE
Refactor plugin marketplace layout into reusable components

### DIFF
--- a/tenvy-server/bun.lock
+++ b/tenvy-server/bun.lock
@@ -40,6 +40,7 @@
         "@sveltejs/kit": "^2.47.0",
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@tailwindcss/vite": "^4.1.14",
+        "@testing-library/svelte": "^5.2.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/d3-geo": "^3.1.0",
         "@types/d3-selection": "^3.0.11",
@@ -428,6 +429,8 @@
     "@tailwindcss/vite": ["@tailwindcss/vite@4.1.14", "", { "dependencies": { "@tailwindcss/node": "4.1.14", "@tailwindcss/oxide": "4.1.14", "tailwindcss": "4.1.14" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-BoFUoU0XqgCUS1UXWhmDJroKKhNXeDzD7/XwabjkDIAbMnc4ULn5e2FuEuBbhZ6ENZoSYzKlzvZ44Yr6EUDUSA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/svelte": ["@testing-library/svelte@5.2.8", "", { "dependencies": { "@testing-library/dom": "9.x.x || 10.x.x" }, "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0", "vite": "*", "vitest": "*" }, "optionalPeers": ["vite", "vitest"] }, "sha512-ucQOtGsJhtawOEtUmbR4rRh53e6RbM1KUluJIXRmh6D4UzxR847iIqqjRtg9mHNFmGQ8Vkam9yVcR5d1mhIHKA=="],
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 

--- a/tenvy-server/package.json
+++ b/tenvy-server/package.json
@@ -33,6 +33,7 @@
 		"@sveltejs/kit": "^2.47.0",
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@tailwindcss/vite": "^4.1.14",
+		"@testing-library/svelte": "^5.2.0",
 		"@types/better-sqlite3": "^7.6.13",
 		"@types/d3-geo": "^3.1.0",
 		"@types/d3-selection": "^3.0.11",
@@ -72,8 +73,8 @@
 		"vitest-browser-svelte": "^1.1.0"
 	},
 	"dependencies": {
-                "@koush/wrtc": "^0.5.3",
-                "@msgpack/msgpack": "^3.0.0",
+		"@koush/wrtc": "^0.5.3",
+		"@msgpack/msgpack": "^3.0.0",
 		"@lucia-auth/adapter-drizzle": "^1.1.0",
 		"@motionone/dom": "^10.18.0",
 		"@node-rs/argon2": "^2.0.2",

--- a/tenvy-server/src/lib/components/plugins/MarketplaceGrid.svelte
+++ b/tenvy-server/src/lib/components/plugins/MarketplaceGrid.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Card,
+		CardContent,
+		CardDescription,
+		CardFooter,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+	import type { Plugin } from '$lib/data/plugin-view.js';
+	import { GitFork, Info, ShieldCheck } from '@lucide/svelte';
+
+	import type { MarketplaceEntitlement, MarketplaceListing, MarketplaceStatus } from './types.js';
+
+	let {
+		listings,
+		entitlements,
+		canPurchase = false,
+		canSubmitMarketplace = false,
+		purchaseListing,
+		signatureBadge,
+		formatSignatureTime,
+		statusStyles
+	}: {
+		listings: MarketplaceListing[];
+		entitlements: MarketplaceEntitlement[];
+		canPurchase?: boolean;
+		canSubmitMarketplace?: boolean;
+		purchaseListing: (listing: MarketplaceListing) => void | Promise<void>;
+		signatureBadge: (signature: Plugin['signature']) => {
+			label: string;
+			icon: typeof ShieldCheck;
+			class: string;
+		};
+		formatSignatureTime: (value: string | null | undefined) => string;
+		statusStyles: Record<MarketplaceStatus, string>;
+	} = $props();
+
+	function isEntitled(listingId: string): boolean {
+		return entitlements.some((entry) => entry.listingId === listingId);
+	}
+</script>
+
+<Card class="border-border/60">
+	<CardHeader class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+		<div class="space-y-1">
+			<CardTitle>Marketplace</CardTitle>
+			<CardDescription>
+				Deploy community plugins backed by signed releases from public repositories.
+			</CardDescription>
+		</div>
+		<Badge variant="secondary" class="gap-2 text-xs">
+			<ShieldCheck class="h-4 w-4" />
+			{listings.length} listing{listings.length === 1 ? '' : 's'}
+		</Badge>
+	</CardHeader>
+	<CardContent>
+		{#if listings.length === 0}
+			<p class="text-sm text-muted-foreground">
+				No marketplace submissions yet. Developers can publish plugins once approved by an
+				administrator.
+			</p>
+		{:else}
+			<div class="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+				{#each listings as listing (listing.id)}
+					<div
+						class="flex flex-col justify-between rounded-lg border border-border bg-card p-4 shadow-sm"
+					>
+						<div class="space-y-3">
+							{@const listingSignature = signatureBadge(listing.signature)}
+							<div class="flex items-start justify-between gap-3">
+								<div class="space-y-1">
+									<h3 class="text-base leading-tight font-semibold">{listing.name}</h3>
+									<p class="text-xs tracking-wide text-muted-foreground uppercase">
+										Version {listing.version} · {listing.pricingTier}
+									</p>
+								</div>
+								<div class="flex flex-col items-end gap-2">
+									<Badge class={statusStyles[listing.status]}>{listing.status}</Badge>
+									<Badge
+										variant="outline"
+										class={cn(
+											'flex items-center gap-1 rounded-full border px-2 py-1 text-[10px] font-semibold tracking-wide uppercase',
+											listingSignature.class
+										)}
+									>
+										<svelte:component this={listingSignature.icon} class="h-3 w-3" />
+										{listingSignature.label}
+									</Badge>
+								</div>
+							</div>
+							<p class="text-sm leading-relaxed text-muted-foreground">
+								{listing.summary ?? listing.manifest.description ?? 'No description provided.'}
+							</p>
+							<div class="flex flex-col gap-2 text-xs text-muted-foreground">
+								<div class="flex items-center gap-2">
+									<GitFork class="h-3.5 w-3.5" />
+									<a
+										href={listing.repositoryUrl}
+										rel="noreferrer"
+										target="_blank"
+										class="truncate underline decoration-dotted hover:text-foreground"
+									>
+										{listing.repositoryUrl}
+									</a>
+								</div>
+								<div class="flex items-center gap-2">
+									<ShieldCheck class="h-3.5 w-3.5" />
+									<span>{listing.manifest.license.spdxId}</span>
+								</div>
+								<div class="flex items-center gap-2">
+									<svelte:component this={listingSignature.icon} class="h-3.5 w-3.5" />
+									<span>
+										{listing.signature.signer ??
+											listing.signature.publicKey ??
+											listingSignature.label}
+									</span>
+								</div>
+								<div class="flex items-center gap-2">
+									<Info class="h-3.5 w-3.5" />
+									<span>
+										Checked {formatSignatureTime(listing.signature.checkedAt ?? null)}
+									</span>
+								</div>
+								{#if listing.signature.error}
+									<p class="text-xs text-red-500">Signature error: {listing.signature.error}</p>
+								{/if}
+							</div>
+						</div>
+						<div class="mt-4 flex items-center justify-between">
+							<span class="text-xs text-muted-foreground">
+								{listing.manifest.capabilities?.length ?? 0} capability{(listing.manifest
+									.capabilities?.length ?? 0) === 1
+									? ''
+									: 'ies'}
+							</span>
+							<Button
+								size="sm"
+								variant={isEntitled(listing.id) ? 'outline' : 'default'}
+								disabled={!canPurchase || isEntitled(listing.id) || listing.status !== 'approved'}
+								onclick={() => purchaseListing(listing)}
+							>
+								{#if isEntitled(listing.id)}
+									Entitled
+								{:else if listing.status !== 'approved'}
+									Awaiting review
+								{:else}
+									Purchase
+								{/if}
+							</Button>
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</CardContent>
+	{#if canSubmitMarketplace}
+		<CardFooter class="text-xs text-muted-foreground">
+			Developers can submit new plugins via the controller API after uploading signed release assets
+			to GitHub.
+		</CardFooter>
+	{/if}
+</Card>

--- a/tenvy-server/src/lib/components/plugins/MarketplaceGrid.svelte.test.ts
+++ b/tenvy-server/src/lib/components/plugins/MarketplaceGrid.svelte.test.ts
@@ -1,0 +1,123 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+
+import MarketplaceGrid from './MarketplaceGrid.svelte';
+import { formatSignatureTime, marketplaceStatusStyles, signatureBadge } from './utils.js';
+import type { MarketplaceEntitlement, MarketplaceListing } from './types.js';
+import type { Plugin } from '$lib/data/plugin-view.js';
+
+const signatureState: Plugin['signature'] = {
+	status: 'trusted',
+	trusted: true,
+	type: 'ed25519',
+	hash: 'abc',
+	signer: 'Signer',
+	publicKey: 'public-key',
+	signedAt: '2024-01-01T00:00:00.000Z',
+	checkedAt: '2024-01-02T00:00:00.000Z'
+};
+
+const baseListing: MarketplaceListing = {
+	id: 'listing-1',
+	name: 'Endpoint monitor',
+	summary: 'Monitors endpoints for new connections.',
+	repositoryUrl: 'https://example.com/repo',
+	version: '1.0.0',
+	pricingTier: 'Community',
+	status: 'approved',
+	manifest: {
+		id: 'plugin-1',
+		name: 'Endpoint monitor',
+		version: '1.0.0',
+		description: 'Collects connection metadata.',
+		entry: 'dist/index.js',
+		author: 'Example',
+		homepage: 'https://example.com',
+		repositoryUrl: 'https://example.com/repo',
+		license: { spdxId: 'MIT' },
+		categories: [],
+		capabilities: [],
+		requirements: {},
+		distribution: {
+			defaultMode: 'manual',
+			autoUpdate: false,
+			signature: { type: 'none' }
+		},
+		package: { artifact: 'plugin.zip' }
+	},
+	submittedBy: 'author-1',
+	reviewerId: null,
+	signature: signatureState
+};
+
+describe('MarketplaceGrid', () => {
+	it('invokes purchase callback for approved listings', async () => {
+		const purchase = vi.fn();
+
+		const { getByRole } = render(MarketplaceGrid, {
+			listings: [baseListing],
+			entitlements: [],
+			canPurchase: true,
+			canSubmitMarketplace: false,
+			purchaseListing: purchase,
+			signatureBadge,
+			formatSignatureTime,
+			statusStyles: marketplaceStatusStyles
+		});
+
+		const button = getByRole('button', { name: 'Purchase' });
+		await fireEvent.click(button);
+
+		expect(purchase).toHaveBeenCalledTimes(1);
+		expect(purchase).toHaveBeenCalledWith(baseListing);
+	});
+
+	it('disables purchase button when entitlement exists', () => {
+		const entitlement: MarketplaceEntitlement = {
+			id: 'entitlement-1',
+			listingId: baseListing.id,
+			tenantId: 'tenant-1',
+			seats: 5,
+			status: 'active',
+			listing: baseListing
+		};
+
+		const { getByRole } = render(MarketplaceGrid, {
+			listings: [baseListing],
+			entitlements: [entitlement],
+			canPurchase: true,
+			canSubmitMarketplace: false,
+			purchaseListing: vi.fn(),
+			signatureBadge,
+			formatSignatureTime,
+			statusStyles: marketplaceStatusStyles
+		});
+
+		const button = getByRole('button', { name: 'Entitled' }) as HTMLButtonElement;
+		expect(button.disabled).toBe(true);
+	});
+
+	it('prevents purchases until listings are approved', () => {
+		const pendingListing: MarketplaceListing = {
+			...baseListing,
+			id: 'listing-2',
+			status: 'pending'
+		};
+
+		const purchase = vi.fn();
+		const { getByRole } = render(MarketplaceGrid, {
+			listings: [pendingListing],
+			entitlements: [],
+			canPurchase: true,
+			canSubmitMarketplace: false,
+			purchaseListing: purchase,
+			signatureBadge,
+			formatSignatureTime,
+			statusStyles: marketplaceStatusStyles
+		});
+
+		const button = getByRole('button', { name: 'Awaiting review' }) as HTMLButtonElement;
+		expect(button.disabled).toBe(true);
+		expect(purchase).not.toHaveBeenCalled();
+	});
+});

--- a/tenvy-server/src/lib/components/plugins/PluginCard.svelte
+++ b/tenvy-server/src/lib/components/plugins/PluginCard.svelte
@@ -1,0 +1,291 @@
+<script lang="ts">
+	import { cn } from '$lib/utils.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Card,
+		CardContent,
+		CardDescription,
+		CardFooter,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+	import { Switch } from '$lib/components/ui/switch/index.js';
+	import {
+		pluginCategoryLabels,
+		pluginDeliveryModeLabels,
+		pluginStatusLabels,
+		pluginStatusStyles,
+		type Plugin,
+		type PluginUpdatePayload
+	} from '$lib/data/plugin-view.js';
+	import { Download, Info, PackageSearch, RefreshCcw, ShieldAlert, Wifi } from '@lucide/svelte';
+
+	import {
+		distributionModes,
+		distributionNotice as defaultDistributionNotice,
+		formatSignatureTime,
+		signatureBadge,
+		statusSeverity
+	} from './utils.js';
+
+	let {
+		plugin,
+		updatePlugin,
+		distributionNotice = defaultDistributionNotice
+	}: {
+		plugin: Plugin;
+		updatePlugin: (id: string, patch: PluginUpdatePayload) => void | Promise<void>;
+		distributionNotice?: (plugin: Plugin) => string;
+	} = $props();
+</script>
+
+<Card
+	class={cn(
+		'border-border/60 transition',
+		plugin.status === 'error' && 'border-red-500/40',
+		plugin.status === 'update' && 'border-amber-500/40',
+		!plugin.enabled && 'opacity-90'
+	)}
+>
+	<CardHeader class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+		<div class="space-y-2">
+			<div class="flex flex-wrap items-center gap-3">
+				<CardTitle class="text-base leading-tight font-semibold">{plugin.name}</CardTitle>
+				<Badge variant="outline" class="px-2.5 py-1 text-xs font-medium text-muted-foreground">
+					v{plugin.version}
+				</Badge>
+				<Badge
+					variant="outline"
+					class={cn('px-2.5 py-1 text-xs font-medium', pluginStatusStyles[plugin.status])}
+				>
+					{pluginStatusLabels[plugin.status]}
+				</Badge>
+				{@const sigBadge = signatureBadge(plugin.signature)}
+				<Badge
+					variant="outline"
+					class={cn('flex items-center gap-1 px-2.5 py-1 text-xs font-medium', sigBadge.class)}
+				>
+					<svelte:component this={sigBadge.icon} class="h-3.5 w-3.5" />
+					{sigBadge.label}
+				</Badge>
+			</div>
+			<CardDescription class="max-w-2xl text-sm text-muted-foreground"
+				>{plugin.description}</CardDescription
+			>
+			<div class="flex flex-wrap items-center gap-2">
+				{#each plugin.capabilities as capability (capability)}
+					<Badge variant="secondary" class="bg-muted text-muted-foreground">
+						{capability}
+					</Badge>
+				{/each}
+				{#if plugin.requiredModules.length > 0}
+					<span class="text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
+						Requires
+					</span>
+					{#each plugin.requiredModules as module (module.id)}
+						<Badge
+							variant="secondary"
+							class="border border-border/60 bg-background/60 text-foreground"
+						>
+							{module.title}
+						</Badge>
+					{/each}
+				{/if}
+			</div>
+		</div>
+		<div class="flex flex-col gap-4 text-sm text-muted-foreground">
+			<div class="flex items-center gap-2">
+				<Info class={cn('h-4 w-4', statusSeverity(plugin.status))} />
+				<span class="font-medium text-foreground">{pluginCategoryLabels[plugin.category]}</span>
+			</div>
+			<div class="grid gap-1">
+				<span>Maintainer: <strong class="font-medium text-foreground">{plugin.author}</strong></span
+				>
+				<span>Last deployed {plugin.lastDeployed}</span>
+				<span>Health check {plugin.lastChecked}</span>
+			</div>
+		</div>
+	</CardHeader>
+	<CardContent class="grid gap-4 lg:grid-cols-2">
+		<div class="grid gap-4 text-sm text-muted-foreground md:grid-cols-2 xl:grid-cols-3">
+			<div class="space-y-1 rounded-md border border-border/60 px-3 py-2">
+				<span class="text-xs tracking-wide uppercase">Signature</span>
+				{@const sig = signatureBadge(plugin.signature)}
+				<p class="flex items-center gap-2 text-sm font-semibold text-foreground">
+					<svelte:component this={sig.icon} class="h-4 w-4" />
+					{sig.label}
+				</p>
+				{#if plugin.signature.error}
+					<p class="text-xs text-muted-foreground">{plugin.signature.error}</p>
+				{:else if plugin.signature.signer}
+					<p class="text-xs text-muted-foreground">Signer: {plugin.signature.signer}</p>
+				{/if}
+				<p class="text-xs text-muted-foreground">
+					Checked {formatSignatureTime(plugin.signature.checkedAt)}
+				</p>
+			</div>
+			<div class="space-y-1 rounded-md border border-border/60 px-3 py-2">
+				<span class="text-xs tracking-wide uppercase">Installations</span>
+				<p class="text-lg font-semibold text-foreground">{plugin.installations}</p>
+			</div>
+			<div class="space-y-1 rounded-md border border-border/60 px-3 py-2">
+				<span class="text-xs tracking-wide uppercase">Package size</span>
+				<p class="text-lg font-semibold text-foreground">{plugin.size}</p>
+			</div>
+			<div class="space-y-1 rounded-md border border-border/60 px-3 py-2">
+				<span class="text-xs tracking-wide uppercase">Status</span>
+				<p class="text-lg font-semibold text-foreground">{pluginStatusLabels[plugin.status]}</p>
+			</div>
+			<div class="space-y-1 rounded-md border border-border/60 px-3 py-2">
+				<div class="flex items-center justify-between">
+					<span class="text-xs tracking-wide uppercase">Manual deployments</span>
+					<Download class="h-4 w-4 text-muted-foreground" />
+				</div>
+				<p class="text-lg font-semibold text-foreground">{plugin.distribution.manualTargets}</p>
+				<p class="text-xs text-muted-foreground">Last push {plugin.distribution.lastManualPush}</p>
+			</div>
+			<div class="space-y-1 rounded-md border border-border/60 px-3 py-2">
+				<div class="flex items-center justify-between">
+					<span class="text-xs tracking-wide uppercase">Auto enrollments</span>
+					<Wifi class="h-4 w-4 text-muted-foreground" />
+				</div>
+				<p class="text-lg font-semibold text-foreground">{plugin.distribution.autoTargets}</p>
+				<p class="text-xs text-muted-foreground">Last sync {plugin.distribution.lastAutoSync}</p>
+			</div>
+			<div class="space-y-1 rounded-md border border-border/60 px-3 py-2">
+				<div class="flex items-center justify-between">
+					<span class="text-xs tracking-wide uppercase">Package artifact</span>
+					<PackageSearch class="h-4 w-4 text-muted-foreground" />
+				</div>
+				<p class="font-medium break-words text-foreground">{plugin.artifact}</p>
+				<p class="text-xs text-muted-foreground">
+					Default: {pluginDeliveryModeLabels[plugin.distribution.defaultMode]}
+				</p>
+			</div>
+		</div>
+		<div class="flex flex-col gap-3">
+			<div class="flex items-center justify-between rounded-md border border-border/60 px-3 py-2">
+				<div class="space-y-1">
+					<p class="text-sm leading-tight font-medium">Plugin enabled</p>
+					<p class="text-xs leading-tight text-muted-foreground">
+						Controls whether the module can run on assigned clients.
+					</p>
+				</div>
+				<Switch
+					checked={plugin.enabled}
+					aria-label={`Toggle ${plugin.name}`}
+					onCheckedChange={(value) => {
+						const nextStatus = value
+							? plugin.status === 'disabled'
+								? 'active'
+								: plugin.status
+							: 'disabled';
+
+						void updatePlugin(plugin.id, {
+							enabled: value,
+							status: nextStatus
+						});
+					}}
+				/>
+			</div>
+			<div class="flex items-center justify-between rounded-md border border-border/60 px-3 py-2">
+				<div class="space-y-1">
+					<p class="text-sm leading-tight font-medium">Automatic updates</p>
+					<p class="text-xs leading-tight text-muted-foreground">
+						When enabled, new builds roll out without manual approval.
+					</p>
+				</div>
+				<Switch
+					checked={plugin.autoUpdate}
+					aria-label={`Toggle auto update for ${plugin.name}`}
+					onCheckedChange={(value) => void updatePlugin(plugin.id, { autoUpdate: value })}
+				/>
+			</div>
+			<div class="space-y-3 rounded-md border border-border/60 px-3 py-2">
+				<div class="space-y-1">
+					<p class="text-sm leading-tight font-medium">Delivery mode</p>
+					<p class="text-xs leading-tight text-muted-foreground">
+						Choose how the plugin is distributed to agents and clients.
+					</p>
+				</div>
+				<div class="flex flex-wrap gap-2">
+					{#each distributionModes as mode (mode)}
+						<Button
+							type="button"
+							size="sm"
+							variant={plugin.distribution.defaultMode === mode ? 'default' : 'outline'}
+							disabled={!plugin.enabled}
+							aria-pressed={plugin.distribution.defaultMode === mode}
+							onclick={() =>
+								void updatePlugin(plugin.id, {
+									distribution: {
+										defaultMode: mode
+									}
+								})}
+						>
+							{pluginDeliveryModeLabels[mode]}
+						</Button>
+					{/each}
+				</div>
+				<div class="grid gap-3 sm:grid-cols-2">
+					<div
+						class="flex items-center justify-between rounded-md border border-dashed border-border/60 px-3 py-2"
+					>
+						<div class="min-w-0 space-y-1">
+							<p class="text-sm leading-tight font-medium">Allow manual downloads</p>
+							<p class="text-xs leading-tight text-muted-foreground">
+								Permit operators to push the package to specific targets.
+							</p>
+						</div>
+						<Switch
+							checked={plugin.distribution.allowManualPush}
+							disabled={!plugin.enabled}
+							aria-label={`Toggle manual downloads for ${plugin.name}`}
+							onCheckedChange={(value) =>
+								void updatePlugin(plugin.id, {
+									distribution: {
+										allowManualPush: value
+									}
+								})}
+						/>
+					</div>
+					<div
+						class="flex items-center justify-between rounded-md border border-dashed border-border/60 px-3 py-2"
+					>
+						<div class="min-w-0 space-y-1">
+							<p class="text-sm leading-tight font-medium">Allow auto-sync</p>
+							<p class="text-xs leading-tight text-muted-foreground">
+								Auto-download the plugin whenever an agent connects.
+							</p>
+						</div>
+						<Switch
+							checked={plugin.distribution.allowAutoSync}
+							disabled={!plugin.enabled}
+							aria-label={`Toggle auto sync for ${plugin.name}`}
+							onCheckedChange={(value) =>
+								void updatePlugin(plugin.id, {
+									distribution: {
+										allowAutoSync: value
+									}
+								})}
+						/>
+					</div>
+				</div>
+			</div>
+		</div>
+	</CardContent>
+	<CardFooter class="flex flex-wrap items-center justify-between gap-3">
+		<div class="flex items-center gap-2 text-xs tracking-wide text-muted-foreground uppercase">
+			<ShieldAlert class="h-4 w-4" />
+			{distributionNotice(plugin)}
+		</div>
+		<div class="flex items-center gap-2">
+			<Button type="button" variant="outline" size="sm" class="gap-2">
+				<RefreshCcw class="h-4 w-4" />
+				Check for updates
+			</Button>
+			<Button type="button" size="sm" variant="ghost">Open details</Button>
+		</div>
+	</CardFooter>
+</Card>

--- a/tenvy-server/src/lib/components/plugins/PluginCard.svelte.test.ts
+++ b/tenvy-server/src/lib/components/plugins/PluginCard.svelte.test.ts
@@ -1,0 +1,108 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+
+import PluginCard from './PluginCard.svelte';
+import type { Plugin } from '$lib/data/plugin-view.js';
+
+const basePlugin: Plugin = {
+	id: 'plugin-1',
+	name: 'Endpoint monitor',
+	description: 'Collects telemetry from endpoints.',
+	version: '1.0.0',
+	author: 'Example',
+	category: 'operations',
+	status: 'active',
+	enabled: true,
+	autoUpdate: false,
+	installations: 24,
+	lastDeployed: '2024-01-01',
+	lastChecked: '2024-01-02',
+	size: '12 MB',
+	capabilities: ['Collect telemetry'],
+	artifact: 'endpoint-monitor.zip',
+	distribution: {
+		defaultMode: 'manual',
+		allowManualPush: true,
+		allowAutoSync: true,
+		manualTargets: 4,
+		autoTargets: 12,
+		lastManualPush: '2024-01-03',
+		lastAutoSync: '2024-01-04'
+	},
+	requiredModules: [],
+	approvalStatus: 'approved',
+	signature: {
+		status: 'trusted',
+		trusted: true,
+		type: 'ed25519',
+		hash: 'abc',
+		signer: 'Signer',
+		publicKey: 'public-key',
+		signedAt: '2024-01-01T00:00:00.000Z',
+		checkedAt: '2024-01-02T00:00:00.000Z'
+	}
+};
+
+describe('PluginCard', () => {
+	it('triggers update when toggling plugin enabled state', async () => {
+		const updatePlugin = vi.fn();
+		const { getByRole } = render(PluginCard, {
+			plugin: { ...basePlugin },
+			updatePlugin,
+			distributionNotice: vi.fn(() => 'Distribution summary')
+		});
+
+		const toggle = getByRole('switch', { name: `Toggle ${basePlugin.name}` });
+		await fireEvent.click(toggle);
+
+		expect(updatePlugin).toHaveBeenCalledWith(basePlugin.id, {
+			enabled: false,
+			status: 'disabled'
+		});
+	});
+
+	it('enables automatic updates via the toggle', async () => {
+		const updatePlugin = vi.fn();
+		const { getByRole } = render(PluginCard, {
+			plugin: { ...basePlugin },
+			updatePlugin,
+			distributionNotice: vi.fn(() => 'Distribution summary')
+		});
+
+		const toggle = getByRole('switch', {
+			name: `Toggle auto update for ${basePlugin.name}`
+		});
+		await fireEvent.click(toggle);
+
+		expect(updatePlugin).toHaveBeenCalledWith(basePlugin.id, { autoUpdate: true });
+	});
+
+	it('switches distribution mode when selecting automatic sync', async () => {
+		const updatePlugin = vi.fn();
+		const { getByRole } = render(PluginCard, {
+			plugin: { ...basePlugin },
+			updatePlugin,
+			distributionNotice: vi.fn(() => 'Distribution summary')
+		});
+
+		const button = getByRole('button', { name: 'Automatic sync' });
+		await fireEvent.click(button);
+
+		expect(updatePlugin).toHaveBeenCalledWith(basePlugin.id, {
+			distribution: { defaultMode: 'automatic' }
+		});
+	});
+
+	it('renders the provided distribution notice helper', () => {
+		const updatePlugin = vi.fn();
+		const distributionNotice = vi.fn(() => 'Custom distribution notice');
+		const { getByText } = render(PluginCard, {
+			plugin: { ...basePlugin },
+			updatePlugin,
+			distributionNotice
+		});
+
+		expect(getByText('Custom distribution notice')).toBeTruthy();
+		expect(distributionNotice).toHaveBeenCalled();
+	});
+});

--- a/tenvy-server/src/lib/components/plugins/types.ts
+++ b/tenvy-server/src/lib/components/plugins/types.ts
@@ -1,0 +1,30 @@
+import type { Plugin } from '$lib/data/plugin-view.js';
+import type { PluginManifest } from '../../../../shared/types/plugin-manifest.js';
+import type { UserRole } from '$lib/server/auth.js';
+
+export type MarketplaceStatus = 'pending' | 'approved' | 'rejected';
+
+export type MarketplaceListing = {
+	id: string;
+	name: string;
+	summary: string | null;
+	repositoryUrl: string;
+	version: string;
+	pricingTier: string;
+	status: MarketplaceStatus;
+	manifest: PluginManifest;
+	submittedBy: string | null;
+	reviewerId: string | null;
+	signature: Plugin['signature'];
+};
+
+export type MarketplaceEntitlement = {
+	id: string;
+	listingId: string;
+	tenantId: string;
+	seats: number;
+	status: string;
+	listing: MarketplaceListing;
+};
+
+export type AuthenticatedUser = { id: string; role: UserRole } | null;

--- a/tenvy-server/src/lib/components/plugins/utils.ts
+++ b/tenvy-server/src/lib/components/plugins/utils.ts
@@ -1,0 +1,90 @@
+import {
+	formatRelativeTime,
+	pluginDeliveryModeLabels,
+	type Plugin,
+	type PluginDeliveryMode,
+	type PluginStatus
+} from '$lib/data/plugin-view.js';
+import { ShieldAlert, ShieldCheck } from '@lucide/svelte';
+
+import type { MarketplaceStatus } from './types.js';
+
+type SignatureMeta = {
+	label: string;
+	icon: typeof ShieldCheck;
+	class: string;
+};
+
+export const distributionModes: PluginDeliveryMode[] = ['manual', 'automatic'];
+
+export function distributionNotice(plugin: Plugin): string {
+	if (!plugin.enabled) return 'Plugin currently disabled';
+
+	const notes = [`Default: ${pluginDeliveryModeLabels[plugin.distribution.defaultMode]}`];
+
+	if (!plugin.distribution.allowManualPush) {
+		notes.push('manual pushes blocked');
+	}
+
+	if (!plugin.distribution.allowAutoSync) {
+		notes.push('auto-sync paused');
+	}
+
+	return notes.join(' · ');
+}
+
+export function statusSeverity(status: PluginStatus): string {
+	switch (status) {
+		case 'error':
+			return 'text-red-500';
+		case 'update':
+			return 'text-amber-500';
+		default:
+			return 'text-muted-foreground';
+	}
+}
+
+export function signatureBadge(signature: Plugin['signature']): SignatureMeta {
+	switch (signature.status) {
+		case 'trusted':
+			return {
+				label: 'Signature trusted',
+				icon: ShieldCheck,
+				class: 'border-emerald-500/40 text-emerald-500'
+			} as const;
+		case 'unsigned':
+			return {
+				label: 'Unsigned',
+				icon: ShieldAlert,
+				class: 'border-amber-500/40 text-amber-500'
+			} as const;
+		case 'untrusted':
+			return {
+				label: 'Untrusted signature',
+				icon: ShieldAlert,
+				class: 'border-amber-500/40 text-amber-500'
+			} as const;
+		case 'invalid':
+		default:
+			return {
+				label: 'Signature invalid',
+				icon: ShieldAlert,
+				class: 'border-red-500/40 text-red-500'
+			} as const;
+	}
+}
+
+export function formatSignatureTime(value: string | null | undefined): string {
+	if (!value) return 'never';
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.valueOf())) {
+		return value;
+	}
+	return formatRelativeTime(parsed);
+}
+
+export const marketplaceStatusStyles: Record<MarketplaceStatus, string> = {
+	approved: 'border border-emerald-500/40 bg-emerald-500/10 text-emerald-500',
+	pending: 'border border-amber-500/40 bg-amber-500/10 text-amber-500',
+	rejected: 'border border-red-500/40 bg-red-500/10 text-red-500'
+};


### PR DESCRIPTION
## Summary
- extract marketplace grid and plugin card into reusable components and pass state from the page route
- share plugin marketplace helpers for signatures and distribution notes across components
- add vitest component specs covering marketplace purchase states and plugin toggle behaviour

## Testing
- ENABLE_BROWSER_TESTS=true bun test:unit -- --run *(fails: Playwright browser dependencies are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f8cffff3b4832ba2daf7e38203a35b