### PR TITLE
Add persistence branding overrides for startup and storage

### DIFF
--- a/tenvy-client/internal/agent/preferences_darwin_test.go
+++ b/tenvy-client/internal/agent/preferences_darwin_test.go
@@ -20,16 +20,18 @@ func TestRegisterStartupPreferenceDarwin(t *testing.T) {
 		t.Fatalf("write target: %v", err)
 	}
 
-	if err := configureStartupPreference(target); err != nil {
+	pref := BuildPreferences{}
+	if err := configureStartupPreference(pref, target); err != nil {
 		t.Fatalf("configure startup: %v", err)
 	}
 
-	plistPath := filepath.Join(tmp, macLaunchAgentsDir, macPlistName)
+	branding := pref.persistenceBranding()
+	plistPath := filepath.Join(tmp, macLaunchAgentsDir, branding.LaunchAgentLabel+".plist")
 	if _, err := os.Stat(plistPath); err != nil {
 		t.Fatalf("stat plist: %v", err)
 	}
 
-	if err := unregisterStartup(); err != nil {
+	if err := unregisterStartup(branding); err != nil {
 		t.Fatalf("unregister startup: %v", err)
 	}
 

--- a/tenvy-client/internal/agent/preferences_windows_test.go
+++ b/tenvy-client/internal/agent/preferences_windows_test.go
@@ -14,7 +14,8 @@ func TestRegisterStartupPreferenceWindows(t *testing.T) {
 	t.Setenv("TENVY_WINDOWS_RUN_FILE", runFile)
 
 	target := `C:\\Program Files\\Tenvy\\tenvy.exe`
-	if err := registerStartup(target); err != nil {
+	pref := BuildPreferences{}
+	if err := registerStartup(target, pref.persistenceBranding()); err != nil {
 		t.Fatalf("register startup: %v", err)
 	}
 
@@ -26,7 +27,7 @@ func TestRegisterStartupPreferenceWindows(t *testing.T) {
 		t.Fatalf("unexpected run file contents: %q", string(data))
 	}
 
-	if err := unregisterStartup(); err != nil {
+	if err := unregisterStartup(pref.persistenceBranding()); err != nil {
 		t.Fatalf("unregister startup: %v", err)
 	}
 

--- a/tenvy-client/internal/agent/result_store.go
+++ b/tenvy-client/internal/agent/result_store.go
@@ -401,9 +401,6 @@ func defaultResultStorePath(pref BuildPreferences) string {
 		}
 		return filepath.Join(filepath.Dir(cleaned), "results")
 	}
-	if exe, err := os.Executable(); err == nil {
-		base := filepath.Dir(exe)
-		return filepath.Join(base, "results")
-	}
-	return filepath.Join(os.TempDir(), "tenvy", "results")
+	baseDir := dataDirectory(pref)
+	return filepath.Join(baseDir, "results")
 }

--- a/tenvy-client/internal/agent/result_store_test.go
+++ b/tenvy-client/internal/agent/result_store_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/rootbay/tenvy-client/internal/protocol"
@@ -40,6 +41,33 @@ func TestResultStorePersistsAcrossRestarts(t *testing.T) {
 		if results[i].CommandID != expected[i].CommandID {
 			t.Fatalf("result %d mismatch: got %q want %q", i, results[i].CommandID, expected[i].CommandID)
 		}
+	}
+}
+
+func TestDefaultResultStorePathUsesDataDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	pref := BuildPreferences{}
+	path := defaultResultStorePath(pref)
+	expected := filepath.Join(tmp, ".config", "tenvy", "results")
+	if path != expected {
+		t.Fatalf("expected result store path %s, got %s", expected, path)
+	}
+}
+
+func TestDefaultResultStorePathCustomBranding(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	pref := BuildPreferences{
+		Persistence: PersistenceBranding{BaseDataDir: filepath.Join(".data", "custom")},
+	}
+
+	path := defaultResultStorePath(pref)
+	expected := filepath.Join(tmp, ".data", "custom", "results")
+	if path != expected {
+		t.Fatalf("expected custom result store path %s, got %s", expected, path)
 	}
 }
 

--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -169,7 +169,7 @@ func runAgentOnce(ctx context.Context, opts RuntimeOptions) error {
 	}
 	agent.commands = router
 
-	if notesPath, err := notes.DefaultPath(); err != nil {
+	if notesPath, err := notes.DefaultPath(dataDirectory(opts.Preferences)); err != nil {
 		opts.Logger.Printf("notes disabled (path error): %v", err)
 	} else {
 		sharedMaterial := opts.SharedSecret

--- a/tenvy-client/internal/agent/startup_unsupported.go
+++ b/tenvy-client/internal/agent/startup_unsupported.go
@@ -7,10 +7,10 @@ import (
 	"runtime"
 )
 
-func registerStartup(target string) error {
+func registerStartup(target string, _ PersistenceBranding) error {
 	return fmt.Errorf("startup registration not supported on %s", runtime.GOOS)
 }
 
-func unregisterStartup() error {
+func unregisterStartup(PersistenceBranding) error {
 	return nil
 }

--- a/tenvy-client/internal/modules/notes/manager.go
+++ b/tenvy-client/internal/modules/notes/manager.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -527,16 +526,14 @@ func (m *Manager) SyncShared(ctx context.Context, client *http.Client, baseURL, 
 	return nil
 }
 
-func DefaultPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
+func DefaultPath(baseDir string) (string, error) {
+	trimmed := strings.TrimSpace(baseDir)
+	if trimmed == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		trimmed = filepath.Join(home, ".config", "tenvy")
 	}
-	var configDir string
-	if runtime.GOOS == "windows" {
-		configDir = filepath.Join(home, "AppData", "Roaming", "Tenvy")
-	} else {
-		configDir = filepath.Join(home, ".config", "tenvy")
-	}
-	return filepath.Join(configDir, "notes.json"), nil
+	return filepath.Join(trimmed, "notes.json"), nil
 }

--- a/tenvy-client/internal/modules/notes/manager_test.go
+++ b/tenvy-client/internal/modules/notes/manager_test.go
@@ -97,3 +97,33 @@ func TestManagerMigratesLegacyLocalNotes(t *testing.T) {
 		t.Fatalf("unexpected note content with stable key: %+v", final)
 	}
 }
+
+func TestDefaultPathUsesBaseDir(t *testing.T) {
+	tmp := t.TempDir()
+	baseDir := filepath.Join(tmp, "brand")
+
+	path, err := DefaultPath(baseDir)
+	if err != nil {
+		t.Fatalf("default path: %v", err)
+	}
+
+	expected := filepath.Join(baseDir, "notes.json")
+	if path != expected {
+		t.Fatalf("expected notes path %s, got %s", expected, path)
+	}
+}
+
+func TestDefaultPathTrimsInput(t *testing.T) {
+	tmp := t.TempDir()
+	baseDir := filepath.Join(tmp, "another")
+
+	path, err := DefaultPath("  " + baseDir + "  ")
+	if err != nil {
+		t.Fatalf("default path: %v", err)
+	}
+
+	expected := filepath.Join(baseDir, "notes.json")
+	if path != expected {
+		t.Fatalf("expected trimmed notes path %s, got %s", expected, path)
+	}
+}


### PR DESCRIPTION
## Summary
- add persistence branding configuration to build preferences and derive shared data directories from it
- update startup registration implementations to use configurable identifiers on every platform
- extend persistence tests to cover default branding and custom overrides

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fa905a5138832bb0400a2a644917ab