### PR TITLE
Add platform-backed power controls for agent control

### DIFF
--- a/tenvy-client/internal/agent/commands.go
+++ b/tenvy-client/internal/agent/commands.go
@@ -92,6 +92,13 @@ func shellCommandHandler(ctx context.Context, agent *Agent, cmd protocol.Command
 	return newDetailedResult(cmd.ID, true, string(output), "")
 }
 
+var (
+	agentShutdownFunc = platform.Shutdown
+	agentRestartFunc  = platform.Restart
+	agentSleepFunc    = platform.Sleep
+	agentLogoffFunc   = platform.Logoff
+)
+
 func agentControlCommandHandler(_ context.Context, agent *Agent, cmd protocol.Command) protocol.CommandResult {
 	if agent == nil {
 		return newFailureResult(cmd.ID, "agent-control command requires agent context")
@@ -110,6 +117,26 @@ func agentControlCommandHandler(_ context.Context, agent *Agent, cmd protocol.Co
 	case "reconnect":
 		agent.requestReconnect()
 		return newSuccessResult(cmd.ID, "reconnect requested")
+	case "shutdown":
+		if err := agentShutdownFunc(); err != nil {
+			return newFailureResult(cmd.ID, fmt.Sprintf("failed to shutdown: %v", err))
+		}
+		return newSuccessResult(cmd.ID, "shutdown requested")
+	case "restart":
+		if err := agentRestartFunc(); err != nil {
+			return newFailureResult(cmd.ID, fmt.Sprintf("failed to restart: %v", err))
+		}
+		return newSuccessResult(cmd.ID, "restart requested")
+	case "sleep":
+		if err := agentSleepFunc(); err != nil {
+			return newFailureResult(cmd.ID, fmt.Sprintf("failed to sleep: %v", err))
+		}
+		return newSuccessResult(cmd.ID, "sleep requested")
+	case "logoff":
+		if err := agentLogoffFunc(); err != nil {
+			return newFailureResult(cmd.ID, fmt.Sprintf("failed to logoff: %v", err))
+		}
+		return newSuccessResult(cmd.ID, "logoff requested")
 	}
 
 	if action == "" {

--- a/tenvy-client/internal/agent/commands_control_test.go
+++ b/tenvy-client/internal/agent/commands_control_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/rootbay/tenvy-client/internal/protocol"
@@ -67,6 +68,132 @@ func TestAgentControlCommandHandlerReconnectDoesNotOverrideDisconnect(t *testing
 
 	if directive := agent.connectionFlag.Load(); directive != connectionDirectiveDisconnect {
 		t.Fatalf("expected disconnect directive to persist, got %d", directive)
+	}
+}
+
+func TestAgentControlCommandHandlerPowerActions(t *testing.T) {
+	restore := stubPowerFunctions()
+	defer restore()
+
+	tests := []struct {
+		name     string
+		action   string
+		stub     func() error
+		expected string
+	}{
+		{
+			name:   "shutdown",
+			action: "shutdown",
+			stub: func() error {
+				return nil
+			},
+			expected: "shutdown requested",
+		},
+		{
+			name:   "restart",
+			action: "restart",
+			stub: func() error {
+				return nil
+			},
+			expected: "restart requested",
+		},
+		{
+			name:   "sleep",
+			action: "sleep",
+			stub: func() error {
+				return nil
+			},
+			expected: "sleep requested",
+		},
+		{
+			name:   "logoff",
+			action: "logoff",
+			stub: func() error {
+				return nil
+			},
+			expected: "logoff requested",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			assignPowerFunc(tt.action, func() error {
+				called = true
+				return tt.stub()
+			})
+
+			cmd := protocol.Command{
+				ID:      "cmd-" + tt.action,
+				Name:    "agent-control",
+				Payload: mustMarshalAgentControlPayload(t, protocol.AgentControlCommandPayload{Action: tt.action}),
+			}
+
+			res := agentControlCommandHandler(context.Background(), &Agent{}, cmd)
+			if !res.Success {
+				t.Fatalf("expected success for %s, got %+v", tt.action, res)
+			}
+			if res.Output != tt.expected {
+				t.Fatalf("expected output %q, got %q", tt.expected, res.Output)
+			}
+			if !called {
+				t.Fatalf("expected %s helper to be invoked", tt.action)
+			}
+		})
+	}
+}
+
+func TestAgentControlCommandHandlerPowerActionFailure(t *testing.T) {
+	restore := stubPowerFunctions()
+	defer restore()
+
+	expectedErr := errors.New("boom")
+	assignPowerFunc("shutdown", func() error {
+		return expectedErr
+	})
+
+	cmd := protocol.Command{
+		ID:      "cmd-shutdown-failure",
+		Name:    "agent-control",
+		Payload: mustMarshalAgentControlPayload(t, protocol.AgentControlCommandPayload{Action: "shutdown"}),
+	}
+
+	res := agentControlCommandHandler(context.Background(), &Agent{}, cmd)
+	if res.Success {
+		t.Fatalf("expected failure, got %+v", res)
+	}
+	if res.Error == "" {
+		t.Fatalf("expected failure error message, got empty string")
+	}
+}
+
+func stubPowerFunctions() func() {
+	shutdownOriginal := agentShutdownFunc
+	restartOriginal := agentRestartFunc
+	sleepOriginal := agentSleepFunc
+	logoffOriginal := agentLogoffFunc
+
+	return func() {
+		agentShutdownFunc = shutdownOriginal
+		agentRestartFunc = restartOriginal
+		agentSleepFunc = sleepOriginal
+		agentLogoffFunc = logoffOriginal
+	}
+}
+
+func assignPowerFunc(action string, fn func() error) {
+	switch action {
+	case "shutdown":
+		agentShutdownFunc = fn
+	case "restart":
+		agentRestartFunc = fn
+	case "sleep":
+		agentSleepFunc = fn
+	case "logoff":
+		agentLogoffFunc = fn
+	default:
+		panic("unknown action: " + action)
 	}
 }
 

--- a/tenvy-client/internal/platform/power_unix.go
+++ b/tenvy-client/internal/platform/power_unix.go
@@ -1,0 +1,113 @@
+//go:build !windows
+
+package platform
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"os/user"
+	"strings"
+)
+
+func requireElevation(action string) error {
+	if !CurrentUserIsElevated() {
+		return fmt.Errorf("%s requires elevated privileges", action)
+	}
+	return nil
+}
+
+func Shutdown() error {
+	if err := requireElevation("shutdown"); err != nil {
+		return err
+	}
+	return exec.Command("shutdown", "-h", "now").Run()
+}
+
+func Restart() error {
+	if err := requireElevation("restart"); err != nil {
+		return err
+	}
+	return exec.Command("shutdown", "-r", "now").Run()
+}
+
+func Sleep() error {
+	if err := requireElevation("sleep"); err != nil {
+		return err
+	}
+
+	attempts := [][]string{
+		{"systemctl", "suspend"},
+		{"pmset", "sleepnow"},
+	}
+
+	var errs []error
+	for _, attempt := range attempts {
+		cmd := exec.Command(attempt[0], attempt[1:]...)
+		if err := cmd.Run(); err != nil {
+			if errors.Is(err, exec.ErrNotFound) {
+				errs = append(errs, fmt.Errorf("%s not found", attempt[0]))
+				continue
+			}
+			errs = append(errs, fmt.Errorf("%s failed: %w", attempt[0], err))
+			continue
+		}
+		return nil
+	}
+
+	if len(errs) == 0 {
+		return fmt.Errorf("no available suspend command")
+	}
+
+	return errors.Join(errs...)
+}
+
+func Logoff() error {
+	if err := requireElevation("logoff"); err != nil {
+		return err
+	}
+
+	username, err := currentUsername()
+	if err != nil {
+		return fmt.Errorf("resolve current user: %w", err)
+	}
+
+	attempts := [][]string{
+		{"loginctl", "terminate-user", username},
+		{"pkill", "-KILL", "-u", username},
+	}
+
+	var errs []error
+	for _, attempt := range attempts {
+		cmd := exec.Command(attempt[0], attempt[1:]...)
+		if err := cmd.Run(); err != nil {
+			if errors.Is(err, exec.ErrNotFound) {
+				errs = append(errs, fmt.Errorf("%s not found", attempt[0]))
+				continue
+			}
+			errs = append(errs, fmt.Errorf("%s failed: %w", attempt[0], err))
+			continue
+		}
+		return nil
+	}
+
+	if len(errs) == 0 {
+		return fmt.Errorf("no available logoff command")
+	}
+
+	return errors.Join(errs...)
+}
+
+func currentUsername() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	username := strings.TrimSpace(u.Username)
+	if username == "" {
+		return "", fmt.Errorf("empty username returned")
+	}
+
+	return username, nil
+}

--- a/tenvy-client/internal/platform/power_windows.go
+++ b/tenvy-client/internal/platform/power_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package platform
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func requireElevation(action string) error {
+	if !CurrentUserIsElevated() {
+		return fmt.Errorf("%s requires elevated privileges", action)
+	}
+	return nil
+}
+
+func Shutdown() error {
+	if err := requireElevation("shutdown"); err != nil {
+		return err
+	}
+	return exec.Command("shutdown", "/s", "/t", "0").Run()
+}
+
+func Restart() error {
+	if err := requireElevation("restart"); err != nil {
+		return err
+	}
+	return exec.Command("shutdown", "/r", "/t", "0").Run()
+}
+
+func Sleep() error {
+	if err := requireElevation("sleep"); err != nil {
+		return err
+	}
+	return exec.Command("rundll32.exe", "powrprof.dll,SetSuspendState", "0,1,0").Run()
+}
+
+func Logoff() error {
+	if err := requireElevation("logoff"); err != nil {
+		return err
+	}
+	return exec.Command("shutdown", "/l").Run()
+}


### PR DESCRIPTION
## Summary
- extend the agent control command handler to handle shutdown, restart, sleep, and logoff via injectable helpers
- add platform-specific power control helpers with privilege checks for Windows and Unix-like systems
- expand agent control command tests to stub and cover the new power actions

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f94bdf2224832b81001f4fbb109f7d