### PR TITLE
Add shared geo lookup for clients table

### DIFF
--- a/tenvy-server/src/routes/api/geo/+server.ts
+++ b/tenvy-server/src/routes/api/geo/+server.ts
@@ -1,0 +1,73 @@
+import { error, json } from '@sveltejs/kit';
+import {
+	normalizeIp,
+	validateLookupTarget,
+	getCachedGeo,
+	fetchGeoData,
+	setCachedGeo,
+	type GeoLookupPayload
+} from './lookup';
+import type { RequestHandler } from './$types';
+
+function isString(value: unknown): value is string {
+	return typeof value === 'string' || value instanceof String;
+}
+
+export const POST: RequestHandler = async ({ request, fetch }) => {
+	let payload: unknown;
+	try {
+		payload = await request.json();
+	} catch (err) {
+		throw error(400, 'Invalid request body');
+	}
+
+	if (!Array.isArray(payload)) {
+		throw error(400, 'Expected an array of IP addresses');
+	}
+
+	const uniqueIps = new Set<string>();
+	for (const candidate of payload) {
+		if (!isString(candidate)) {
+			continue;
+		}
+		const normalized = normalizeIp(candidate);
+		if (!normalized) {
+			continue;
+		}
+		try {
+			validateLookupTarget(normalized);
+		} catch {
+			continue;
+		}
+		uniqueIps.add(normalized);
+	}
+
+	if (uniqueIps.size === 0) {
+		return json({});
+	}
+
+	const results: Record<string, GeoLookupPayload> = {};
+	const pending: Promise<void>[] = [];
+
+	for (const ip of uniqueIps) {
+		const cached = getCachedGeo(ip);
+		if (cached) {
+			results[ip] = cached;
+			continue;
+		}
+
+		pending.push(
+			(async () => {
+				const lookup = await fetchGeoData(fetch, ip);
+				setCachedGeo(ip, lookup);
+				results[ip] = lookup;
+			})()
+		);
+	}
+
+	if (pending.length > 0) {
+		await Promise.allSettled(pending);
+	}
+
+	return json(results satisfies Record<string, GeoLookupPayload>);
+};

--- a/tenvy-server/src/routes/api/geo/[ip]/+server.ts
+++ b/tenvy-server/src/routes/api/geo/[ip]/+server.ts
@@ -1,127 +1,38 @@
-import { json, error } from '@sveltejs/kit';
-import { isIP } from 'node:net';
-import { isLikelyPrivateIp } from '$lib/utils/ip';
+import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-
-const CACHE_TTL_SECONDS = 15 * 60;
-const CACHE_TTL_MS = CACHE_TTL_SECONDS * 1000;
-
-export type GeoLookupPayload = {
-        countryName: string | null;
-        countryCode: string | null;
-        isProxy: boolean;
-};
-
-type CacheEntry = {
-        expiresAt: number;
-        payload: GeoLookupPayload;
-};
-
-const geoCache = new Map<string, CacheEntry>();
-
-function normalizeIp(ipParam: string | undefined): string {
-        const raw = (ipParam ?? '').trim();
-        if (!raw) {
-                return '';
-        }
-
-        const withoutBrackets = raw.startsWith('[') && raw.endsWith(']') ? raw.slice(1, -1) : raw;
-        return withoutBrackets.toLowerCase();
-}
-
-function getCached(ip: string): GeoLookupPayload | null {
-        const cached = geoCache.get(ip);
-        if (!cached) {
-                return null;
-        }
-
-        if (cached.expiresAt < Date.now()) {
-                geoCache.delete(ip);
-                return null;
-        }
-
-        return cached.payload;
-}
-
-function setCached(ip: string, payload: GeoLookupPayload): void {
-        geoCache.set(ip, {
-                expiresAt: Date.now() + CACHE_TTL_MS,
-                payload
-        });
-}
-
-async function fetchGeoData(
-        fetchFn: typeof fetch,
-        ip: string
-): Promise<GeoLookupPayload> {
-        const endpoint = new URL(`https://ip-api.com/json/${encodeURIComponent(ip)}`);
-        endpoint.searchParams.set('fields', 'status,message,country,countryCode,proxy');
-
-        let response: Response;
-        try {
-                response = await fetchFn(endpoint.toString(), {
-                        headers: { Accept: 'application/json' }
-                });
-        } catch (err) {
-                throw error(502, 'Failed to contact geo provider');
-        }
-
-        if (!response.ok) {
-                throw error(502, 'Geo provider returned an unexpected response');
-        }
-
-        let payload: {
-                status?: 'success' | 'fail';
-                message?: string;
-                country?: string;
-                countryCode?: string;
-                proxy?: boolean;
-        };
-
-        try {
-                payload = (await response.json()) as typeof payload;
-        } catch (err) {
-                throw error(502, 'Geo provider returned malformed data');
-        }
-
-        if (payload.status !== 'success') {
-                throw error(502, payload.message ?? 'Geo lookup failed');
-        }
-
-        const countryName = payload.country?.trim() || null;
-        const countryCode = payload.countryCode?.trim().toUpperCase() || null;
-
-        return {
-                countryName,
-                countryCode,
-                isProxy: payload.proxy === true
-        } satisfies GeoLookupPayload;
-}
+import {
+	CACHE_TTL_SECONDS,
+	fetchGeoData,
+	getCachedGeo,
+	normalizeIp,
+	setCachedGeo,
+	validateLookupTarget,
+	type GeoLookupPayload,
+	__testing as sharedTesting
+} from '../lookup';
 
 export const GET: RequestHandler = async ({ params, fetch, setHeaders }) => {
-        const ip = normalizeIp(params.ip);
-        if (!ip || isIP(ip) === 0 || isLikelyPrivateIp(ip)) {
-                throw error(400, 'Invalid IP address');
-        }
+	const ip = normalizeIp(params.ip);
+	validateLookupTarget(ip);
 
-        const cached = getCached(ip);
-        if (cached) {
-                setHeaders({
-                        'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}`
-                });
-                return json(cached satisfies GeoLookupPayload);
-        }
+	const cached = getCachedGeo(ip);
+	if (cached) {
+		setHeaders({
+			'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}`
+		});
+		return json(cached satisfies GeoLookupPayload);
+	}
 
-        const payload = await fetchGeoData(fetch, ip);
-        setCached(ip, payload);
+	const payload = await fetchGeoData(fetch, ip);
+	setCachedGeo(ip, payload);
 
-        setHeaders({
-                'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}`
-        });
+	setHeaders({
+		'Cache-Control': `public, max-age=${CACHE_TTL_SECONDS}`
+	});
 
-        return json(payload satisfies GeoLookupPayload);
+	return json(payload satisfies GeoLookupPayload);
 };
 
 export const __testing = {
-        clearCache: () => geoCache.clear()
+	clearCache: () => sharedTesting.clearCache()
 };

--- a/tenvy-server/src/routes/api/geo/lookup.ts
+++ b/tenvy-server/src/routes/api/geo/lookup.ts
@@ -1,0 +1,105 @@
+import { error } from '@sveltejs/kit';
+import { isIP } from 'node:net';
+import { isLikelyPrivateIp } from '$lib/utils/ip';
+
+export const CACHE_TTL_SECONDS = 15 * 60;
+const CACHE_TTL_MS = CACHE_TTL_SECONDS * 1000;
+
+export type GeoLookupPayload = {
+	countryName: string | null;
+	countryCode: string | null;
+	isProxy: boolean;
+};
+
+type CacheEntry = {
+	expiresAt: number;
+	payload: GeoLookupPayload;
+};
+
+const geoCache = new Map<string, CacheEntry>();
+
+export function normalizeIp(rawValue: string | null | undefined): string {
+	const raw = (rawValue ?? '').trim();
+	if (!raw) {
+		return '';
+	}
+
+	const withoutBrackets = raw.startsWith('[') && raw.endsWith(']') ? raw.slice(1, -1) : raw;
+	return withoutBrackets.toLowerCase();
+}
+
+export function validateLookupTarget(ip: string): void {
+	if (!ip || isIP(ip) === 0 || isLikelyPrivateIp(ip)) {
+		throw error(400, 'Invalid IP address');
+	}
+}
+
+export function getCachedGeo(ip: string): GeoLookupPayload | null {
+	const cached = geoCache.get(ip);
+	if (!cached) {
+		return null;
+	}
+
+	if (cached.expiresAt < Date.now()) {
+		geoCache.delete(ip);
+		return null;
+	}
+
+	return cached.payload;
+}
+
+export function setCachedGeo(ip: string, payload: GeoLookupPayload): void {
+	geoCache.set(ip, {
+		expiresAt: Date.now() + CACHE_TTL_MS,
+		payload
+	});
+}
+
+export async function fetchGeoData(fetchFn: typeof fetch, ip: string): Promise<GeoLookupPayload> {
+	const endpoint = new URL(`https://ip-api.com/json/${encodeURIComponent(ip)}`);
+	endpoint.searchParams.set('fields', 'status,message,country,countryCode,proxy');
+
+	let response: Response;
+	try {
+		response = await fetchFn(endpoint.toString(), {
+			headers: { Accept: 'application/json' }
+		});
+	} catch (err) {
+		throw error(502, 'Failed to contact geo provider');
+	}
+
+	if (!response.ok) {
+		throw error(502, 'Geo provider returned an unexpected response');
+	}
+
+	let payload: {
+		status?: 'success' | 'fail';
+		message?: string;
+		country?: string;
+		countryCode?: string;
+		proxy?: boolean;
+	};
+
+	try {
+		payload = (await response.json()) as typeof payload;
+	} catch (err) {
+		throw error(502, 'Geo provider returned malformed data');
+	}
+
+	if (payload.status !== 'success') {
+		throw error(502, payload.message ?? 'Geo lookup failed');
+	}
+
+	const countryName = payload.country?.trim() || null;
+	const countryCode = payload.countryCode?.trim().toUpperCase() || null;
+
+	return {
+		countryName,
+		countryCode,
+		isProxy: payload.proxy === true
+	} satisfies GeoLookupPayload;
+}
+
+export const __testing = {
+	clearCache: () => geoCache.clear()
+};


### PR DESCRIPTION
## Summary
- extract the geo lookup cache helpers into a shared module and add a bulk lookup API route
- hydrate the clients page with shared public IP lookups and pass the cache into each table row
- simplify the table row to rely on the shared map instead of per-row fetches

## Testing
- bun check *(fails: existing type errors in unrelated build/dashboard routes)*

------
https://chatgpt.com/codex/tasks/task_e_68f8f4f88908832ba5a10a06b539c068