### PR TITLE
Fix notes key derivation and migrate legacy data

### DIFF
--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -170,7 +170,11 @@ func runAgentOnce(ctx context.Context, opts RuntimeOptions) error {
 		if strings.TrimSpace(sharedMaterial) == "" {
 			sharedMaterial = registration.AgentKey + "-shared"
 		}
-		if notesManager, err := notes.NewManager(notesPath, registration.AgentKey, sharedMaterial); err != nil {
+		localMaterial := opts.SharedSecret
+		if strings.TrimSpace(localMaterial) == "" {
+			localMaterial = registration.AgentID
+		}
+		if notesManager, err := notes.NewManager(notesPath, localMaterial, sharedMaterial, registration.AgentKey); err != nil {
 			opts.Logger.Printf("notes disabled (init failed): %v", err)
 		} else {
 			agent.notes = notesManager

--- a/tenvy-client/internal/modules/notes/manager_test.go
+++ b/tenvy-client/internal/modules/notes/manager_test.go
@@ -1,0 +1,99 @@
+package notes
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestManagerMigratesLegacyLocalNotes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.json")
+
+	legacyLocal := "legacy-local-key"
+	sharedMaterial := "shared-key"
+
+	legacyManager, err := NewManager(path, legacyLocal, sharedMaterial, "")
+	if err != nil {
+		t.Fatalf("failed to initialize legacy manager: %v", err)
+	}
+
+	note, err := legacyManager.SaveNote(Note{Title: "Legacy", Body: "classified", Shared: false}, 0)
+	if err != nil {
+		t.Fatalf("failed to save legacy note: %v", err)
+	}
+
+	rawBefore, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read notes file: %v", err)
+	}
+
+	var snapshotBefore noteFile
+	if err := json.Unmarshal(rawBefore, &snapshotBefore); err != nil {
+		t.Fatalf("failed to decode notes file: %v", err)
+	}
+
+	if len(snapshotBefore.Notes) != 1 {
+		t.Fatalf("expected 1 note in snapshot, got %d", len(snapshotBefore.Notes))
+	}
+
+	originalCiphertext := snapshotBefore.Notes[0].Ciphertext
+
+	stableLocal := "stable-local-key"
+	migratedManager, err := NewManager(path, stableLocal, sharedMaterial, legacyLocal)
+	if err != nil {
+		t.Fatalf("failed to initialize migrated manager: %v", err)
+	}
+
+	listed, err := migratedManager.ListNotes()
+	if err != nil {
+		t.Fatalf("failed to list notes: %v", err)
+	}
+
+	if len(listed) != 1 {
+		t.Fatalf("expected 1 note after migration, got %d", len(listed))
+	}
+
+	got := listed[0]
+	if got.ID != note.ID || got.Title != note.Title || got.Body != note.Body {
+		t.Fatalf("unexpected note content after migration: %+v", got)
+	}
+
+	rawAfter, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read notes file after migration: %v", err)
+	}
+
+	var snapshotAfter noteFile
+	if err := json.Unmarshal(rawAfter, &snapshotAfter); err != nil {
+		t.Fatalf("failed to decode migrated notes file: %v", err)
+	}
+
+	if len(snapshotAfter.Notes) != 1 {
+		t.Fatalf("expected 1 note in migrated snapshot, got %d", len(snapshotAfter.Notes))
+	}
+
+	if snapshotAfter.Notes[0].Ciphertext == originalCiphertext {
+		t.Fatalf("expected ciphertext to change after migration")
+	}
+
+	stableManager, err := NewManager(path, stableLocal, sharedMaterial, "")
+	if err != nil {
+		t.Fatalf("failed to initialize stable manager: %v", err)
+	}
+
+	stableNotes, err := stableManager.ListNotes()
+	if err != nil {
+		t.Fatalf("failed to list notes with stable key: %v", err)
+	}
+
+	if len(stableNotes) != 1 {
+		t.Fatalf("expected 1 note with stable key, got %d", len(stableNotes))
+	}
+
+	final := stableNotes[0]
+	if final.ID != note.ID || final.Title != note.Title || final.Body != note.Body {
+		t.Fatalf("unexpected note content with stable key: %+v", final)
+	}
+}


### PR DESCRIPTION
## Summary
- derive the notes local key from the shared secret or persistent agent identifier while keeping the agent key as legacy material
- add migration logic to fall back to the legacy key when decrypting local notes and persist the re-encrypted data
- add a regression test to ensure notes survive agent key rotation after restart

## Testing
- go test ./internal/agent ./internal/modules/notes

------
https://chatgpt.com/codex/tasks/task_e_68f9d1d50400832ba27c4472cf31e022