### PR TITLE
Add macOS uptime implementation with tests

### DIFF
--- a/tenvy-client/internal/agent/uptime_darwin.go
+++ b/tenvy-client/internal/agent/uptime_darwin.go
@@ -1,0 +1,30 @@
+//go:build darwin
+
+package agent
+
+import (
+	"errors"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+var (
+	sysctlTimeval = func(name string) (unix.Timeval, error) {
+		return unix.SysctlTimeval(name)
+	}
+	timeNow = time.Now
+)
+
+func systemUptime() (time.Duration, error) {
+	tv, err := sysctlTimeval("kern.boottime")
+	if err != nil {
+		return 0, err
+	}
+	boot := time.Unix(int64(tv.Sec), int64(tv.Usec)*1000)
+	now := timeNow()
+	if now.Before(boot) {
+		return 0, errors.New("system boot time is in the future")
+	}
+	return now.Sub(boot), nil
+}

--- a/tenvy-client/internal/agent/uptime_darwin_test.go
+++ b/tenvy-client/internal/agent/uptime_darwin_test.go
@@ -1,0 +1,82 @@
+//go:build darwin
+
+package agent
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestSystemUptime(t *testing.T) {
+	originalSysctl := sysctlTimeval
+	originalNow := timeNow
+	t.Cleanup(func() {
+		sysctlTimeval = originalSysctl
+		timeNow = originalNow
+	})
+
+	boot := unix.Timeval{Sec: 100, Usec: 250000}
+	fakeNow := time.Unix(200, 0)
+
+	sysctlTimeval = func(string) (unix.Timeval, error) {
+		return boot, nil
+	}
+	timeNow = func() time.Time {
+		return fakeNow
+	}
+
+	uptime, err := systemUptime()
+	if err != nil {
+		t.Fatalf("systemUptime returned error: %v", err)
+	}
+
+	expected := fakeNow.Sub(time.Unix(int64(boot.Sec), int64(boot.Usec)*1000))
+	if uptime != expected {
+		t.Fatalf("expected uptime %s, got %s", expected, uptime)
+	}
+}
+
+func TestSystemUptimeSysctlError(t *testing.T) {
+	originalSysctl := sysctlTimeval
+	originalNow := timeNow
+	t.Cleanup(func() {
+		sysctlTimeval = originalSysctl
+		timeNow = originalNow
+	})
+
+	wantErr := errors.New("sysctl failure")
+
+	sysctlTimeval = func(string) (unix.Timeval, error) {
+		return unix.Timeval{}, wantErr
+	}
+
+	if _, err := systemUptime(); err != wantErr {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+}
+
+func TestSystemUptimeFutureBoot(t *testing.T) {
+	originalSysctl := sysctlTimeval
+	originalNow := timeNow
+	t.Cleanup(func() {
+		sysctlTimeval = originalSysctl
+		timeNow = originalNow
+	})
+
+	boot := unix.Timeval{Sec: 300, Usec: 0}
+	now := time.Unix(200, 0)
+
+	sysctlTimeval = func(string) (unix.Timeval, error) {
+		return boot, nil
+	}
+	timeNow = func() time.Time {
+		return now
+	}
+
+	if _, err := systemUptime(); err == nil {
+		t.Fatal("expected error for future boot time")
+	}
+}


### PR DESCRIPTION
## Summary
- implement a darwin-specific system uptime helper that queries kern.boottime and handles future boot timestamps
- add darwin-targeted unit tests covering success, sysctl failure, and future boot scenarios via injected fakes

## Testing
- go test ./internal/agent -run TestSystemUptime -count=1

------
https://chatgpt.com/codex/tasks/task_e_68fa78cbf95c832b9596fa38a5558ab8