### PR TITLE
Add webcam control contracts and agent/server scaffolding

### DIFF
--- a/shared/types/messages.ts
+++ b/shared/types/messages.ts
@@ -13,6 +13,7 @@ import type { FileManagerCommandPayload } from "./file-manager";
 import type { TcpConnectionsCommandPayload } from "./tcp-connections";
 import type { ClientChatCommandPayload } from "./client-chat";
 import type { ToolActivationCommandPayload } from "./tool-activation";
+import type { WebcamCommandPayload } from "./webcam";
 
 export type CommandName =
   | "ping"
@@ -28,7 +29,8 @@ export type CommandName =
   | "file-manager"
   | "tcp-connections"
   | "client-chat"
-  | "tool-activation";
+  | "tool-activation"
+  | "webcam-control";
 
 export interface PingCommandPayload {
   message?: string;
@@ -79,7 +81,8 @@ export type CommandPayload =
   | FileManagerCommandPayload
   | TcpConnectionsCommandPayload
   | ClientChatCommandPayload
-  | ToolActivationCommandPayload;
+  | ToolActivationCommandPayload
+  | WebcamCommandPayload;
 
 export interface CommandInput {
   name: CommandName;

--- a/shared/types/webcam.ts
+++ b/shared/types/webcam.ts
@@ -1,0 +1,90 @@
+export type WebcamQuality = "max" | "high" | "medium" | "low";
+
+export interface WebcamResolution {
+  width: number;
+  height: number;
+}
+
+export interface WebcamZoomRange {
+  min: number;
+  max: number;
+  step: number;
+}
+
+export interface WebcamDeviceCapabilities {
+  resolutions?: WebcamResolution[];
+  frameRates?: number[];
+  zoom?: WebcamZoomRange;
+  facingMode?: "user" | "environment" | "external";
+}
+
+export interface WebcamDevice {
+  id: string;
+  label: string;
+  capabilities?: WebcamDeviceCapabilities;
+}
+
+export interface WebcamDeviceInventory {
+  devices: WebcamDevice[];
+  capturedAt: string;
+  requestId?: string;
+  warning?: string;
+}
+
+export interface WebcamDeviceInventoryState {
+  inventory: WebcamDeviceInventory | null;
+  pending: boolean;
+}
+
+export interface WebcamStreamSettings {
+  quality?: WebcamQuality;
+  width?: number;
+  height?: number;
+  frameRate?: number;
+  zoom?: number;
+}
+
+export interface WebcamNegotiationOffer {
+  transport: "webrtc" | "http";
+  offer?: string;
+  iceServers?: string[];
+  dataChannel?: string;
+}
+
+export interface WebcamNegotiationAnswer {
+  answer?: string;
+  iceServers?: string[];
+  dataChannel?: string;
+}
+
+export interface WebcamNegotiationState {
+  offer?: WebcamNegotiationOffer;
+  answer?: WebcamNegotiationAnswer;
+}
+
+export type WebcamCommandAction =
+  | "enumerate"
+  | "start"
+  | "stop"
+  | "update";
+
+export interface WebcamCommandPayload {
+  action: WebcamCommandAction;
+  requestId?: string;
+  sessionId?: string;
+  deviceId?: string;
+  settings?: WebcamStreamSettings;
+  negotiation?: WebcamNegotiationState;
+}
+
+export interface WebcamSessionState {
+  sessionId: string;
+  agentId: string;
+  deviceId?: string;
+  createdAt: string;
+  updatedAt: string;
+  status: "pending" | "active" | "stopped" | "error";
+  settings?: WebcamStreamSettings;
+  negotiation?: WebcamNegotiationState;
+  error?: string;
+}

--- a/tenvy-client/internal/modules/control/webcam/inventory_stub.go
+++ b/tenvy-client/internal/modules/control/webcam/inventory_stub.go
@@ -1,0 +1,9 @@
+package webcam
+
+import "github.com/rootbay/tenvy-client/internal/protocol"
+
+func captureWebcamInventory() ([]protocol.WebcamDevice, string, error) {
+	devices := make([]protocol.WebcamDevice, 0)
+	warning := "webcam enumeration is not implemented on this platform"
+	return devices, warning, nil
+}

--- a/tenvy-client/internal/modules/control/webcam/manager.go
+++ b/tenvy-client/internal/modules/control/webcam/manager.go
@@ -1,0 +1,190 @@
+package webcam
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/rootbay/tenvy-client/internal/protocol"
+)
+
+type (
+	Command       = protocol.Command
+	CommandResult = protocol.CommandResult
+)
+
+type Logger interface {
+	Printf(format string, args ...interface{})
+}
+
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type Config struct {
+	AgentID   string
+	BaseURL   string
+	AuthKey   string
+	Client    HTTPDoer
+	Logger    Logger
+	UserAgent string
+}
+
+type Manager struct {
+	cfg atomic.Value // stores Config
+}
+
+func NewManager(cfg Config) *Manager {
+	manager := &Manager{}
+	manager.updateConfig(cfg)
+	return manager
+}
+
+func (m *Manager) UpdateConfig(cfg Config) {
+	if m == nil {
+		return
+	}
+	m.updateConfig(cfg)
+}
+
+func (m *Manager) updateConfig(cfg Config) {
+	m.cfg.Store(cfg)
+}
+
+func (m *Manager) config() Config {
+	if value := m.cfg.Load(); value != nil {
+		return value.(Config)
+	}
+	return Config{}
+}
+
+func (m *Manager) userAgent() string {
+	cfg := m.config()
+	ua := strings.TrimSpace(cfg.UserAgent)
+	if ua != "" {
+		return ua
+	}
+	return "tenvy-client"
+}
+
+func (m *Manager) logf(format string, args ...interface{}) {
+	if m == nil {
+		return
+	}
+	cfg := m.config()
+	if cfg.Logger == nil {
+		return
+	}
+	cfg.Logger.Printf(format, args...)
+}
+
+func (m *Manager) HandleCommand(ctx context.Context, cmd Command) CommandResult {
+	completedAt := time.Now().UTC().Format(time.RFC3339Nano)
+
+	var payload protocol.WebcamCommandPayload
+	if len(cmd.Payload) > 0 {
+		if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
+			return CommandResult{
+				CommandID:   cmd.ID,
+				Success:     false,
+				Error:       fmt.Sprintf("invalid webcam control payload: %v", err),
+				CompletedAt: completedAt,
+			}
+		}
+	}
+
+	action := strings.TrimSpace(strings.ToLower(payload.Action))
+	var err error
+
+	switch action {
+	case "enumerate", "inventory":
+		err = m.publishInventory(ctx, payload.RequestID)
+	case "start", "stop", "update":
+		err = errors.New("webcam streaming is not supported on this agent")
+	case "":
+		err = errors.New("missing webcam control action")
+	default:
+		err = fmt.Errorf("unsupported webcam control action: %s", payload.Action)
+	}
+
+	if err != nil {
+		return CommandResult{
+			CommandID:   cmd.ID,
+			Success:     false,
+			Error:       err.Error(),
+			CompletedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		}
+	}
+
+	return CommandResult{
+		CommandID:   cmd.ID,
+		Success:     true,
+		CompletedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+}
+
+func (m *Manager) publishInventory(ctx context.Context, requestID string) error {
+	devices, warning, err := captureWebcamInventory()
+	if err != nil {
+		return err
+	}
+
+	inventory := protocol.WebcamDeviceInventory{
+		Devices:    devices,
+		CapturedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	if trimmed := strings.TrimSpace(requestID); trimmed != "" {
+		inventory.RequestID = trimmed
+	}
+	if warning != "" {
+		inventory.Warning = warning
+	}
+
+	data, err := json.Marshal(inventory)
+	if err != nil {
+		return err
+	}
+
+	cfg := m.config()
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+	if baseURL == "" {
+		return errors.New("webcam control: missing base URL")
+	}
+	if cfg.Client == nil {
+		return errors.New("webcam control: missing http client")
+	}
+
+	endpoint := fmt.Sprintf("%s/api/agents/%s/webcam/devices", baseURL, url.PathEscape(cfg.AgentID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if ua := strings.TrimSpace(m.userAgent()); ua != "" {
+		req.Header.Set("User-Agent", ua)
+	}
+	if key := strings.TrimSpace(cfg.AuthKey); key != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
+	}
+
+	resp, err := cfg.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("webcam inventory publish failed: status %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/tenvy-client/internal/protocol/types.go
+++ b/tenvy-client/internal/protocol/types.go
@@ -199,6 +199,81 @@ type RemoteDesktopInputBurst struct {
 	Events    []RemoteDesktopInputEvent `json:"events"`
 }
 
+type WebcamQuality string
+
+const (
+	WebcamQualityMax    WebcamQuality = "max"
+	WebcamQualityHigh   WebcamQuality = "high"
+	WebcamQualityMedium WebcamQuality = "medium"
+	WebcamQualityLow    WebcamQuality = "low"
+)
+
+type WebcamResolution struct {
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+type WebcamZoomRange struct {
+	Min  float64 `json:"min"`
+	Max  float64 `json:"max"`
+	Step float64 `json:"step"`
+}
+
+type WebcamDeviceCapabilities struct {
+	Resolutions []WebcamResolution `json:"resolutions,omitempty"`
+	FrameRates  []float64          `json:"frameRates,omitempty"`
+	Zoom        *WebcamZoomRange   `json:"zoom,omitempty"`
+	FacingMode  string             `json:"facingMode,omitempty"`
+}
+
+type WebcamDevice struct {
+	ID           string                    `json:"id"`
+	Label        string                    `json:"label"`
+	Capabilities *WebcamDeviceCapabilities `json:"capabilities,omitempty"`
+}
+
+type WebcamDeviceInventory struct {
+	Devices    []WebcamDevice `json:"devices"`
+	CapturedAt string         `json:"capturedAt"`
+	RequestID  string         `json:"requestId,omitempty"`
+	Warning    string         `json:"warning,omitempty"`
+}
+
+type WebcamStreamSettings struct {
+	Quality   WebcamQuality `json:"quality,omitempty"`
+	Width     int           `json:"width,omitempty"`
+	Height    int           `json:"height,omitempty"`
+	FrameRate float64       `json:"frameRate,omitempty"`
+	Zoom      float64       `json:"zoom,omitempty"`
+}
+
+type WebcamNegotiationOffer struct {
+	Transport   string   `json:"transport"`
+	Offer       string   `json:"offer,omitempty"`
+	IceServers  []string `json:"iceServers,omitempty"`
+	DataChannel string   `json:"dataChannel,omitempty"`
+}
+
+type WebcamNegotiationAnswer struct {
+	Answer      string   `json:"answer,omitempty"`
+	IceServers  []string `json:"iceServers,omitempty"`
+	DataChannel string   `json:"dataChannel,omitempty"`
+}
+
+type WebcamNegotiationState struct {
+	Offer  *WebcamNegotiationOffer  `json:"offer,omitempty"`
+	Answer *WebcamNegotiationAnswer `json:"answer,omitempty"`
+}
+
+type WebcamCommandPayload struct {
+	Action      string                  `json:"action"`
+	RequestID   string                  `json:"requestId,omitempty"`
+	SessionID   string                  `json:"sessionId,omitempty"`
+	DeviceID    string                  `json:"deviceId,omitempty"`
+	Settings    *WebcamStreamSettings   `json:"settings,omitempty"`
+	Negotiation *WebcamNegotiationState `json:"negotiation,omitempty"`
+}
+
 type AppVncInputBurst struct {
 	SessionID string             `json:"sessionId"`
 	Events    []AppVncInputEvent `json:"events"`

--- a/tenvy-server/src/lib/components/workspace/tools/webcam-control-workspace.svelte
+++ b/tenvy-server/src/lib/components/workspace/tools/webcam-control-workspace.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import { onMount, tick } from 'svelte';
-	import { SvelteSet } from 'svelte/reactivity';
+	import { onMount } from 'svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import { Label } from '$lib/components/ui/label/index.js';
@@ -20,1087 +19,266 @@
 	import { getClientTool } from '$lib/data/client-tools';
 	import type { Client } from '$lib/data/clients';
 	import { appendWorkspaceLog, createWorkspaceLogEntry } from '$lib/workspace/utils';
-	import { notifyToolActivationCommand } from '$lib/utils/agent-commands.js';
 	import type { WorkspaceLogEntry } from '$lib/workspace/types';
-
-	type WebcamDevice = {
-		id: string;
-		label: string;
-	};
-
-	type StillCapture = {
-		id: string;
-		url: string;
-		width: number;
-		height: number;
-		timestamp: string;
-		cameraLabel: string;
-	};
-
-	type RecordingClip = {
-		id: string;
-		url: string;
-		mimeType: string;
-		size: number;
-		durationMs: number;
-		createdAt: string;
-		cameraLabel: string;
-		resolution: string;
-		frameRate: number | null;
-	};
+	import { notifyToolActivationCommand } from '$lib/utils/agent-commands.js';
+	import type {
+		WebcamDevice,
+		WebcamDeviceInventoryState,
+		WebcamSessionState
+	} from '$lib/types/webcam';
 
 	const { client } = $props<{ client: Client }>();
-	void client;
 
 	const tool = getClientTool('webcam-control');
 	void tool;
 
-	const RESOLUTION_OPTIONS = [
-		{ value: '3840×2160', label: '3840×2160 · 4K' },
-		{ value: '1920×1080', label: '1920×1080 · 1080p' },
-		{ value: '1280×720', label: '1280×720 · 720p' },
-		{ value: '640×480', label: '640×480 · VGA' }
-	] as const;
+	const apiBase = `/api/agents/${encodeURIComponent(client.id)}/webcam` as const;
 
+	let inventoryPending = $state(false);
+	let inventoryLoading = $state(false);
 	let devices = $state<WebcamDevice[]>([]);
-	let selectedCamera = $state('');
-	let resolution = $state<(typeof RESOLUTION_OPTIONS)[number]['value']>('1280×720');
-	let frameRate = $state(30);
-	let zoom = $state(1);
-	let zoomSupported = $state(false);
-	let zoomMin = $state(1);
-	let zoomMax = $state(1);
-	let zoomStep = $state(0.1);
-	let previewActive = $state(false);
-	let initializing = $state(false);
-	let mediaSupported = $state(false);
+	let selectedDevice = $state('');
+	let session = $state<WebcamSessionState | null>(null);
+	let sessionLoading = $state(false);
 	let errorMessage = $state<string | null>(null);
 	let log = $state<WorkspaceLogEntry[]>([]);
-	let captures = $state<StillCapture[]>([]);
-	let recordings = $state<RecordingClip[]>([]);
-	let recordingActive = $state(false);
-	let recordingSeconds = $state(0);
+	let infoMessage = $state<string | null>(null);
 
 	let videoElement: HTMLVideoElement | null = null;
-	let stream: MediaStream | null = null;
-	let mediaRecorder: MediaRecorder | null = null;
-	let recordedChunks: Blob[] = [];
-	let recordingTimer: ReturnType<typeof setInterval> | null = null;
-	let recordingStartedAt = 0;
-	let discardRecording = false;
-
-	const objectUrls = new SvelteSet<string>();
-
-	function generateId(): string {
-		return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-	}
-
-	function parseResolution(value: string): { width: number; height: number } {
-		const [rawWidth, rawHeight] = value.split(/[×x]/u);
-		const width = Number.parseInt(rawWidth ?? '', 10);
-		const height = Number.parseInt(rawHeight ?? '', 10);
-		if (!Number.isFinite(width) || width <= 0 || !Number.isFinite(height) || height <= 0) {
-			return { width: 1280, height: 720 };
-		}
-		return { width, height };
-	}
-
-	function clamp(value: number, min: number, max: number): number {
-		if (!Number.isFinite(value)) {
-			return min;
-		}
-		if (max < min) {
-			[min, max] = [max, min];
-		}
-		if (value < min) {
-			return min;
-		}
-		if (value > max) {
-			return max;
-		}
-		return value;
-	}
-
-	function cameraLabel(): string {
-		if (selectedCamera === '') {
-			return devices.length > 0 ? 'Auto select' : 'No camera';
-		}
-		const match = devices.find((device) => device.id === selectedCamera);
-		return match?.label ?? 'Selected device';
-	}
-
-	function describeTrack(track: MediaStreamTrack | null): string {
-		const label = cameraLabel();
-		const { width: fallbackWidth, height: fallbackHeight } = parseResolution(resolution);
-		if (!track || typeof track.getSettings !== 'function') {
-			return `${label} · ${fallbackWidth}×${fallbackHeight} @ ${frameRate}fps`;
-		}
-		const settings = track.getSettings();
-		const width =
-			typeof settings.width === 'number' && !Number.isNaN(settings.width)
-				? Math.round(settings.width)
-				: fallbackWidth;
-		const height =
-			typeof settings.height === 'number' && !Number.isNaN(settings.height)
-				? Math.round(settings.height)
-				: fallbackHeight;
-		const fps =
-			typeof settings.frameRate === 'number' && !Number.isNaN(settings.frameRate)
-				? Math.round(settings.frameRate)
-				: frameRate;
-		return `${label} · ${width}×${height} @ ${fps}fps`;
-	}
-
-	function formatResolutionLabel(settings: MediaTrackSettings | null): string {
-		const { width: fallbackWidth, height: fallbackHeight } = parseResolution(resolution);
-		if (!settings) {
-			return `${fallbackWidth}×${fallbackHeight}`;
-		}
-		const width =
-			typeof settings.width === 'number' && !Number.isNaN(settings.width)
-				? Math.round(settings.width)
-				: fallbackWidth;
-		const height =
-			typeof settings.height === 'number' && !Number.isNaN(settings.height)
-				? Math.round(settings.height)
-				: fallbackHeight;
-		return `${width}×${height}`;
-	}
 
 	function logAction(
 		action: string,
 		detail: string,
-		status: WorkspaceLogEntry['status'] = 'complete',
-		metadata?: Record<string, unknown>
+		status: WorkspaceLogEntry['status'] = 'complete'
 	) {
 		log = appendWorkspaceLog(log, createWorkspaceLogEntry(action, detail, status));
 		notifyToolActivationCommand(client.id, 'webcam-control', {
 			action: `event:${action}`,
-			metadata: {
-				detail,
-				status,
-				...metadata
-			}
+			metadata: { detail, status }
 		});
 	}
 
-	function buildConstraints(): MediaStreamConstraints {
-		const { width, height } = parseResolution(resolution);
-		const video: MediaTrackConstraints = {
-			width: { ideal: width },
-			height: { ideal: height },
-			frameRate: { ideal: frameRate },
-			facingMode: 'user'
-		};
-		if (selectedCamera) {
-			video.deviceId = { exact: selectedCamera };
-		}
-		return { video, audio: false } satisfies MediaStreamConstraints;
-	}
-
-	function resetZoomCapabilities() {
-		zoomSupported = false;
-		zoom = 1;
-		zoomMin = 1;
-		zoomMax = 1;
-		zoomStep = 0.1;
-	}
-
-	async function configureZoom(track: MediaStreamTrack | null) {
-		if (
-			!track ||
-			typeof track.getCapabilities !== 'function' ||
-			typeof track.getSettings !== 'function'
-		) {
-			resetZoomCapabilities();
-			return;
-		}
-
-		try {
-			const capabilities = track.getCapabilities() as MediaTrackCapabilities & {
-				zoom?: { min?: number; max?: number; step?: number };
-			};
-			if (!capabilities || typeof capabilities.zoom !== 'object') {
-				resetZoomCapabilities();
-				return;
-			}
-			const { min, max, step } = capabilities.zoom;
-			const rangeMin = Number.isFinite(min) && min !== undefined ? min : 1;
-			const rangeMax = Number.isFinite(max) && max !== undefined ? max : Math.max(rangeMin, 1);
-			const rangeStep = Number.isFinite(step) && step && step > 0 ? step : 0.1;
-			zoomMin = rangeMin;
-			zoomMax = rangeMax;
-			zoomStep = rangeStep;
-
-			const settings = track.getSettings();
-			const current =
-				typeof settings.zoom === 'number' && !Number.isNaN(settings.zoom)
-					? clamp(settings.zoom, rangeMin, rangeMax)
-					: clamp(zoom, rangeMin, rangeMax);
-			zoom = current;
-			zoomSupported = true;
-		} catch {
-			resetZoomCapabilities();
-		}
-	}
-
-	async function applyZoom(value: number) {
-		const track = stream?.getVideoTracks()[0] ?? null;
-		if (!track || typeof track.applyConstraints !== 'function') {
-			throw new Error('Zoom is not supported by the active track.');
-		}
-		const zoomConstraints = { zoom: value } as unknown as MediaTrackConstraintSet;
-		await track.applyConstraints({ advanced: [zoomConstraints] });
-	}
-
-	async function handleZoomInput(event: Event & { currentTarget: HTMLInputElement }) {
-		const target = event.currentTarget;
-		const numeric = Number(target.value);
-		const nextValue = clamp(numeric, zoomMin, zoomMax);
-		const previous = zoom;
-		zoom = nextValue;
-		if (!zoomSupported || !previewActive) {
-			return;
-		}
-		try {
-			await applyZoom(nextValue);
-		} catch (err) {
-			zoom = previous;
-			target.value = previous.toString();
-			const message =
-				err instanceof DOMException || err instanceof Error
-					? err.message
-					: 'Unable to adjust zoom for this camera.';
-			errorMessage = message;
-			logAction('Zoom adjustment failed', message, 'draft');
-		}
-	}
-
-	function formatSeconds(value: number): string {
-		const totalSeconds = Math.max(0, Math.floor(value));
-		const hours = Math.floor(totalSeconds / 3600);
-		const minutes = Math.floor((totalSeconds % 3600) / 60);
-		const seconds = totalSeconds % 60;
-		if (hours > 0) {
-			return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds
-				.toString()
-				.padStart(2, '0')}`;
-		}
-		return `${minutes}:${seconds.toString().padStart(2, '0')}`;
-	}
-
-	function formatDurationLabel(totalSeconds: number): string {
-		const hours = Math.floor(totalSeconds / 3600);
-		const minutes = Math.floor((totalSeconds % 3600) / 60);
-		const seconds = totalSeconds % 60;
-		const segments: string[] = [];
-		if (hours > 0) {
-			segments.push(`${hours}h`);
-		}
-		if (minutes > 0) {
-			segments.push(`${minutes}m`);
-		}
-		segments.push(`${seconds}s`);
-		return segments.join(' ');
-	}
-
-	function formatTimestamp(value: string): string {
-		const date = new Date(value);
-		if (Number.isNaN(date.getTime())) {
-			return value;
-		}
-		return new Intl.DateTimeFormat(undefined, {
-			hour: '2-digit',
-			minute: '2-digit',
-			second: '2-digit'
-		}).format(date);
-	}
-
-	function formatBytes(value: number): string {
-		if (!Number.isFinite(value) || value <= 0) {
-			return '0 B';
-		}
-		const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-		let current = value;
-		let index = 0;
-		while (current >= 1024 && index < units.length - 1) {
-			current /= 1024;
-			index += 1;
-		}
-		const decimals = index === 0 ? 0 : 1;
-		return `${current.toFixed(decimals)} ${units[index]}`;
-	}
-
-	function recordingExtension(mimeType: string): string {
-		if (mimeType.includes('mp4')) {
-			return 'mp4';
-		}
-		if (mimeType.includes('ogg')) {
-			return 'ogg';
-		}
-		return 'webm';
-	}
-
-	function stopRecordingTimer(reset = false) {
-		if (recordingTimer) {
-			clearInterval(recordingTimer);
-			recordingTimer = null;
-		}
-		if (reset) {
-			recordingSeconds = 0;
-		}
-	}
-
-	function startRecordingTimer() {
-		stopRecordingTimer(true);
-		recordingTimer = setInterval(() => {
-			if (recordingStartedAt > 0) {
-				const elapsed = Math.max(0, Date.now() - recordingStartedAt);
-				recordingSeconds = Math.round(elapsed / 1000);
-			}
-		}, 500);
-	}
-
-	async function stopRecording(discard = false): Promise<void> {
-		const recorder = mediaRecorder;
-		if (!recorder) {
-			recordingActive = false;
-			discardRecording = false;
-			stopRecordingTimer(true);
-			return;
-		}
-		if (recorder.state !== 'recording') {
-			recordingActive = false;
-			discardRecording = false;
-			stopRecordingTimer(true);
-			return;
-		}
-
-		discardRecording = discard;
-		recordingActive = false;
-		stopRecordingTimer(false);
-
-		await new Promise<void>((resolve) => {
-			const cleanup = () => {
-				recorder.removeEventListener('stop', cleanup);
-				resolve();
-			};
-			recorder.addEventListener('stop', cleanup, { once: true });
-			try {
-				recorder.stop();
-			} catch {
-				recorder.removeEventListener('stop', cleanup);
-				resolve();
-			}
-		});
-	}
-
-	async function stopPreview(
-		reason?: string,
-		options: { discardRecording?: boolean } = {}
-	): Promise<void> {
-		const detail = describeTrack(stream?.getVideoTracks()[0] ?? null);
-		await stopRecording(options.discardRecording ?? false);
-		releaseStream();
-		if (reason) {
-			logAction(reason, detail, 'complete');
-		}
-	}
-
-	function releaseStream() {
-		if (stream) {
-			for (const track of stream.getTracks()) {
-				if (typeof track.removeEventListener === 'function') {
-					track.removeEventListener('ended', handleTrackEnded);
-				}
-				track.stop();
-			}
-		}
-		if (videoElement) {
-			videoElement.pause();
-			videoElement.srcObject = null;
-		}
-		stream = null;
-		previewActive = false;
-		resetZoomCapabilities();
-	}
-
-	function selectRecorderMimeType(): string | undefined {
-		if (
-			typeof MediaRecorder === 'undefined' ||
-			typeof MediaRecorder.isTypeSupported !== 'function'
-		) {
-			return undefined;
-		}
-		const candidates = [
-			'video/webm;codecs=vp9',
-			'video/webm;codecs=vp8',
-			'video/webm;codecs=vp8.0',
-			'video/webm',
-			'video/mp4'
-		];
-		for (const candidate of candidates) {
-			try {
-				if (MediaRecorder.isTypeSupported(candidate)) {
-					return candidate;
-				}
-			} catch {
-				// ignore unsupported candidate
-			}
-		}
-		return undefined;
-	}
-
-	async function startPreview(options: { restart?: boolean } = {}) {
-		if (initializing) {
-			return;
-		}
-		if (
-			!mediaSupported ||
-			typeof navigator === 'undefined' ||
-			!navigator.mediaDevices?.getUserMedia
-		) {
-			errorMessage = 'Webcam preview is not supported in this environment.';
-			logAction('Webcam preview failed', 'MediaDevices API unavailable', 'draft');
-			return;
-		}
-
-		initializing = true;
-		const restarting = options.restart ?? false;
+	async function fetchInventory() {
+		inventoryLoading = true;
 		errorMessage = null;
-
-		await stopPreview(undefined, { discardRecording: true });
-
+		infoMessage = null;
 		try {
-			const constraints = buildConstraints();
-			const nextStream = await navigator.mediaDevices.getUserMedia(constraints);
-			stream = nextStream;
-			const track = nextStream.getVideoTracks()[0] ?? null;
-			if (track && typeof track.addEventListener === 'function') {
-				track.addEventListener('ended', handleTrackEnded);
-			}
-			await tick();
-			if (videoElement) {
-				videoElement.srcObject = nextStream;
-				try {
-					await videoElement.play();
-				} catch {
-					// playback errors can be ignored in muted preview mode
-				}
-			}
-			previewActive = true;
-			await configureZoom(track);
-			const settings =
-				track && typeof track.getSettings === 'function'
-					? (track.getSettings() as MediaTrackSettings)
-					: undefined;
-			const detail = describeTrack(track);
-			const resolutionLabel = formatResolutionLabel(settings ?? null);
-			const fpsSetting =
-				settings && typeof settings.frameRate === 'number'
-					? Math.round(settings.frameRate)
-					: frameRate;
-			logAction(
-				restarting ? 'Webcam preview restarted' : 'Webcam preview started',
-				detail,
-				'complete',
-				{
-					camera: cameraLabel(),
-					resolution: resolutionLabel,
-					frameRate: fpsSetting
-				}
-			);
-			void refreshDevices();
-		} catch (err) {
-			releaseStream();
-			const message =
-				err instanceof DOMException || err instanceof Error
-					? err.message
-					: 'Unable to start webcam preview.';
-			errorMessage = message;
-			logAction('Webcam preview failed', message, 'draft', {
-				camera: cameraLabel(),
-				resolution,
-				frameRate
+			const response = await fetch(`${apiBase}/devices`, {
+				method: 'GET',
+				headers: { Accept: 'application/json' }
 			});
+			if (!response.ok) {
+				throw new Error(`Inventory request failed (${response.status})`);
+			}
+			const payload = (await response.json()) as WebcamDeviceInventoryState;
+			inventoryPending = Boolean(payload.pending);
+			devices = payload.inventory?.devices ?? [];
+			if (!selectedDevice && devices.length > 0) {
+				selectedDevice = devices[0]?.id ?? '';
+			}
+			if (devices.length === 0 && !inventoryPending) {
+				infoMessage = 'No webcams reported by the remote agent.';
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : 'Failed to load webcam inventory.';
+			errorMessage = message;
+			logAction('Inventory fetch failed', message, 'draft');
 		} finally {
-			initializing = false;
+			inventoryLoading = false;
 		}
 	}
 
-	async function restartPreview() {
-		if (!previewActive || initializing) {
-			return;
-		}
-		await startPreview({ restart: true });
-	}
-
-	async function refreshDevices() {
-		if (
-			!mediaSupported ||
-			typeof navigator === 'undefined' ||
-			!navigator.mediaDevices?.enumerateDevices
-		) {
-			return;
-		}
-		try {
-			const allDevices = await navigator.mediaDevices.enumerateDevices();
-			const cameras = allDevices
-				.filter((device) => device.kind === 'videoinput')
-				.map((device, index) => ({
-					id: device.deviceId,
-					label: device.label || `Camera ${index + 1}`
-				}));
-			devices = cameras;
-
-			if (selectedCamera && !cameras.some((device) => device.id === selectedCamera)) {
-				if (cameras.length > 0) {
-					selectedCamera = cameras[0].id;
-				} else {
-					selectedCamera = '';
-				}
-				if (previewActive && cameras.length === 0) {
-					await stopPreview('Webcam preview stopped', { discardRecording: true });
-				}
-			} else if (!selectedCamera && cameras.length > 0) {
-				selectedCamera = cameras[0].id;
-			}
-		} catch (err) {
-			if (err instanceof DOMException && err.name === 'NotAllowedError') {
-				return;
-			}
-			const message = err instanceof Error ? err.message : 'Unable to enumerate cameras.';
-			errorMessage = message;
-		}
-	}
-
-	async function handleFrameRateChange(event: Event & { currentTarget: HTMLInputElement }) {
-		const target = event.currentTarget;
-		const numeric = Number(target.value);
-		const next = clamp(Math.round(Number.isFinite(numeric) ? numeric : frameRate), 1, 120);
-		frameRate = next;
-		target.value = next.toString();
-		if (previewActive && !initializing) {
-			await restartPreview();
-		}
-	}
-
-	function handleResolutionChange(value: string) {
-		if (value === resolution) {
-			return;
-		}
-		resolution = value as (typeof RESOLUTION_OPTIONS)[number]['value'];
-		if (previewActive && !initializing) {
-			void restartPreview();
-		}
-	}
-
-	function handleCameraChange(value: string) {
-		if (value === selectedCamera) {
-			return;
-		}
-		selectedCamera = value;
-		if (previewActive && !initializing) {
-			void restartPreview();
-		}
-	}
-
-	function handleTrackEnded() {
-		void stopPreview('Webcam preview ended', { discardRecording: false });
-	}
-
-	function captureStill() {
-		if (!previewActive || !videoElement) {
-			const message = 'Start the preview before capturing still images.';
-			errorMessage = message;
-			logAction('Webcam capture failed', message, 'draft');
-			return;
-		}
-		const width = videoElement.videoWidth;
-		const height = videoElement.videoHeight;
-		if (width === 0 || height === 0) {
-			const message = 'The webcam stream is not ready yet.';
-			errorMessage = message;
-			logAction('Webcam capture failed', message, 'draft');
-			return;
-		}
-		const canvas = document.createElement('canvas');
-		canvas.width = width;
-		canvas.height = height;
-		const context = canvas.getContext('2d');
-		if (!context) {
-			const message = 'Unable to read frames from the webcam stream.';
-			errorMessage = message;
-			logAction('Webcam capture failed', message, 'draft');
-			return;
-		}
-		context.drawImage(videoElement, 0, 0, width, height);
-		const url = canvas.toDataURL('image/png');
-		const capture: StillCapture = {
-			id: generateId(),
-			url,
-			width,
-			height,
-			timestamp: new Date().toISOString(),
-			cameraLabel: cameraLabel()
-		} satisfies StillCapture;
-		captures = [capture, ...captures].slice(0, 8);
+	async function requestInventoryRefresh() {
 		errorMessage = null;
-		logAction('Webcam still captured', `${capture.cameraLabel} · ${width}×${height}`, 'complete', {
-			camera: capture.cameraLabel,
-			width,
-			height
-		});
-	}
-
-	function removeCapture(id: string) {
-		captures = captures.filter((capture) => capture.id !== id);
-	}
-
-	async function startRecording() {
-		if (!previewActive || !stream) {
-			const message = 'Start the preview before recording video.';
-			errorMessage = message;
-			logAction('Webcam recording failed', message, 'draft');
-			return;
-		}
-		if (typeof MediaRecorder === 'undefined') {
-			const message = 'MediaRecorder is not supported in this environment.';
-			errorMessage = message;
-			logAction('Webcam recording failed', message, 'draft');
-			return;
-		}
-		if (mediaRecorder && mediaRecorder.state === 'recording') {
-			return;
-		}
-
-		const track = stream.getVideoTracks()[0] ?? null;
-		const settings = track?.getSettings() ?? null;
-		const resolutionLabel = formatResolutionLabel(settings);
-		const fps =
-			typeof settings?.frameRate === 'number' && !Number.isNaN(settings.frameRate)
-				? Math.round(settings.frameRate)
-				: frameRate;
-		const cameraName = cameraLabel();
-		const mimeType = selectRecorderMimeType();
-
-		let recorder: MediaRecorder;
+		infoMessage = null;
 		try {
-			recorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
-		} catch (err) {
-			const message =
-				err instanceof DOMException || err instanceof Error
-					? err.message
-					: 'Unable to start recording.';
-			errorMessage = message;
-			logAction('Webcam recording failed', message, 'draft');
-			return;
-		}
-
-		recordedChunks = [];
-		discardRecording = false;
-		mediaRecorder = recorder;
-
-		recorder.addEventListener('dataavailable', (event) => {
-			if (event.data && event.data.size > 0) {
-				recordedChunks.push(event.data);
+			const response = await fetch(`${apiBase}/devices/refresh`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', Accept: 'application/json' }
+			});
+			if (!response.ok) {
+				throw new Error(`Refresh failed (${response.status})`);
 			}
-		});
-
-		recorder.addEventListener('error', (event) => {
-			const errorEvent = event as Event & { error?: DOMException };
-			const message = errorEvent.error?.message ?? 'An unknown recording error occurred.';
-			errorMessage = message;
-			logAction('Webcam recording error', message, 'draft');
-		});
-
-		recorder.addEventListener('stop', () => {
-			const durationMs = Math.max(0, Date.now() - recordingStartedAt);
-			const seconds = Math.max(0, Math.round(durationMs / 1000));
-			const blob =
-				recordedChunks.length > 0
-					? new Blob(recordedChunks, {
-							type: recorder.mimeType || mimeType || 'video/webm'
-						})
-					: null;
-
-			if (discardRecording) {
-				recordedChunks = [];
-				discardRecording = false;
-				mediaRecorder = null;
-				recordingStartedAt = 0;
-				stopRecordingTimer(true);
-				return;
-			}
-
-			if (!blob) {
-				recordedChunks = [];
-				mediaRecorder = null;
-				recordingStartedAt = 0;
-				stopRecordingTimer(true);
-				logAction('Webcam recording discarded', 'No data was captured', 'draft');
-				return;
-			}
-
-			const url = URL.createObjectURL(blob);
-			objectUrls.add(url);
-			const clip: RecordingClip = {
-				id: generateId(),
-				url,
-				mimeType: blob.type || mimeType || 'video/webm',
-				size: blob.size,
-				durationMs,
-				createdAt: new Date().toISOString(),
-				cameraLabel: cameraName,
-				resolution: resolutionLabel,
-				frameRate: fps ?? null
-			} satisfies RecordingClip;
-
-			recordings = [clip, ...recordings].slice(0, 8);
-			recordedChunks = [];
-			mediaRecorder = null;
-			recordingStartedAt = 0;
-			stopRecordingTimer(true);
+			inventoryPending = true;
 			logAction(
-				'Webcam recording saved',
-				`${cameraName} · ${resolutionLabel}${fps ? ` @ ${fps}fps` : ''} · ${formatDurationLabel(seconds)}`,
-				'complete'
-			);
-		});
-
-		try {
-			recorder.start();
-			recordingStartedAt = Date.now();
-			recordingActive = true;
-			startRecordingTimer();
-			errorMessage = null;
-			logAction(
-				'Webcam recording started',
-				`${cameraName} · ${resolutionLabel}${fps ? ` @ ${fps}fps` : ''}`,
+				'Inventory refresh requested',
+				'Webcam inventory refresh command queued.',
 				'in-progress'
 			);
 		} catch (err) {
-			recordedChunks = [];
-			mediaRecorder = null;
-			recordingStartedAt = 0;
-			stopRecordingTimer(true);
-			const message =
-				err instanceof DOMException || err instanceof Error
-					? err.message
-					: 'Unable to start recording.';
+			const message = err instanceof Error ? err.message : 'Unable to refresh webcam inventory.';
 			errorMessage = message;
-			logAction('Webcam recording failed', message, 'draft');
+			logAction('Inventory refresh failed', message, 'draft');
 		}
 	}
 
-	async function handleToggleRecording() {
-		if (recordingActive) {
-			await stopRecording(false);
-		} else {
-			await startRecording();
+	async function startSession() {
+		if (sessionLoading) {
+			return;
+		}
+		if (!selectedDevice) {
+			errorMessage = 'Select a webcam before starting the stream.';
+			logAction('Webcam start rejected', 'No webcam selected.', 'draft');
+			return;
+		}
+
+		sessionLoading = true;
+		errorMessage = null;
+		infoMessage = null;
+
+		try {
+			const response = await fetch(`${apiBase}/sessions`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+				body: JSON.stringify({ deviceId: selectedDevice })
+			});
+			if (!response.ok) {
+				throw new Error(`Session start failed (${response.status})`);
+			}
+			const payload = (await response.json()) as WebcamSessionState;
+			session = payload;
+			logAction(
+				'Webcam session requested',
+				`Stream request queued for ${selectedDevice}`,
+				'in-progress'
+			);
+			infoMessage =
+				'Webcam streaming is queued. The connected agent will begin streaming when the capability is available.';
+		} catch (err) {
+			const message =
+				err instanceof Error ? err.message : 'Unable to start the remote webcam session.';
+			errorMessage = message;
+			logAction('Webcam session failed', message, 'draft');
+		} finally {
+			sessionLoading = false;
 		}
 	}
 
-	function removeRecording(id: string) {
-		const clip = recordings.find((item) => item.id === id);
-		if (clip) {
-			URL.revokeObjectURL(clip.url);
-			objectUrls.delete(clip.url);
+	async function stopSession() {
+		if (sessionLoading || !session) {
+			return;
 		}
-		recordings = recordings.filter((clip) => clip.id !== id);
+		sessionLoading = true;
+		try {
+			const response = await fetch(`${apiBase}/sessions/${encodeURIComponent(session.sessionId)}`, {
+				method: 'DELETE',
+				headers: { Accept: 'application/json' }
+			});
+			if (!response.ok) {
+				throw new Error(`Session stop failed (${response.status})`);
+			}
+			session = null;
+			infoMessage = 'Webcam session closed. Await further commands to resume streaming.';
+			logAction('Webcam session stopped', 'Remote webcam session terminated.');
+		} catch (err) {
+			const message =
+				err instanceof Error ? err.message : 'Unable to stop the remote webcam session.';
+			errorMessage = message;
+			logAction('Webcam stop failed', message, 'draft');
+		} finally {
+			sessionLoading = false;
+		}
 	}
 
 	onMount(() => {
-		const supported = typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia;
-		mediaSupported = supported;
-		if (!supported) {
-			errorMessage = 'MediaDevices API unavailable in this environment.';
-			return () => {
-				for (const url of objectUrls) {
-					URL.revokeObjectURL(url);
-				}
-				objectUrls.clear();
-			};
-		}
-
-		void refreshDevices();
-
-		const handleDeviceChange = () => {
-			void refreshDevices();
-		};
-
-		navigator.mediaDevices.addEventListener?.('devicechange', handleDeviceChange);
-
-		return () => {
-			navigator.mediaDevices.removeEventListener?.('devicechange', handleDeviceChange);
-			void stopPreview(undefined, { discardRecording: true });
-			for (const url of objectUrls) {
-				URL.revokeObjectURL(url);
-			}
-			objectUrls.clear();
-		};
+		void fetchInventory();
 	});
 </script>
 
-<div class="space-y-6">
-	<Card>
-		<CardHeader>
-			<CardTitle class="text-base">Live preview</CardTitle>
-			<CardDescription
-				>Start the webcam stream and adjust capture parameters in real time.</CardDescription
-			>
-		</CardHeader>
-		<CardContent>
-			<div class="grid gap-6 lg:grid-cols-[3fr_2fr]">
-				<div class="space-y-4">
-					<div
-						class="relative aspect-video overflow-hidden rounded-xl border border-border/60 bg-black"
-					>
-						<video
-							bind:this={videoElement}
-							class="h-full w-full object-cover"
-							autoplay
-							muted
-							playsinline
-						></video>
-						{#if !previewActive}
-							<div
-								class="absolute inset-0 flex items-center justify-center bg-background/80 text-sm text-muted-foreground"
-							>
-								<p>{initializing ? 'Requesting camera access…' : 'Preview inactive'}</p>
-							</div>
-						{/if}
-						{#if recordingActive}
-							<div
-								class="text-destructive-foreground absolute top-4 left-4 flex items-center gap-2 rounded-full bg-destructive/80 px-3 py-1 text-xs font-medium shadow-sm"
-							>
-								<span class="bg-destructive-foreground size-2 rounded-full"></span>
-								Recording {formatSeconds(recordingSeconds)}
-							</div>
-						{/if}
-					</div>
-
-					<div class="flex flex-wrap gap-3">
-						<Button
-							type="button"
-							onclick={() => {
-								void startPreview({ restart: previewActive });
-							}}
-							disabled={initializing || !mediaSupported}
-						>
-							Start preview
-						</Button>
-						<Button
-							type="button"
-							variant="outline"
-							onclick={() => {
-								void stopPreview('Webcam preview stopped', { discardRecording: false });
-							}}
-							disabled={!previewActive}
-						>
-							Stop preview
-						</Button>
-						<Button
-							type="button"
-							variant="secondary"
-							onclick={captureStill}
-							disabled={!previewActive}
-						>
-							Capture still
-						</Button>
-						<Button
-							type="button"
-							variant={recordingActive ? 'destructive' : 'secondary'}
-							onclick={() => {
-								void handleToggleRecording();
-							}}
-							disabled={!previewActive || initializing || !mediaSupported}
-						>
-							{recordingActive ? 'Stop recording' : 'Record video'}
-						</Button>
-					</div>
-
-					{#if errorMessage}
-						<p class="text-sm text-destructive">{errorMessage}</p>
-					{/if}
-				</div>
-
-				<div class="space-y-4">
-					<div class="grid gap-2">
-						<Label for="webcam-camera">Camera</Label>
-						{#if mediaSupported && devices.length > 0}
-							<Select type="single" value={selectedCamera} onValueChange={handleCameraChange}>
-								<SelectTrigger id="webcam-camera" class="w-full">
-									<span class="truncate">{cameraLabel()}</span>
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value="">Auto (system default)</SelectItem>
-									{#each devices as device (device.id)}
-										<SelectItem value={device.id}>{device.label}</SelectItem>
-									{/each}
-								</SelectContent>
-							</Select>
-						{:else}
-							<Input id="webcam-camera" value="No cameras detected" readonly disabled />
-						{/if}
-					</div>
-
-					<div class="grid gap-2">
-						<Label for="webcam-resolution">Resolution</Label>
-						<Select type="single" value={resolution} onValueChange={handleResolutionChange}>
-							<SelectTrigger id="webcam-resolution" class="w-full">
-								<span>{resolution}</span>
+<Card class="flex flex-col gap-4">
+	<CardHeader>
+		<CardTitle>Webcam Control</CardTitle>
+		<CardDescription>
+			Manage remote webcam enumeration and streaming requests via the connected agent.
+		</CardDescription>
+	</CardHeader>
+	<CardContent class="flex flex-col gap-6">
+		<section class="flex flex-col gap-3">
+			<div class="flex flex-wrap items-end gap-3">
+				<div class="flex flex-col gap-1">
+					<Label for="webcam-device">Camera</Label>
+					{#if devices.length > 0}
+						<Select bind:value={selectedDevice}>
+							<SelectTrigger id="webcam-device" class="w-64">
+								{#if selectedDevice}
+									{devices.find((device) => device.id === selectedDevice)?.label ??
+										'Select a camera'}
+								{:else}
+									Select a camera
+								{/if}
 							</SelectTrigger>
 							<SelectContent>
-								{#each RESOLUTION_OPTIONS as option (option.value)}
-									<SelectItem value={option.value}>{option.label}</SelectItem>
+								{#each devices as device}
+									<SelectItem value={device.id}>{device.label}</SelectItem>
 								{/each}
 							</SelectContent>
 						</Select>
-					</div>
-
-					<div class="grid gap-2">
-						<Label for="webcam-framerate">Frame rate (fps)</Label>
-						<Input
-							id="webcam-framerate"
-							type="number"
-							min={1}
-							max={120}
-							bind:value={frameRate}
-							onchange={handleFrameRateChange}
-						/>
-					</div>
-
-					<div class="grid gap-2">
-						<Label for="webcam-zoom">Zoom</Label>
-						<div class="flex items-center gap-3">
-							<Input
-								id="webcam-zoom"
-								type="range"
-								min={zoomMin}
-								max={zoomMax}
-								step={zoomStep}
-								value={zoom}
-								oninput={handleZoomInput}
-								disabled={!zoomSupported || !previewActive}
-							/>
-							<span class="w-16 text-right text-sm text-muted-foreground">
-								{zoomSupported ? `${zoom.toFixed(2)}×` : '—'}
-							</span>
-						</div>
-						<p class="text-xs text-muted-foreground">
-							{zoomSupported
-								? 'Adjust optical zoom when supported by the selected camera.'
-								: 'Zoom control is unavailable for this camera.'}
-						</p>
-					</div>
+					{:else}
+						<Input id="webcam-device" value="No webcams detected" readonly disabled class="w-64" />
+					{/if}
+				</div>
+				<div class="flex gap-2">
+					<Button variant="secondary" disabled={inventoryLoading} on:click={fetchInventory}>
+						Refresh status
+					</Button>
+					<Button variant="outline" disabled={inventoryLoading} on:click={requestInventoryRefresh}>
+						Request agent refresh
+					</Button>
 				</div>
 			</div>
-		</CardContent>
-	</Card>
-
-	<Card class="border-dashed">
-		<CardHeader>
-			<CardTitle class="text-base">Still captures</CardTitle>
-			<CardDescription>Download snapshots captured from the live webcam feed.</CardDescription>
-		</CardHeader>
-		<CardContent>
-			{#if captures.length === 0}
+			{#if inventoryPending}
 				<p class="text-sm text-muted-foreground">
-					No still captures yet. Use “Capture still” while the preview is active.
+					Awaiting an updated device inventory from the agent.
 				</p>
-			{:else}
-				<div class="grid gap-4 md:grid-cols-2">
-					{#each captures as capture (capture.id)}
-						<div class="space-y-3 rounded-lg border border-border/60 bg-muted/30 p-3">
-							<img
-								src={capture.url}
-								alt={`Capture from ${capture.cameraLabel}`}
-								class="aspect-video w-full rounded-md object-cover"
-							/>
-							<div class="space-y-1 text-xs">
-								<p class="font-medium text-foreground">{capture.cameraLabel}</p>
-								<p class="text-muted-foreground">
-									{capture.width}×{capture.height} · {formatTimestamp(capture.timestamp)}
-								</p>
-							</div>
-							<div class="flex gap-2">
-								<Button
-									href={capture.url}
-									download={`capture-${capture.id}.png`}
-									variant="outline"
-									size="sm"
-								>
-									Download
-								</Button>
-								<Button
-									type="button"
-									variant="ghost"
-									size="sm"
-									onclick={() => {
-										removeCapture(capture.id);
-									}}
-								>
-									Remove
-								</Button>
-							</div>
-						</div>
-					{/each}
-				</div>
 			{/if}
-		</CardContent>
-	</Card>
+			{#if infoMessage}
+				<p class="text-sm text-muted-foreground">{infoMessage}</p>
+			{/if}
+			{#if errorMessage}
+				<p class="text-sm text-destructive">{errorMessage}</p>
+			{/if}
+		</section>
 
-	<Card class="border-dashed">
-		<CardHeader>
-			<CardTitle class="text-base">Recorded clips</CardTitle>
-			<CardDescription>Clips are stored locally until you download or remove them.</CardDescription>
-		</CardHeader>
-		<CardContent>
-			{#if recordings.length === 0}
-				<p class="text-sm text-muted-foreground">
-					No recordings yet. Start the preview and use “Record video” to capture the feed.
+		<section class="flex flex-col gap-4">
+			<div class="flex gap-2">
+				<Button on:click={startSession} disabled={sessionLoading || !selectedDevice}>
+					{session ? 'Restart stream' : 'Start stream'}
+				</Button>
+				<Button variant="outline" on:click={stopSession} disabled={sessionLoading || !session}>
+					Stop stream
+				</Button>
+			</div>
+			<div class="rounded-lg border bg-muted/40 p-4">
+				<video
+					bind:this={videoElement}
+					class="aspect-video w-full rounded-lg bg-black"
+					autoplay
+					playsinline
+					muted
+				/>
+				<p class="mt-2 text-sm text-muted-foreground">
+					Remote webcam streaming will appear here once the agent begins transmitting media. Until
+					then, commands queue successfully but playback may remain unavailable if the agent does
+					not support webcam streaming yet.
 				</p>
+			</div>
+		</section>
+
+		<section class="flex flex-col gap-2">
+			<h3 class="text-sm font-semibold">Activity log</h3>
+			{#if log.length === 0}
+				<p class="text-sm text-muted-foreground">No actions recorded for this session yet.</p>
 			{:else}
-				<div class="space-y-3">
-					{#each recordings as clip (clip.id)}
-						<div
-							class="flex flex-col gap-3 rounded-lg border border-border/60 bg-muted/30 p-3 md:flex-row md:items-center md:justify-between"
-						>
-							<div class="space-y-1 text-xs">
-								<p class="text-sm font-medium text-foreground">{clip.cameraLabel}</p>
-								<p class="text-muted-foreground">
-									{clip.resolution}
-									{clip.frameRate ? ` @ ${clip.frameRate}fps` : ''}
-									· {formatDurationLabel(Math.max(0, Math.round(clip.durationMs / 1000)))}
-									· {formatBytes(clip.size)}
-								</p>
-								<p class="text-muted-foreground">{formatTimestamp(clip.createdAt)}</p>
-							</div>
-							<div class="flex gap-2">
-								<Button
-									href={clip.url}
-									download={`recording-${clip.id}.${recordingExtension(clip.mimeType)}`}
-									variant="outline"
-									size="sm"
-								>
-									Download
-								</Button>
-								<Button
-									type="button"
-									variant="ghost"
-									size="sm"
-									onclick={() => {
-										removeRecording(clip.id);
-									}}
-								>
-									Remove
-								</Button>
-							</div>
-						</div>
+				<ul class="flex flex-col gap-1 text-sm">
+					{#each log as entry (entry.id)}
+						<li>
+							<span class="font-medium">{entry.action}</span>
+							<span class="mx-2 text-muted-foreground">—</span>
+							<span>{entry.detail}</span>
+						</li>
 					{/each}
-				</div>
+				</ul>
 			{/if}
-		</CardContent>
-	</Card>
-</div>
+		</section>
+	</CardContent>
+</Card>

--- a/tenvy-server/src/lib/server/rat/webcam.test.ts
+++ b/tenvy-server/src/lib/server/rat/webcam.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { WebcamControlManager } from './webcam';
+
+describe('WebcamControlManager', () => {
+	let manager: WebcamControlManager;
+
+	beforeEach(() => {
+		manager = new WebcamControlManager();
+	});
+
+	it('tracks pending inventory requests until fulfilled', () => {
+		const stateEmpty = manager.getInventoryState('agent-1');
+		expect(stateEmpty.pending).toBe(false);
+		expect(stateEmpty.inventory).toBeNull();
+
+		manager.markInventoryRequest('agent-1', 'req-1');
+		let state = manager.getInventoryState('agent-1');
+		expect(state.pending).toBe(true);
+
+		manager.updateInventory('agent-1', {
+			devices: [],
+			capturedAt: new Date().toISOString(),
+			requestId: 'req-1'
+		});
+
+		state = manager.getInventoryState('agent-1');
+		expect(state.pending).toBe(false);
+		expect(state.inventory).not.toBeNull();
+	});
+
+	it('creates, updates, and removes sessions', () => {
+		const session = manager.createSession('agent-1', {
+			deviceId: 'camera-1',
+			settings: { width: 1280, height: 720 }
+		});
+
+		expect(session.sessionId).toBeTruthy();
+		expect(session.status).toBe('pending');
+
+		const updated = manager.updateSession('agent-1', session.sessionId, {
+			status: 'active',
+			negotiation: {
+				offer: { transport: 'webrtc', offer: 'abc' }
+			}
+		});
+
+		expect(updated.status).toBe('active');
+		expect(updated.negotiation?.offer?.offer).toBe('abc');
+
+		const fetched = manager.getSession('agent-1', session.sessionId);
+		expect(fetched?.status).toBe('active');
+
+		manager.deleteSession('agent-1', session.sessionId);
+		expect(manager.getSession('agent-1', session.sessionId)).toBeNull();
+	});
+});

--- a/tenvy-server/src/lib/server/rat/webcam.ts
+++ b/tenvy-server/src/lib/server/rat/webcam.ts
@@ -1,0 +1,205 @@
+import { randomUUID } from 'crypto';
+import type {
+	WebcamDeviceInventory,
+	WebcamDeviceInventoryState,
+	WebcamNegotiationState,
+	WebcamSessionState,
+	WebcamStreamSettings
+} from '$lib/types/webcam';
+
+function cloneInventory(input: WebcamDeviceInventory | null): WebcamDeviceInventory | null {
+	if (!input) {
+		return null;
+	}
+	return {
+		devices: input.devices.map((device) => ({
+			...device,
+			capabilities: device.capabilities
+				? {
+						...device.capabilities,
+						resolutions: device.capabilities.resolutions
+							? device.capabilities.resolutions.map((item) => ({ ...item }))
+							: undefined,
+						frameRates: device.capabilities.frameRates
+							? [...device.capabilities.frameRates]
+							: undefined,
+						zoom: device.capabilities.zoom ? { ...device.capabilities.zoom } : undefined
+					}
+				: undefined
+		})),
+		capturedAt: input.capturedAt,
+		requestId: input.requestId,
+		warning: input.warning
+	} satisfies WebcamDeviceInventory;
+}
+
+interface WebcamSessionRecord {
+	id: string;
+	agentId: string;
+	deviceId?: string;
+	settings?: WebcamStreamSettings;
+	status: 'pending' | 'active' | 'stopped' | 'error';
+	createdAt: Date;
+	updatedAt: Date;
+	negotiation?: WebcamNegotiationState;
+	error?: string;
+}
+
+function cloneSession(record: WebcamSessionRecord): WebcamSessionState {
+	return {
+		sessionId: record.id,
+		agentId: record.agentId,
+		deviceId: record.deviceId,
+		createdAt: record.createdAt.toISOString(),
+		updatedAt: record.updatedAt.toISOString(),
+		status: record.status,
+		settings: record.settings ? { ...record.settings } : undefined,
+		negotiation: record.negotiation
+			? {
+					offer: record.negotiation.offer
+						? {
+								...record.negotiation.offer,
+								iceServers: record.negotiation.offer.iceServers?.slice()
+							}
+						: undefined,
+					answer: record.negotiation.answer
+						? {
+								...record.negotiation.answer,
+								iceServers: record.negotiation.answer.iceServers?.slice()
+							}
+						: undefined
+				}
+			: undefined,
+		error: record.error
+	} satisfies WebcamSessionState;
+}
+
+export class WebcamControlError extends Error {
+	status: number;
+
+	constructor(message: string, status = 400) {
+		super(message);
+		this.name = 'WebcamControlError';
+		this.status = status;
+	}
+}
+
+export class WebcamControlManager {
+	private inventories = new Map<string, WebcamDeviceInventory>();
+	private pendingInventory = new Map<string, Set<string>>();
+	private sessions = new Map<string, Map<string, WebcamSessionRecord>>();
+
+	markInventoryRequest(agentId: string, requestId: string) {
+		const trimmed = requestId?.trim();
+		if (!trimmed) {
+			return;
+		}
+		if (!this.pendingInventory.has(agentId)) {
+			this.pendingInventory.set(agentId, new Set());
+		}
+		this.pendingInventory.get(agentId)?.add(trimmed);
+	}
+
+	updateInventory(agentId: string, inventory: WebcamDeviceInventory) {
+		if (!inventory || !Array.isArray(inventory.devices)) {
+			throw new WebcamControlError('Invalid webcam inventory payload', 400);
+		}
+		this.inventories.set(agentId, cloneInventory(inventory)!);
+		if (inventory.requestId) {
+			const pending = this.pendingInventory.get(agentId);
+			pending?.delete(inventory.requestId);
+			if (pending && pending.size === 0) {
+				this.pendingInventory.delete(agentId);
+			}
+		}
+	}
+
+	getInventoryState(agentId: string): WebcamDeviceInventoryState {
+		const inventory = this.inventories.get(agentId) ?? null;
+		const pending = this.pendingInventory.get(agentId);
+		return {
+			inventory: cloneInventory(inventory),
+			pending: Boolean(pending && pending.size > 0)
+		} satisfies WebcamDeviceInventoryState;
+	}
+
+	createSession(
+		agentId: string,
+		options: { deviceId?: string; settings?: WebcamStreamSettings; sessionId?: string }
+	): WebcamSessionState {
+		const id = options.sessionId?.trim() || randomUUID();
+		const now = new Date();
+		const record: WebcamSessionRecord = {
+			id,
+			agentId,
+			deviceId: options.deviceId?.trim() || undefined,
+			settings: options.settings ? { ...options.settings } : undefined,
+			status: 'pending',
+			createdAt: now,
+			updatedAt: now
+		};
+
+		if (!this.sessions.has(agentId)) {
+			this.sessions.set(agentId, new Map());
+		}
+		this.sessions.get(agentId)!.set(id, record);
+		return cloneSession(record);
+	}
+
+	updateSession(
+		agentId: string,
+		sessionId: string,
+		patch: {
+			status?: 'pending' | 'active' | 'stopped' | 'error';
+			negotiation?: WebcamNegotiationState | null;
+			error?: string | null;
+		}
+	): WebcamSessionState {
+		const sessions = this.sessions.get(agentId);
+		const record = sessions?.get(sessionId);
+		if (!record) {
+			throw new WebcamControlError('Webcam session not found', 404);
+		}
+		if (patch.status) {
+			record.status = patch.status;
+		}
+		if (patch.negotiation !== undefined) {
+			record.negotiation = patch.negotiation
+				? {
+						offer: patch.negotiation.offer
+							? {
+									...patch.negotiation.offer,
+									iceServers: patch.negotiation.offer.iceServers?.slice()
+								}
+							: undefined,
+						answer: patch.negotiation.answer
+							? {
+									...patch.negotiation.answer,
+									iceServers: patch.negotiation.answer.iceServers?.slice()
+								}
+							: undefined
+					}
+				: undefined;
+		}
+		if (patch.error !== undefined) {
+			record.error = patch.error ?? undefined;
+		}
+		record.updatedAt = new Date();
+		return cloneSession(record);
+	}
+
+	getSession(agentId: string, sessionId: string): WebcamSessionState | null {
+		const record = this.sessions.get(agentId)?.get(sessionId) ?? null;
+		return record ? cloneSession(record) : null;
+	}
+
+	deleteSession(agentId: string, sessionId: string) {
+		const sessions = this.sessions.get(agentId);
+		sessions?.delete(sessionId);
+		if (sessions && sessions.size === 0) {
+			this.sessions.delete(agentId);
+		}
+	}
+}
+
+export const webcamControlManager = new WebcamControlManager();

--- a/tenvy-server/src/lib/types/webcam.ts
+++ b/tenvy-server/src/lib/types/webcam.ts
@@ -1,0 +1,1 @@
+export * from '../../../../shared/types/webcam';

--- a/tenvy-server/src/routes/api/agents/[clientId]/webcam/devices/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[clientId]/webcam/devices/+server.ts
@@ -1,0 +1,39 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { webcamControlManager, WebcamControlError } from '$lib/server/rat/webcam';
+import type { WebcamDeviceInventory } from '$lib/types/webcam';
+
+export const GET: RequestHandler = ({ params }) => {
+	const clientId = params.clientId;
+	if (!clientId) {
+		throw error(400, 'Missing agent identifier');
+	}
+
+	const state = webcamControlManager.getInventoryState(clientId);
+	return json(state);
+};
+
+export const POST: RequestHandler = async ({ params, request }) => {
+	const clientId = params.clientId;
+	if (!clientId) {
+		throw error(400, 'Missing agent identifier');
+	}
+
+	let payload: WebcamDeviceInventory;
+	try {
+		payload = (await request.json()) as WebcamDeviceInventory;
+	} catch {
+		throw error(400, 'Invalid webcam inventory payload');
+	}
+
+	try {
+		webcamControlManager.updateInventory(clientId, payload);
+	} catch (err) {
+		if (err instanceof WebcamControlError) {
+			throw error(err.status, err.message);
+		}
+		throw error(500, 'Failed to update webcam inventory');
+	}
+
+	return json({ accepted: true });
+};

--- a/tenvy-server/src/routes/api/agents/[clientId]/webcam/devices/refresh/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[clientId]/webcam/devices/refresh/+server.ts
@@ -1,0 +1,38 @@
+import { randomUUID } from 'crypto';
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireOperator } from '$lib/server/authorization';
+import { registry, RegistryError } from '$lib/server/rat/store';
+import { webcamControlManager } from '$lib/server/rat/webcam';
+import type { WebcamCommandPayload } from '$lib/types/webcam';
+
+export const POST: RequestHandler = ({ params, locals }) => {
+	const clientId = params.clientId;
+	if (!clientId) {
+		throw error(400, 'Missing agent identifier');
+	}
+
+	const operator = requireOperator(locals.user);
+	const requestId = randomUUID();
+	webcamControlManager.markInventoryRequest(clientId, requestId);
+
+	const payload: WebcamCommandPayload = {
+		action: 'enumerate',
+		requestId
+	};
+
+	try {
+		registry.queueCommand(
+			clientId,
+			{ name: 'webcam-control', payload },
+			{ operatorId: operator.id }
+		);
+	} catch (err) {
+		if (err instanceof RegistryError) {
+			throw error(err.status, err.message);
+		}
+		throw error(500, 'Failed to queue webcam inventory command');
+	}
+
+	return json({ requestId });
+};

--- a/tenvy-server/src/routes/api/agents/[clientId]/webcam/sessions/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[clientId]/webcam/sessions/+server.ts
@@ -1,0 +1,63 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireOperator } from '$lib/server/authorization';
+import { registry, RegistryError } from '$lib/server/rat/store';
+import { webcamControlManager, WebcamControlError } from '$lib/server/rat/webcam';
+import type { WebcamCommandPayload, WebcamStreamSettings } from '$lib/types/webcam';
+
+interface CreateSessionPayload {
+	deviceId?: string;
+	settings?: WebcamStreamSettings;
+}
+
+export const POST: RequestHandler = async ({ params, request, locals }) => {
+	const clientId = params.clientId;
+	if (!clientId) {
+		throw error(400, 'Missing agent identifier');
+	}
+
+	const operator = requireOperator(locals.user);
+
+	let payload: CreateSessionPayload;
+	try {
+		payload = (await request.json()) as CreateSessionPayload;
+	} catch {
+		throw error(400, 'Invalid webcam session payload');
+	}
+
+	let session;
+	try {
+		session = webcamControlManager.createSession(clientId, {
+			deviceId: payload.deviceId,
+			settings: payload.settings
+		});
+	} catch (err) {
+		if (err instanceof WebcamControlError) {
+			throw error(err.status, err.message);
+		}
+		throw error(500, 'Failed to create webcam session');
+	}
+
+	const command: WebcamCommandPayload = {
+		action: 'start',
+		sessionId: session.sessionId,
+		deviceId: payload.deviceId,
+		settings: payload.settings
+	};
+
+	try {
+		registry.queueCommand(
+			clientId,
+			{ name: 'webcam-control', payload: command },
+			{ operatorId: operator.id }
+		);
+	} catch (err) {
+		webcamControlManager.deleteSession(clientId, session.sessionId);
+		if (err instanceof RegistryError) {
+			throw error(err.status, err.message);
+		}
+		throw error(500, 'Failed to queue webcam session command');
+	}
+
+	return json(session);
+};

--- a/tenvy-server/src/routes/api/agents/[clientId]/webcam/sessions/[sessionId]/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[clientId]/webcam/sessions/[sessionId]/+server.ts
@@ -1,0 +1,89 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireOperator } from '$lib/server/authorization';
+import { registry, RegistryError } from '$lib/server/rat/store';
+import { webcamControlManager, WebcamControlError } from '$lib/server/rat/webcam';
+import type { WebcamCommandPayload } from '$lib/types/webcam';
+
+export const GET: RequestHandler = ({ params }) => {
+	const clientId = params.clientId;
+	const sessionId = params.sessionId;
+	if (!clientId || !sessionId) {
+		throw error(400, 'Missing agent or session identifier');
+	}
+
+	const session = webcamControlManager.getSession(clientId, sessionId);
+	if (!session) {
+		throw error(404, 'Webcam session not found');
+	}
+	return json(session);
+};
+
+export const DELETE: RequestHandler = ({ params, locals }) => {
+	const clientId = params.clientId;
+	const sessionId = params.sessionId;
+	if (!clientId || !sessionId) {
+		throw error(400, 'Missing agent or session identifier');
+	}
+
+	const operator = requireOperator(locals.user);
+	const session = webcamControlManager.getSession(clientId, sessionId);
+	if (!session) {
+		throw error(404, 'Webcam session not found');
+	}
+
+	const command: WebcamCommandPayload = {
+		action: 'stop',
+		sessionId
+	};
+
+	try {
+		registry.queueCommand(
+			clientId,
+			{ name: 'webcam-control', payload: command },
+			{ operatorId: operator.id }
+		);
+	} catch (err) {
+		if (err instanceof RegistryError) {
+			throw error(err.status, err.message);
+		}
+		throw error(500, 'Failed to queue webcam stop command');
+	}
+
+	webcamControlManager.updateSession(clientId, sessionId, { status: 'stopped' });
+	webcamControlManager.deleteSession(clientId, sessionId);
+	return json({ stopped: true });
+};
+
+export const PATCH: RequestHandler = async ({ params, request }) => {
+	const clientId = params.clientId;
+	const sessionId = params.sessionId;
+	if (!clientId || !sessionId) {
+		throw error(400, 'Missing agent or session identifier');
+	}
+
+	let payload: {
+		status?: 'pending' | 'active' | 'stopped' | 'error';
+		error?: string | null;
+		negotiation?: WebcamCommandPayload['negotiation'] | null;
+	};
+	try {
+		payload = (await request.json()) as typeof payload;
+	} catch {
+		throw error(400, 'Invalid webcam session payload');
+	}
+
+	try {
+		const updated = webcamControlManager.updateSession(clientId, sessionId, {
+			status: payload.status,
+			error: payload.error ?? undefined,
+			negotiation: payload.negotiation ?? undefined
+		});
+		return json(updated);
+	} catch (err) {
+		if (err instanceof WebcamControlError) {
+			throw error(err.status, err.message);
+		}
+		throw error(500, 'Failed to update webcam session');
+	}
+};

--- a/tenvy-server/tests/webcam-api.test.ts
+++ b/tenvy-server/tests/webcam-api.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockEnv = { env: {} };
+
+vi.mock('$env/dynamic/private', () => mockEnv, { virtual: true });
+
+const queueCommand = vi.fn();
+
+class MockRegistryError extends Error {
+        status: number;
+
+        constructor(message: string, status = 400) {
+                super(message);
+                this.status = status;
+        }
+}
+
+vi.mock('../src/lib/server/authorization.js', () => ({
+        requireOperator: (user: { id: string }) => user ?? { id: 'operator-test' }
+}));
+
+vi.mock('../src/lib/server/rat/store.js', () => ({
+        registry: {
+                queueCommand
+        },
+        RegistryError: MockRegistryError
+}));
+
+const refreshModule = await import('../src/routes/api/agents/[clientId]/webcam/devices/refresh/+server.js');
+const devicesModule = await import('../src/routes/api/agents/[clientId]/webcam/devices/+server.js');
+const sessionsModule = await import('../src/routes/api/agents/[clientId]/webcam/sessions/+server.js');
+const sessionModule = await import('../src/routes/api/agents/[clientId]/webcam/sessions/[sessionId]/+server.js');
+const { webcamControlManager } = await import('../src/lib/server/rat/webcam.js');
+
+const refreshPOST = refreshModule.POST;
+const devicesPOST = devicesModule.POST;
+const devicesGET = devicesModule.GET;
+const sessionsPOST = sessionsModule.POST;
+const sessionDELETE = sessionModule.DELETE;
+
+function createEvent<T extends (...args: any) => any>(
+        handler: T,
+        options: Partial<Parameters<T>[0]>
+): Parameters<T>[0] {
+        return {
+                params: {},
+                request: new Request('https://controller.test', { method: 'GET' }),
+                locals: { user: { id: 'operator-test' } },
+                ...options
+        } as Parameters<T>[0];
+}
+
+describe('webcam API routes', () => {
+        beforeEach(() => {
+                queueCommand.mockReset();
+        });
+
+        it('queues an inventory refresh command', async () => {
+                const response = await refreshPOST(
+                        createEvent(refreshPOST, {
+                                params: { clientId: 'agent-refresh' }
+                        })
+                );
+
+                expect(queueCommand).toHaveBeenCalledTimes(1);
+                const payload = queueCommand.mock.calls[0]?.[1]?.payload as { action: string; requestId?: string };
+                expect(payload?.action).toBe('enumerate');
+                expect(payload?.requestId).toBeTruthy();
+
+                const body = (await response.json()) as { requestId: string };
+                expect(body.requestId).toBe(payload.requestId);
+        });
+
+        it('persists inventory updates and supports session creation lifecycle', async () => {
+                const now = new Date().toISOString();
+                await devicesPOST(
+                        createEvent(devicesPOST, {
+                                params: { clientId: 'agent-inventory' },
+                                request: new Request('https://controller.test', {
+                                        method: 'POST',
+                                        body: JSON.stringify({
+                                                devices: [
+                                                        { id: 'cam-1', label: 'Primary Camera' }
+                                                ],
+                                                capturedAt: now
+                                        }),
+                                        headers: { 'Content-Type': 'application/json' }
+                                })
+                        })
+                );
+
+                const response = await devicesGET(
+                        createEvent(devicesGET, {
+                                params: { clientId: 'agent-inventory' }
+                        })
+                );
+
+                const state = (await response.json()) as {
+                        inventory: { devices: { id: string }[] } | null;
+                        pending: boolean;
+                };
+                expect(state.pending).toBe(false);
+                expect(state.inventory?.devices[0]?.id).toBe('cam-1');
+
+                queueCommand.mockReset();
+                const sessionResponse = await sessionsPOST(
+                        createEvent(sessionsPOST, {
+                                params: { clientId: 'agent-inventory' },
+                                request: new Request('https://controller.test', {
+                                        method: 'POST',
+                                        body: JSON.stringify({ deviceId: 'cam-1' }),
+                                        headers: { 'Content-Type': 'application/json' }
+                                })
+                        })
+                );
+
+                expect(queueCommand).toHaveBeenCalledTimes(1);
+                const sessionPayload = queueCommand.mock.calls[0]?.[1]?.payload as { action: string };
+                expect(sessionPayload?.action).toBe('start');
+
+                const sessionBody = (await sessionResponse.json()) as { sessionId: string };
+                expect(sessionBody.sessionId).toBeTruthy();
+
+                queueCommand.mockReset();
+                await sessionDELETE(
+                        createEvent(sessionDELETE, {
+                                params: { clientId: 'agent-inventory', sessionId: sessionBody.sessionId }
+                        })
+                );
+
+                expect(queueCommand).toHaveBeenCalledTimes(1);
+                const stopPayload = queueCommand.mock.calls[0]?.[1]?.payload as { action: string };
+                expect(stopPayload?.action).toBe('stop');
+                expect(webcamControlManager.getSession('agent-inventory', sessionBody.sessionId)).toBeNull();
+        });
+});


### PR DESCRIPTION
## Summary
- define shared webcam command and state contracts and register the new `webcam-control` command
- add a stubbed Go webcam manager, module wiring, and expose inventory publishing
- build server-side webcam manager, API routes, UI workspace refactor, and vitest coverage

## Testing
- go test ./... -run TestModuleManagerLifecycle -count=1
- bun run test:unit tests/webcam-api.test.ts --run

------
https://chatgpt.com/codex/tasks/task_e_68f9de3d9cb0832b980a821aea4a3344