### PR TITLE
refactor: share marketplace data contracts

### DIFF
--- a/tenvy-server/src/lib/components/plugins/MarketplaceGrid.svelte
+++ b/tenvy-server/src/lib/components/plugins/MarketplaceGrid.svelte
@@ -13,7 +13,11 @@
 	import type { Plugin } from '$lib/data/plugin-view.js';
 	import { GitFork, Info, ShieldCheck } from '@lucide/svelte';
 
-	import type { MarketplaceEntitlement, MarketplaceListing, MarketplaceStatus } from './types.js';
+	import type {
+		MarketplaceEntitlement,
+		MarketplaceListing,
+		MarketplaceStatus
+	} from '$lib/data/marketplace.js';
 
 	let {
 		listings,

--- a/tenvy-server/src/lib/components/plugins/MarketplaceGrid.svelte.test.ts
+++ b/tenvy-server/src/lib/components/plugins/MarketplaceGrid.svelte.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import MarketplaceGrid from './MarketplaceGrid.svelte';
 import { formatSignatureTime, marketplaceStatusStyles, signatureBadge } from './utils.js';
-import type { MarketplaceEntitlement, MarketplaceListing } from './types.js';
+import type { MarketplaceEntitlement, MarketplaceListing } from '$lib/data/marketplace.js';
 import type { Plugin } from '$lib/data/plugin-view.js';
 
 const signatureState: Plugin['signature'] = {

--- a/tenvy-server/src/lib/components/plugins/types.ts
+++ b/tenvy-server/src/lib/components/plugins/types.ts
@@ -1,30 +1,10 @@
-import type { Plugin } from '$lib/data/plugin-view.js';
-import type { PluginManifest } from '../../../../shared/types/plugin-manifest.js';
+import type {
+	MarketplaceEntitlement,
+	MarketplaceListing,
+	MarketplaceStatus
+} from '$lib/data/marketplace.js';
 import type { UserRole } from '$lib/server/auth.js';
 
-export type MarketplaceStatus = 'pending' | 'approved' | 'rejected';
-
-export type MarketplaceListing = {
-	id: string;
-	name: string;
-	summary: string | null;
-	repositoryUrl: string;
-	version: string;
-	pricingTier: string;
-	status: MarketplaceStatus;
-	manifest: PluginManifest;
-	submittedBy: string | null;
-	reviewerId: string | null;
-	signature: Plugin['signature'];
-};
-
-export type MarketplaceEntitlement = {
-	id: string;
-	listingId: string;
-	tenantId: string;
-	seats: number;
-	status: string;
-	listing: MarketplaceListing;
-};
+export type { MarketplaceEntitlement, MarketplaceListing, MarketplaceStatus };
 
 export type AuthenticatedUser = { id: string; role: UserRole } | null;

--- a/tenvy-server/src/lib/components/plugins/utils.ts
+++ b/tenvy-server/src/lib/components/plugins/utils.ts
@@ -7,7 +7,7 @@ import {
 } from '$lib/data/plugin-view.js';
 import { ShieldAlert, ShieldCheck } from '@lucide/svelte';
 
-import type { MarketplaceStatus } from './types.js';
+import type { MarketplaceStatus } from '$lib/data/marketplace.js';
 
 type SignatureMeta = {
 	label: string;

--- a/tenvy-server/src/lib/data/marketplace.ts
+++ b/tenvy-server/src/lib/data/marketplace.ts
@@ -1,0 +1,60 @@
+import type {
+	PluginManifest,
+	PluginSignatureStatus,
+	PluginSignatureType
+} from '../../../../shared/types/plugin-manifest.js';
+
+export type MarketplaceStatus = 'pending' | 'approved' | 'rejected';
+
+export type MarketplaceSignature = {
+	status: PluginSignatureStatus;
+	trusted: boolean;
+	type: PluginSignatureType;
+	hash?: string | null;
+	signer?: string | null;
+	publicKey?: string | null;
+	signedAt?: string | null;
+	checkedAt?: string | null;
+	error?: string | null;
+	errorCode?: string | null;
+	certificateChain?: string[] | null;
+};
+
+export type MarketplaceListing = {
+	id: string;
+	name: string;
+	summary: string | null;
+	repositoryUrl: string;
+	version: string;
+	pricingTier: string;
+	status: MarketplaceStatus;
+	manifest: PluginManifest;
+	submittedBy: string | null;
+	reviewerId: string | null;
+	signature: MarketplaceSignature;
+};
+
+export type MarketplaceListingsResponse = {
+	listings: MarketplaceListing[];
+};
+
+export type MarketplaceListingResponse = {
+	listing: MarketplaceListing;
+};
+
+export type MarketplaceEntitlement = {
+	id: string;
+	listingId: string;
+	tenantId: string;
+	seats: number;
+	status: string;
+	listing: MarketplaceListing;
+};
+
+export type MarketplaceEntitlementsResponse = {
+	entitlements: MarketplaceEntitlement[];
+};
+
+export type MarketplaceEntitlementResponse = {
+	entitlement: MarketplaceEntitlement;
+};

--- a/tenvy-server/src/routes/(app)/plugins/+page.svelte
+++ b/tenvy-server/src/routes/(app)/plugins/+page.svelte
@@ -8,19 +8,19 @@
 		formatSignatureTime,
 		signatureBadge
 	} from '$lib/components/plugins/utils.js';
-        import { Badge } from '$lib/components/ui/badge/index.js';
-        import { Button } from '$lib/components/ui/button/index.js';
-        import {
-                Card,
-                CardContent,
-                CardDescription,
-                CardFooter,
-                CardHeader,
-                CardTitle
-        } from '$lib/components/ui/card/index.js';
-        import { Input } from '$lib/components/ui/input/index.js';
-        import { Separator } from '$lib/components/ui/separator/index.js';
-        import { Switch } from '$lib/components/ui/switch/index.js';
+	import { Badge } from '$lib/components/ui/badge/index.js';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import {
+		Card,
+		CardContent,
+		CardDescription,
+		CardFooter,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
+	import { Separator } from '$lib/components/ui/separator/index.js';
+	import { Switch } from '$lib/components/ui/switch/index.js';
 	import {
 		pluginCategories,
 		pluginCategoryLabels,
@@ -31,11 +31,8 @@
 		type PluginStatus,
 		type PluginUpdatePayload
 	} from '$lib/data/plugin-view.js';
-	import type {
-		AuthenticatedUser,
-		MarketplaceEntitlement,
-		MarketplaceListing
-	} from '$lib/components/plugins/types.js';
+	import type { MarketplaceEntitlement, MarketplaceListing } from '$lib/data/marketplace.js';
+	import type { AuthenticatedUser } from '$lib/components/plugins/types.js';
 	import { Check, Info, RefreshCcw, Search, SlidersHorizontal } from '@lucide/svelte';
 
 	let {

--- a/tenvy-server/src/routes/(app)/plugins/+page.ts
+++ b/tenvy-server/src/routes/(app)/plugins/+page.ts
@@ -2,62 +2,21 @@ import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 import type { Plugin } from '$lib/data/plugin-view.js';
 import type {
-        PluginManifest,
-        PluginSignatureStatus,
-        PluginSignatureType
-} from '../../../../../shared/types/plugin-manifest.js';
+	MarketplaceEntitlementsResponse,
+	MarketplaceListingsResponse
+} from '$lib/data/marketplace.js';
 import type { UserRole } from '$lib/server/auth.js';
 
 type PluginListResponse = { plugins: Plugin[] };
-type MarketplaceStatus = 'pending' | 'approved' | 'rejected';
-
-type MarketplaceSignature = {
-        status: PluginSignatureStatus;
-        trusted: boolean;
-        type: PluginSignatureType;
-        hash?: string | null;
-        signer?: string | null;
-        publicKey?: string | null;
-        signedAt?: string | null;
-        checkedAt?: string | null;
-        error?: string | null;
-        errorCode?: string | null;
-        certificateChain?: string[] | null;
-};
-
-type MarketplaceListing = {
-        id: string;
-        name: string;
-        summary: string | null;
-        repositoryUrl: string;
-        version: string;
-        pricingTier: string;
-        status: MarketplaceStatus;
-        manifest: PluginManifest;
-        submittedBy: string | null;
-        reviewerId: string | null;
-        signature: MarketplaceSignature;
-};
-
-type MarketplaceListingsResponse = { listings: MarketplaceListing[] };
-
-type MarketplaceEntitlement = {
-	id: string;
-	listingId: string;
-	tenantId: string;
-	seats: number;
-	status: string;
-	listing: MarketplaceListing;
-};
-
-type MarketplaceEntitlementsResponse = { entitlements: MarketplaceEntitlement[] };
 
 type MinimalUser = { id: string; role: UserRole };
 
 export const load: PageLoad = async ({ fetch, parent }) => {
-        const parentData = await parent<{ user?: MinimalUser | null }>();
+	const parentData = await parent<{ user?: MinimalUser | null }>();
 
-        const minimalUser = parentData.user ? { id: parentData.user.id, role: parentData.user.role } : null;
+	const minimalUser = parentData.user
+		? { id: parentData.user.id, role: parentData.user.role }
+		: null;
 
 	const [pluginsResponse, listingsResponse, entitlementsResponse] = await Promise.all([
 		fetch('/api/plugins'),
@@ -88,7 +47,7 @@ export const load: PageLoad = async ({ fetch, parent }) => {
 	return {
 		plugins: pluginsPayload.plugins,
 		listings: listingsPayload.listings,
-                entitlements: entitlementsPayload.entitlements,
-                user: minimalUser
-        };
+		entitlements: entitlementsPayload.entitlements,
+		user: minimalUser
+	};
 };


### PR DESCRIPTION
## Summary
- add a shared `$lib/data/marketplace` module with marketplace listings, signatures, and response contracts
- update the plugins page load function and route component to consume the shared marketplace types
- switch marketplace utilities, grid component, and tests to import the shared contracts to keep definitions in sync

## Testing
- bun check *(fails: existing type errors in unrelated build and client modules)*

------
https://chatgpt.com/codex/tasks/task_e_68f8d4a24ae0832bbf24f12b7248da5b