### PR TITLE
Handle App VNC input bursts

### DIFF
--- a/tenvy-client/internal/agent/command_stream_test.go
+++ b/tenvy-client/internal/agent/command_stream_test.go
@@ -35,6 +35,37 @@ func (stubRemoteDesktopEngine) DeliverFrame(context.Context, remotedesktop.Remot
 }
 func (stubRemoteDesktopEngine) Shutdown() {}
 
+type recordingAppVncHandler struct {
+	mu     sync.Mutex
+	bursts []protocol.AppVncInputBurst
+}
+
+func (r *recordingAppVncHandler) HandleInputBurst(_ context.Context, burst protocol.AppVncInputBurst) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	copyBurst := protocol.AppVncInputBurst{
+		SessionID: burst.SessionID,
+		Sequence:  burst.Sequence,
+		Events:    append([]protocol.AppVncInputEvent(nil), burst.Events...),
+	}
+	r.bursts = append(r.bursts, copyBurst)
+	return nil
+}
+
+func (r *recordingAppVncHandler) snapshot() []protocol.AppVncInputBurst {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]protocol.AppVncInputBurst, len(r.bursts))
+	copy(out, r.bursts)
+	for i, burst := range out {
+		if len(burst.Events) > 0 {
+			events := append([]protocol.AppVncInputEvent(nil), burst.Events...)
+			out[i].Events = events
+		}
+	}
+	return out
+}
+
 func makeTestAgent(baseURL string, client *http.Client, router *commandRouter) *Agent {
 	return &Agent{
 		id:             "agent-1",
@@ -175,6 +206,142 @@ func TestCommandStreamDeliversImmediately(t *testing.T) {
 		}
 	case <-ctx.Done():
 		t.Fatalf("command was not executed: %v", ctx.Err())
+	}
+}
+
+func TestCommandStreamDispatchesAppVncInput(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	router := newCommandRouter()
+	handler := &recordingAppVncHandler{}
+
+	var connMu sync.Mutex
+	var sessionConn *websocket.Conn
+	sessionReady := make(chan struct{})
+	var sessionOnce sync.Once
+
+	var tokenMu sync.Mutex
+	var issuedToken string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/agents/agent-1/session-token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+			return
+		}
+		token := fmt.Sprintf("session-%d", time.Now().UnixNano())
+		tokenMu.Lock()
+		issuedToken = token
+		tokenMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(sessionTokenResponse{
+			Token:     token,
+			ExpiresAt: time.Now().Add(30 * time.Second).UTC().Format(time.RFC3339Nano),
+		})
+	})
+	mux.HandleFunc("/api/agents/agent-1/session", func(w http.ResponseWriter, r *http.Request) {
+		tokenMu.Lock()
+		token := issuedToken
+		tokenMu.Unlock()
+		if got := r.Header.Get(sessionTokenHeader); got != token {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		c, err := websocket.Accept(w, r, &websocket.AcceptOptions{Subprotocols: []string{protocol.CommandStreamSubprotocol}})
+		if err != nil {
+			t.Errorf("accept websocket: %v", err)
+			return
+		}
+		connMu.Lock()
+		sessionConn = c
+		connMu.Unlock()
+		sessionOnce.Do(func() {
+			close(sessionReady)
+		})
+	})
+	mux.HandleFunc("/api/agents/agent-1/sync", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(protocol.AgentSyncResponse{AgentID: "agent-1", ServerTime: time.Now().UTC().Format(time.RFC3339Nano)})
+	})
+
+	srv := httptest.NewTLSServer(mux)
+	defer srv.Close()
+
+	agent := makeTestAgent(srv.URL, srv.Client(), router)
+	agent.modules = &moduleManager{appVnc: handler}
+
+	go agent.runCommandStream(ctx)
+
+	select {
+	case <-sessionReady:
+	case <-ctx.Done():
+		t.Fatalf("command stream did not connect: %v", ctx.Err())
+	}
+
+	connMu.Lock()
+	c := sessionConn
+	connMu.Unlock()
+	if c == nil {
+		t.Fatalf("session connection not captured")
+	}
+	defer c.Close(websocket.StatusNormalClosure, "test complete")
+
+	burst := protocol.AppVncInputBurst{
+		SessionID: "session-1",
+		Sequence:  42,
+		Events: []protocol.AppVncInputEvent{{
+			Type:       protocol.AppVncInputPointerMove,
+			CapturedAt: time.Now().UnixMilli(),
+			X:          0.5,
+			Y:          0.25,
+			Normalized: true,
+		}},
+	}
+	payload := protocol.CommandEnvelope{
+		Type:        "app-vnc-input",
+		AppVncInput: &burst,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal app-vnc input: %v", err)
+	}
+
+	if err := c.Write(ctx, websocket.MessageText, data); err != nil {
+		t.Fatalf("write app-vnc input: %v", err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("app-vnc burst not delivered")
+		default:
+			bursts := handler.snapshot()
+			if len(bursts) > 0 {
+				received := bursts[0]
+				if received.SessionID != burst.SessionID {
+					t.Fatalf("unexpected session id: %s", received.SessionID)
+				}
+				if received.Sequence != burst.Sequence {
+					t.Fatalf("unexpected sequence: %d", received.Sequence)
+				}
+				if len(received.Events) != len(burst.Events) {
+					t.Fatalf("unexpected event count: %d", len(received.Events))
+				}
+				if received.Events[0].Type != burst.Events[0].Type {
+					t.Fatalf("unexpected event type: %s", received.Events[0].Type)
+				}
+				if received.Events[0].X != burst.Events[0].X || received.Events[0].Y != burst.Events[0].Y {
+					t.Fatalf("unexpected pointer coordinates: %v,%v", received.Events[0].X, received.Events[0].Y)
+				}
+				if !received.Events[0].Normalized {
+					t.Fatalf("expected normalized flag")
+				}
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
 	}
 }
 

--- a/tenvy-client/internal/modules/control/appvnc/controller_test.go
+++ b/tenvy-client/internal/modules/control/appvnc/controller_test.go
@@ -1,0 +1,106 @@
+package appvnc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rootbay/tenvy-client/internal/protocol"
+)
+
+func TestHandleInputBurstValidatesSession(t *testing.T) {
+	controller := NewController()
+
+	err := controller.HandleInputBurst(context.Background(), protocol.AppVncInputBurst{
+		SessionID: "session-1",
+		Events: []protocol.AppVncInputEvent{{
+			Type:       protocol.AppVncInputPointerMove,
+			CapturedAt: 1,
+			X:          0.1,
+			Y:          0.2,
+		}},
+	})
+	if err == nil || err.Error() != "no active session" {
+		t.Fatalf("expected no active session error, got: %v", err)
+	}
+
+	controller.session = &sessionState{id: "session-1"}
+
+	err = controller.HandleInputBurst(context.Background(), protocol.AppVncInputBurst{
+		SessionID: " ",
+		Events: []protocol.AppVncInputEvent{{
+			Type:       protocol.AppVncInputPointerMove,
+			CapturedAt: 2,
+			X:          0.3,
+			Y:          0.4,
+		}},
+	})
+	if err == nil || err.Error() != "missing session identifier" {
+		t.Fatalf("expected missing session identifier error, got: %v", err)
+	}
+
+	err = controller.HandleInputBurst(context.Background(), protocol.AppVncInputBurst{
+		SessionID: "session-2",
+		Events: []protocol.AppVncInputEvent{{
+			Type:       protocol.AppVncInputPointerMove,
+			CapturedAt: 3,
+			X:          0.5,
+			Y:          0.6,
+		}},
+	})
+	if err == nil || err.Error() != "session identifier mismatch" {
+		t.Fatalf("expected session identifier mismatch error, got: %v", err)
+	}
+}
+
+func TestHandleInputBurstQueuesEvents(t *testing.T) {
+	controller := NewController()
+	controller.session = &sessionState{id: "session-1"}
+
+	burst := protocol.AppVncInputBurst{
+		SessionID: "session-1",
+		Sequence:  7,
+		Events: []protocol.AppVncInputEvent{{
+			Type:       protocol.AppVncInputPointerButton,
+			CapturedAt: 99,
+			Button:     protocol.AppVncPointerButtonLeft,
+			Pressed:    true,
+		}},
+	}
+
+	if err := controller.HandleInputBurst(context.Background(), burst); err != nil {
+		t.Fatalf("HandleInputBurst returned error: %v", err)
+	}
+
+	burst.Events[0].Pressed = false
+	burst.Events[0].Button = protocol.AppVncPointerButtonRight
+
+	controller.mu.Lock()
+	defer controller.mu.Unlock()
+
+	if controller.session == nil {
+		t.Fatalf("session cleared unexpectedly")
+	}
+	if len(controller.session.inputQueue) != 1 {
+		t.Fatalf("expected 1 queued burst, got %d", len(controller.session.inputQueue))
+	}
+
+	stored := controller.session.inputQueue[0]
+	if stored.SessionID != "session-1" {
+		t.Fatalf("unexpected stored session id: %s", stored.SessionID)
+	}
+	if stored.Sequence != 7 {
+		t.Fatalf("unexpected stored sequence: %d", stored.Sequence)
+	}
+	if len(stored.Events) != 1 {
+		t.Fatalf("unexpected stored event count: %d", len(stored.Events))
+	}
+	if !stored.Events[0].Pressed {
+		t.Fatalf("expected stored event to remain pressed")
+	}
+	if stored.Events[0].Button != protocol.AppVncPointerButtonLeft {
+		t.Fatalf("expected stored event button to remain left, got %s", stored.Events[0].Button)
+	}
+	if controller.session.lastSequence != 7 {
+		t.Fatalf("unexpected last sequence: %d", controller.session.lastSequence)
+	}
+}


### PR DESCRIPTION
## Summary
- extend the protocol envelope and command stream to decode app-vnc input bursts
- expose app-vnc input handling through the module manager and controller, queuing validated bursts
- add regression tests for app-vnc burst delivery through the command stream and controller

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68f943ef0238832ba049d885c3fa1e7b