### PR TITLE
Allow unstoppable flag to be toggled on active chat sessions

### DIFF
--- a/tenvy-server/src/lib/server/rat/client-chat.ts
+++ b/tenvy-server/src/lib/server/rat/client-chat.ts
@@ -194,19 +194,15 @@ export class ClientChatManager {
 		}
 	): ClientChatSessionState {
 		const record = this.getOrCreateRecord(agentId);
-		const requestedId = options.sessionId?.trim();
-		if (requestedId && requestedId !== record.id) {
-			record.id = requestedId;
-			record.messages = [];
-		}
-		this.applyAliases(record, options.aliases);
-		this.applyFeatures(record, options.features);
-		if (record.active) {
-			record.unstoppable = true;
-			record.features.unstoppable = true;
-		}
-		return cloneState(record);
-	}
+                const requestedId = options.sessionId?.trim();
+                if (requestedId && requestedId !== record.id) {
+                        record.id = requestedId;
+                        record.messages = [];
+                }
+                this.applyAliases(record, options.aliases);
+                this.applyFeatures(record, options.features);
+                return cloneState(record);
+        }
 
 	sendOperatorMessage(
 		agentId: string,

--- a/tenvy-server/src/routes/api/agents/[id]/chat/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/chat/+server.ts
@@ -78,17 +78,17 @@ function normalizeAliases(
 }
 
 function normalizeFeatures(
-	features: Partial<ClientChatFeatureFlags> | undefined,
-	options: { forceUnstoppable?: boolean } = {}
+        features: Partial<ClientChatFeatureFlags> | undefined,
+        options: { forceUnstoppable?: boolean } = {}
 ): Partial<ClientChatFeatureFlags> | undefined {
-	const normalized: Partial<ClientChatFeatureFlags> = { ...(features ?? {}) };
-	const shouldForce = options.forceUnstoppable || normalized.unstoppable === false;
-	if (shouldForce) {
-		normalized.unstoppable = true;
-	}
-	if (Object.keys(normalized).length === 0) {
-		return undefined;
-	}
+        const normalized: Partial<ClientChatFeatureFlags> = { ...(features ?? {}) };
+        const shouldForce = options.forceUnstoppable === true;
+        if (shouldForce) {
+                normalized.unstoppable = true;
+        }
+        if (Object.keys(normalized).length === 0) {
+                return undefined;
+        }
 	return normalized;
 }
 
@@ -228,16 +228,14 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 				throw error(500, 'Failed to dispatch chat message');
 			}
 		}
-		case 'configure': {
-			const current = clientChatManager.getState(agentId);
-			const sessionId = payload.sessionId?.trim() || current?.sessionId || randomUUID();
-			const aliases = normalizeAliases(payload.aliases, {
-				operator: current?.operatorAlias ?? 'Operator',
-				client: current?.clientAlias ?? 'Client'
-			});
-			const features = normalizeFeatures(payload.features, {
-				forceUnstoppable: current?.active ?? false
-			});
+                case 'configure': {
+                        const current = clientChatManager.getState(agentId);
+                        const sessionId = payload.sessionId?.trim() || current?.sessionId || randomUUID();
+                        const aliases = normalizeAliases(payload.aliases, {
+                                operator: current?.operatorAlias ?? 'Operator',
+                                client: current?.clientAlias ?? 'Client'
+                        });
+                        const features = normalizeFeatures(payload.features);
 			queueChatCommand(
 				agentId,
 				{

--- a/tenvy-server/tests/client-chat-manager.test.ts
+++ b/tenvy-server/tests/client-chat-manager.test.ts
@@ -59,15 +59,22 @@ describe('ClientChatManager', () => {
 		expect(stopped?.unstoppable).toBe(false);
 	});
 
-	it('ignores requests to disable unstoppable while active', () => {
-		const state = manager.ensureSession(agentId);
-		const updated = manager.configureSession(agentId, {
-			sessionId: state.sessionId,
-			features: { unstoppable: false }
-		});
-		expect(updated.unstoppable).toBe(true);
-		expect(updated.features.unstoppable).toBe(true);
-	});
+        it('allows toggling unstoppable off and on while active', () => {
+                const state = manager.ensureSession(agentId);
+                const disabled = manager.configureSession(agentId, {
+                        sessionId: state.sessionId,
+                        features: { unstoppable: false }
+                });
+                expect(disabled.unstoppable).toBe(false);
+                expect(disabled.features.unstoppable).toBe(false);
+
+                const reenabled = manager.configureSession(agentId, {
+                        sessionId: state.sessionId,
+                        features: { unstoppable: true }
+                });
+                expect(reenabled.unstoppable).toBe(true);
+                expect(reenabled.features.unstoppable).toBe(true);
+        });
 
 	it('rejects operator messages when session inactive', () => {
 		expect(() =>


### PR DESCRIPTION
## Summary
- update chat API feature normalization so unstoppable=false is preserved during configure requests
- allow ClientChatManager.configureSession to honor unstoppable flag updates on active sessions
- extend the client chat manager test suite to cover toggling unstoppable off and back on

## Testing
- bun test tests/client-chat-manager.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fa08f363c8832b99a60f529199aedc