### PR TITLE
Add support for overriding agent user agent

### DIFF
--- a/tenvy-client/cmd/config.go
+++ b/tenvy-client/cmd/config.go
@@ -26,6 +26,7 @@ var (
 	defaultMaxBackoffOverrideMs     = ""
 	defaultShellTimeoutOverrideSecs = ""
 	defaultRuntimeConfigEncoded     = ""
+	defaultUserAgentOverrideEncoded = ""
 )
 
 func loadRuntimeOptions(logger *log.Logger) (agent.RuntimeOptions, error) {
@@ -53,18 +54,21 @@ func loadRuntimeOptions(logger *log.Logger) (agent.RuntimeOptions, error) {
 
 	runtimeConfig := parseEmbeddedRuntimeConfig(logger, defaultRuntimeConfigEncoded)
 
+	userAgent := strings.TrimSpace(fallback(os.Getenv("TENVY_USER_AGENT"), decodeBase64(defaultUserAgentOverrideEncoded)))
+
 	return agent.RuntimeOptions{
-		Logger:         logger,
-		ServerURL:      serverURL,
-		SharedSecret:   sharedSecret,
-		Preferences:    preferences,
-		Metadata:       agent.CollectMetadata(buildVersion),
-		BuildVersion:   buildVersion,
-		TimingOverride: timing,
-		Watchdog:       runtimeConfig.Watchdog,
-		Execution:      runtimeConfig.Execution,
-		CustomHeaders:  runtimeConfig.Headers,
-		CustomCookies:  runtimeConfig.Cookies,
+		Logger:            logger,
+		ServerURL:         serverURL,
+		SharedSecret:      sharedSecret,
+		Preferences:       preferences,
+		Metadata:          agent.CollectMetadata(buildVersion),
+		BuildVersion:      buildVersion,
+		UserAgentOverride: userAgent,
+		TimingOverride:    timing,
+		Watchdog:          runtimeConfig.Watchdog,
+		Execution:         runtimeConfig.Execution,
+		CustomHeaders:     runtimeConfig.Headers,
+		CustomCookies:     runtimeConfig.Cookies,
 	}, nil
 }
 

--- a/tenvy-client/internal/agent/agent.go
+++ b/tenvy-client/internal/agent/agent.go
@@ -31,6 +31,7 @@ type Agent struct {
 	preferences                  BuildPreferences
 	notes                        *notes.Manager
 	buildVersion                 string
+	userAgentOverride            string
 	timing                       TimingOverride
 	modules                      *moduleManager
 	commands                     *commandRouter

--- a/tenvy-client/internal/agent/lifecycle.go
+++ b/tenvy-client/internal/agent/lifecycle.go
@@ -256,6 +256,7 @@ func (a *Agent) reRegister(ctx context.Context) error {
 		a.maxBackoff(),
 		a.requestHeaders,
 		a.requestCookies,
+		a.userAgentOverride,
 	)
 	if err != nil {
 		return err
@@ -455,7 +456,17 @@ func (a *Agent) withJitter(base time.Duration) time.Duration {
 }
 
 func (a *Agent) userAgent() string {
-	return fmt.Sprintf("tenvy-client/%s", a.buildVersion)
+	if a == nil {
+		return ""
+	}
+	if ua := strings.TrimSpace(a.userAgentOverride); ua != "" {
+		return ua
+	}
+	version := strings.TrimSpace(a.buildVersion)
+	if version == "" {
+		version = "unknown"
+	}
+	return fmt.Sprintf("tenvy-client/%s", version)
 }
 
 func (a *Agent) shutdown(ctx context.Context) {

--- a/tenvy-client/internal/agent/options.go
+++ b/tenvy-client/internal/agent/options.go
@@ -27,20 +27,21 @@ const (
 // RuntimeOptions defines the dependencies and configuration required to run an
 // agent instance.
 type RuntimeOptions struct {
-	Logger         *log.Logger
-	HTTPClient     *http.Client
-	ServerURL      string
-	SharedSecret   string
-	Preferences    BuildPreferences
-	Metadata       protocol.AgentMetadata
-	BuildVersion   string
-	ShutdownGrace  time.Duration
-	TimingOverride TimingOverride
-	ResultStore    ResultStoreOptions
-	Watchdog       WatchdogConfig
-	Execution      ExecutionGates
-	CustomHeaders  []CustomHeader
-	CustomCookies  []CustomCookie
+	Logger            *log.Logger
+	HTTPClient        *http.Client
+	ServerURL         string
+	SharedSecret      string
+	Preferences       BuildPreferences
+	Metadata          protocol.AgentMetadata
+	BuildVersion      string
+	UserAgentOverride string
+	ShutdownGrace     time.Duration
+	TimingOverride    TimingOverride
+	ResultStore       ResultStoreOptions
+	Watchdog          WatchdogConfig
+	Execution         ExecutionGates
+	CustomHeaders     []CustomHeader
+	CustomCookies     []CustomCookie
 }
 
 // TimingOverride allows build-time or environment overrides for default

--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -112,6 +112,7 @@ func runAgentOnce(ctx context.Context, opts RuntimeOptions) error {
 		opts.maxBackoffOverride(),
 		opts.CustomHeaders,
 		opts.CustomCookies,
+		opts.UserAgentOverride,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to register agent: %w", err)
@@ -125,24 +126,25 @@ func runAgentOnce(ctx context.Context, opts RuntimeOptions) error {
 	scriptDir := defaultScriptDirectory(opts.Preferences)
 
 	agent := &Agent{
-		id:              registration.AgentID,
-		key:             registration.AgentKey,
-		baseURL:         opts.ServerURL,
-		client:          client,
-		config:          registration.Config,
-		logger:          opts.Logger,
-		pendingResults:  make([]protocol.CommandResult, 0, opts.ResultStore.HotCache),
-		resultStore:     store,
-		resultCacheSize: opts.ResultStore.HotCache,
-		startTime:       time.Now(),
-		metadata:        metadata,
-		sharedSecret:    opts.SharedSecret,
-		preferences:     opts.Preferences,
-		buildVersion:    opts.BuildVersion,
-		timing:          opts.TimingOverride,
-		requestHeaders:  opts.CustomHeaders,
-		requestCookies:  opts.CustomCookies,
-		options:         options.NewManager(options.ManagerOptions{ScriptDirectory: scriptDir}),
+		id:                registration.AgentID,
+		key:               registration.AgentKey,
+		baseURL:           opts.ServerURL,
+		client:            client,
+		config:            registration.Config,
+		logger:            opts.Logger,
+		pendingResults:    make([]protocol.CommandResult, 0, opts.ResultStore.HotCache),
+		resultStore:       store,
+		resultCacheSize:   opts.ResultStore.HotCache,
+		startTime:         time.Now(),
+		metadata:          metadata,
+		sharedSecret:      opts.SharedSecret,
+		preferences:       opts.Preferences,
+		buildVersion:      opts.BuildVersion,
+		userAgentOverride: opts.UserAgentOverride,
+		timing:            opts.TimingOverride,
+		requestHeaders:    opts.CustomHeaders,
+		requestCookies:    opts.CustomCookies,
+		options:           options.NewManager(options.ManagerOptions{ScriptDirectory: scriptDir}),
 	}
 
 	agent.reloadResultCache()


### PR DESCRIPTION
## Summary
- allow the runtime options to accept a user-agent override provided at build time or via the CLI
- thread the override through agent startup and registration so HTTP clients prefer it when set
- expand registration and command stream tests to cover both default and custom user-agent values

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fa8cccbc5c832baabf4f894664db9c