### PR TITLE
Ensure canonicalizeServerURL retains IPv6 brackets

### DIFF
--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -237,7 +237,11 @@ func canonicalizeServerURL(raw string) (string, error) {
 	if port != "" {
 		parsed.Host = net.JoinHostPort(host, port)
 	} else {
-		parsed.Host = host
+		if strings.Contains(host, ":") {
+			parsed.Host = "[" + host + "]"
+		} else {
+			parsed.Host = host
+		}
 	}
 
 	return parsed.String(), nil

--- a/tenvy-client/internal/agent/runtime_test.go
+++ b/tenvy-client/internal/agent/runtime_test.go
@@ -27,6 +27,16 @@ func TestCanonicalizeServerURL(t *testing.T) {
 			want:  "https://controller.example.com",
 		},
 		{
+			name:  "ipv6 without port",
+			input: "https://[2001:db8::1]",
+			want:  "https://[2001:db8::1]",
+		},
+		{
+			name:  "ipv6 with port",
+			input: "https://[2001:db8::1]:8443",
+			want:  "https://[2001:db8::1]:8443",
+		},
+		{
 			name:    "http disallowed",
 			input:   "http://[::1]:8080",
 			wantErr: true,


### PR DESCRIPTION
## Summary
- ensure IPv6 hosts remain bracketed when canonicalizing server URLs without explicit ports
- cover IPv6 host scenarios in the canonicalizeServerURL tests

## Testing
- go test ./... (from tenvy-client)


------
https://chatgpt.com/codex/tasks/task_e_68f9cef718d0832b9b4a97c3801270f2