### PR TITLE
Prevent link-local IPv4 addresses from being treated as public

### DIFF
--- a/tenvy-server/src/lib/utils/ip.test.ts
+++ b/tenvy-server/src/lib/utils/ip.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { isLikelyPrivateIp } from './ip.js';
+
+describe('isLikelyPrivateIp', () => {
+        it('treats IPv4 link-local addresses as private', () => {
+                expect(isLikelyPrivateIp('169.254.10.20')).toBe(true);
+        });
+
+        it('treats IPv4-mapped link-local IPv6 addresses as private', () => {
+                expect(isLikelyPrivateIp('::ffff:169.254.42.99')).toBe(true);
+        });
+
+        it('does not treat public IPv4 addresses as private', () => {
+                expect(isLikelyPrivateIp('8.8.8.8')).toBe(false);
+        });
+});

--- a/tenvy-server/src/lib/utils/ip.ts
+++ b/tenvy-server/src/lib/utils/ip.ts
@@ -25,14 +25,15 @@ export function isLikelyPrivateIp(ip: string): boolean {
 		? normalized.slice('::ffff:'.length)
 		: normalized;
 
-	if (ipv4Candidate === '0.0.0.0') {
-		return true;
-	}
+        if (ipv4Candidate === '0.0.0.0') {
+                return true;
+        }
 
-	return (
-		ipv4Candidate.startsWith('10.') ||
-		ipv4Candidate.startsWith('192.168.') ||
-		/^172\.(1[6-9]|2\d|3[0-1])\./.test(ipv4Candidate) ||
-		ipv4Candidate.startsWith('127.')
-	);
+        return (
+                ipv4Candidate.startsWith('10.') ||
+                ipv4Candidate.startsWith('192.168.') ||
+                ipv4Candidate.startsWith('169.254.') ||
+                /^172\.(1[6-9]|2\d|3[0-1])\./.test(ipv4Candidate) ||
+                ipv4Candidate.startsWith('127.')
+        );
 }


### PR DESCRIPTION
## Summary
- update the IP utility to classify IPv4 link-local addresses as private
- cover IPv4 and IPv4-mapped IPv6 link-local addresses with unit tests

## Testing
- bun test src/lib/utils/ip.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f92809046c832b838cd28e21608751