### PR TITLE
Fix splitCommandLine to preserve empty quoted arguments

### DIFF
--- a/shared/utils/command.ts
+++ b/shared/utils/command.ts
@@ -3,42 +3,49 @@ export function splitCommandLine(input: string): string[] {
         let current = '';
         let quote: '"' | "'" | null = null;
         let escape = false;
+        let inToken = false;
 
         for (const char of input.trim()) {
                 if (escape) {
                         current += char;
                         escape = false;
+                        inToken = true;
                         continue;
                 }
 
                 if (char === '\\' && quote !== "'") {
                         escape = true;
+                        inToken = true;
                         continue;
                 }
 
                 if (char === '"' || char === "'") {
                         if (quote === char) {
                                 quote = null;
+                                inToken = true;
                                 continue;
                         }
                         if (!quote) {
                                 quote = char;
+                                inToken = true;
                                 continue;
                         }
                 }
 
                 if (!quote && /\s/.test(char)) {
-                        if (current) {
+                        if (inToken) {
                                 tokens.push(current);
                                 current = '';
+                                inToken = false;
                         }
                         continue;
                 }
 
                 current += char;
+                inToken = true;
         }
 
-        if (current) {
+        if (inToken) {
                 tokens.push(current);
         }
 

--- a/tenvy-server/tests/command-utils.test.ts
+++ b/tenvy-server/tests/command-utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { splitCommandLine } from '../../shared/utils/command.ts';
+
+describe('splitCommandLine', () => {
+        it('preserves empty arguments created by double quotes', () => {
+                expect(splitCommandLine(['cmd', '""', 'arg'].join(' '))).toEqual(['cmd', '', 'arg']);
+        });
+
+        it('preserves multiple adjacent empty arguments', () => {
+                expect(splitCommandLine(['""', '""'].join(' '))).toEqual(['', '']);
+        });
+});


### PR DESCRIPTION
## Summary
- track in-progress tokens in `splitCommandLine` so empty quoted arguments are preserved
- add regression tests for empty quoted tokens in `splitCommandLine`

## Testing
- bun test tests/command-utils.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f930395b6c832b9d7271c6c2eef65a