### PR TITLE
feat: add geo lookup proxy

### DIFF
--- a/tenvy-server/src/lib/utils/ip.ts
+++ b/tenvy-server/src/lib/utils/ip.ts
@@ -1,0 +1,40 @@
+export function isLikelyPrivateIp(ip: string): boolean {
+        if (!ip) {
+                return false;
+        }
+
+        const trimmed = ip.trim();
+        if (!trimmed) {
+                return false;
+        }
+
+        const normalized = trimmed
+                .replace(/^\[(.*)]$/, '$1')
+                .toLowerCase();
+
+        if (
+                normalized === '::1' ||
+                normalized === '0:0:0:0:0:0:0:1' ||
+                normalized === '::' ||
+                normalized.startsWith('fe80:') ||
+                normalized.startsWith('fc') ||
+                normalized.startsWith('fd')
+        ) {
+                return true;
+        }
+
+        const ipv4Candidate = normalized.startsWith('::ffff:')
+                ? normalized.slice('::ffff:'.length)
+                : normalized;
+
+        if (ipv4Candidate === '0.0.0.0') {
+                return true;
+        }
+
+        return (
+                ipv4Candidate.startsWith('10.') ||
+                ipv4Candidate.startsWith('192.168.') ||
+                /^172\.(1[6-9]|2\d|3[0-1])\./.test(ipv4Candidate) ||
+                ipv4Candidate.startsWith('127.')
+        );
+}

--- a/tenvy-server/src/routes/api/geo/[ip]/+server.ts
+++ b/tenvy-server/src/routes/api/geo/[ip]/+server.ts
@@ -1,0 +1,127 @@
+import { json, error } from '@sveltejs/kit';
+import { isIP } from 'node:net';
+import { isLikelyPrivateIp } from '$lib/utils/ip';
+import type { RequestHandler } from './$types';
+
+const CACHE_TTL_SECONDS = 15 * 60;
+const CACHE_TTL_MS = CACHE_TTL_SECONDS * 1000;
+
+export type GeoLookupPayload = {
+        countryName: string | null;
+        countryCode: string | null;
+        isProxy: boolean;
+};
+
+type CacheEntry = {
+        expiresAt: number;
+        payload: GeoLookupPayload;
+};
+
+const geoCache = new Map<string, CacheEntry>();
+
+function normalizeIp(ipParam: string | undefined): string {
+        const raw = (ipParam ?? '').trim();
+        if (!raw) {
+                return '';
+        }
+
+        const withoutBrackets = raw.startsWith('[') && raw.endsWith(']') ? raw.slice(1, -1) : raw;
+        return withoutBrackets.toLowerCase();
+}
+
+function getCached(ip: string): GeoLookupPayload | null {
+        const cached = geoCache.get(ip);
+        if (!cached) {
+                return null;
+        }
+
+        if (cached.expiresAt < Date.now()) {
+                geoCache.delete(ip);
+                return null;
+        }
+
+        return cached.payload;
+}
+
+function setCached(ip: string, payload: GeoLookupPayload): void {
+        geoCache.set(ip, {
+                expiresAt: Date.now() + CACHE_TTL_MS,
+                payload
+        });
+}
+
+async function fetchGeoData(
+        fetchFn: typeof fetch,
+        ip: string
+): Promise<GeoLookupPayload> {
+        const endpoint = new URL(`https://ip-api.com/json/${encodeURIComponent(ip)}`);
+        endpoint.searchParams.set('fields', 'status,message,country,countryCode,proxy');
+
+        let response: Response;
+        try {
+                response = await fetchFn(endpoint.toString(), {
+                        headers: { Accept: 'application/json' }
+                });
+        } catch (err) {
+                throw error(502, 'Failed to contact geo provider');
+        }
+
+        if (!response.ok) {
+                throw error(502, 'Geo provider returned an unexpected response');
+        }
+
+        let payload: {
+                status?: 'success' | 'fail';
+                message?: string;
+                country?: string;
+                countryCode?: string;
+                proxy?: boolean;
+        };
+
+        try {
+                payload = (await response.json()) as typeof payload;
+        } catch (err) {
+                throw error(502, 'Geo provider returned malformed data');
+        }
+
+        if (payload.status !== 'success') {
+                throw error(502, payload.message ?? 'Geo lookup failed');
+        }
+
+        const countryName = payload.country?.trim() || null;
+        const countryCode = payload.countryCode?.trim().toUpperCase() || null;
+
+        return {
+                countryName,
+                countryCode,
+                isProxy: payload.proxy === true
+        } satisfies GeoLookupPayload;
+}
+
+export const GET: RequestHandler = async ({ params, fetch, setHeaders }) => {
+        const ip = normalizeIp(params.ip);
+        if (!ip || isIP(ip) === 0 || isLikelyPrivateIp(ip)) {
+                throw error(400, 'Invalid IP address');
+        }
+
+        const cached = getCached(ip);
+        if (cached) {
+                setHeaders({
+                        'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}`
+                });
+                return json(cached satisfies GeoLookupPayload);
+        }
+
+        const payload = await fetchGeoData(fetch, ip);
+        setCached(ip, payload);
+
+        setHeaders({
+                'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}`
+        });
+
+        return json(payload satisfies GeoLookupPayload);
+};
+
+export const __testing = {
+        clearCache: () => geoCache.clear()
+};

--- a/tenvy-server/tests/geo-proxy.test.ts
+++ b/tenvy-server/tests/geo-proxy.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HttpError } from '@sveltejs/kit';
+import { GET, __testing } from '../src/routes/api/geo/[ip]/+server.js';
+
+function createEvent(
+        ip: string,
+        fetchMock: typeof fetch,
+        setHeaders: (headers: Record<string, string>) => void = vi.fn()
+) {
+        return {
+                params: { ip },
+                fetch: fetchMock,
+                setHeaders
+        } as unknown as Parameters<typeof GET>[0];
+}
+
+describe('GET /api/geo/[ip]', () => {
+        beforeEach(() => {
+                __testing.clearCache();
+        });
+
+        it('returns provider data for a valid public IP', async () => {
+                const fetchMock = vi.fn(async () =>
+                        new Response(
+                                JSON.stringify({
+                                        status: 'success',
+                                        country: 'United States',
+                                        countryCode: 'us',
+                                        proxy: false
+                                }),
+                                {
+                                        status: 200,
+                                        headers: { 'Content-Type': 'application/json' }
+                                }
+                        )
+                );
+
+                const setHeaders = vi.fn();
+                const response = await GET(createEvent('8.8.8.8', fetchMock, setHeaders));
+
+                expect(fetchMock).toHaveBeenCalledTimes(1);
+                expect(fetchMock.mock.calls[0]?.[0]).toContain('https://ip-api.com/json/8.8.8.8');
+
+                const payload = (await response.json()) as {
+                        countryName: string | null;
+                        countryCode: string | null;
+                        isProxy: boolean;
+                };
+
+                expect(payload.countryName).toBe('United States');
+                expect(payload.countryCode).toBe('US');
+                expect(payload.isProxy).toBe(false);
+                expect(setHeaders).toHaveBeenCalledWith({ 'Cache-Control': 'public, max-age=900' });
+        });
+
+        it('serves cached responses without hitting the provider again', async () => {
+                const fetchMock = vi.fn(async () =>
+                        new Response(
+                                JSON.stringify({
+                                        status: 'success',
+                                        country: 'Canada',
+                                        countryCode: 'CA',
+                                        proxy: true
+                                }),
+                                {
+                                        status: 200,
+                                        headers: { 'Content-Type': 'application/json' }
+                                }
+                        )
+                );
+
+                await GET(createEvent('1.1.1.1', fetchMock));
+
+                const fetchMockSecond = vi.fn();
+                const setHeadersSecond = vi.fn();
+                const cachedResponse = await GET(createEvent('1.1.1.1', fetchMockSecond, setHeadersSecond));
+
+                expect(fetchMock).toHaveBeenCalledTimes(1);
+                expect(fetchMockSecond).not.toHaveBeenCalled();
+                const payload = await cachedResponse.json();
+                expect(payload.countryName).toBe('Canada');
+                expect(payload.isProxy).toBe(true);
+                expect(setHeadersSecond).toHaveBeenCalledWith({ 'Cache-Control': 'public, max-age=900' });
+        });
+
+        it('rejects invalid IP addresses', async () => {
+                await expect(() => GET(createEvent('not-an-ip', vi.fn(), vi.fn()))).rejects.toMatchObject({ status: 400 });
+
+                await expect(() => GET(createEvent('192.168.1.10', vi.fn(), vi.fn()))).rejects.toMatchObject({ status: 400 });
+        });
+
+        it('propagates provider failures as a 502 error', async () => {
+                const fetchMock = vi.fn(async () =>
+                        new Response(
+                                JSON.stringify({ status: 'fail', message: 'invalid query' }),
+                                {
+                                        status: 200,
+                                        headers: { 'Content-Type': 'application/json' }
+                                }
+                        )
+                );
+
+                try {
+                        await GET(createEvent('2.2.2.2', fetchMock, vi.fn()));
+                        throw new Error('Expected request to fail');
+                } catch (error) {
+                        const err = error as HttpError;
+                        expect(err.status).toBe(502);
+                        const message =
+                                typeof err.body === 'object' && err.body && 'message' in err.body
+                                        ? String((err.body as { message?: unknown }).message ?? '')
+                                        : String(err.message ?? err);
+                        expect(message).toContain('invalid query');
+                }
+        });
+});


### PR DESCRIPTION
## Summary
- add a controller-side geo lookup endpoint that validates IPs, calls the upstream provider over HTTPS, and caches responses
- share a reusable private-IP detector and point the clients table row component at the internal proxy while preserving its caches
- cover successful lookups, cache hits, and provider failures with dedicated unit tests

## Testing
- npm run test:unit -- --run *(fails: existing suite contains unrelated failing tests in plugin/remote desktop specs)*
- npx vitest run tests/geo-proxy.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68f8ed664d5c832bbcfaf84bea5ecfce