### PR TITLE
Fix async rejection expectations in geo proxy tests

### DIFF
--- a/tenvy-server/tests/geo-proxy.test.ts
+++ b/tenvy-server/tests/geo-proxy.test.ts
@@ -85,15 +85,15 @@ describe('GET /api/geo/[ip]', () => {
 		expect(setHeadersSecond).toHaveBeenCalledWith({ 'Cache-Control': 'public, max-age=900' });
 	});
 
-	it('rejects invalid IP addresses', async () => {
-		await expect(() => GET(createEvent('not-an-ip', vi.fn(), vi.fn()))).rejects.toMatchObject({
-			status: 400
-		});
+        it('rejects invalid IP addresses', async () => {
+                await expect(GET(createEvent('not-an-ip', vi.fn(), vi.fn()))).rejects.toMatchObject({
+                        status: 400
+                });
 
-		await expect(() => GET(createEvent('192.168.1.10', vi.fn(), vi.fn()))).rejects.toMatchObject({
-			status: 400
-		});
-	});
+                await expect(GET(createEvent('192.168.1.10', vi.fn(), vi.fn()))).rejects.toMatchObject({
+                        status: 400
+                });
+        });
 
 	it('propagates provider failures as a 502 error', async () => {
 		const fetchMock = vi.fn(


### PR DESCRIPTION
## Summary
- update the geo proxy API test to await the request promise when asserting on rejected lookups

## Testing
- bun test tests/geo-proxy.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f94c4e4d20832b9779e3fe4634ecf5