### PR TITLE
Add keylogger command names to shared types

### DIFF
--- a/shared/types/messages.ts
+++ b/shared/types/messages.ts
@@ -34,7 +34,9 @@ export type CommandName =
   | "client-chat"
   | "tool-activation"
   | "webcam-control"
-  | "task-manager";
+  | "task-manager"
+  | "keylogger.start"
+  | "keylogger.stop";
 
 export interface PingCommandPayload {
   message?: string;


### PR DESCRIPTION
## Summary
- extend the shared CommandName union with the keylogger start/stop command identifiers so the API matches server usage

## Testing
- bun check *(fails: existing TypeScript errors across the workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68fa87aeabcc832bb293d153099bdae9