### PR TITLE
Refactor dynamic component rendering for runes mode

### DIFF
--- a/tenvy-server/src/lib/components/dashboard/client-presence-map.lazy.svelte
+++ b/tenvy-server/src/lib/components/dashboard/client-presence-map.lazy.svelte
@@ -18,11 +18,11 @@
 </script>
 
 {#if MapComponent}
-	<svelte:component
-		this={MapComponent}
-		clients={props.clients}
-		highlightCountry={props.highlightCountry}
-	/>
+        {@const ClientPresenceMap = MapComponent}
+        <ClientPresenceMap
+                clients={props.clients}
+                highlightCountry={props.highlightCountry}
+        />
 {:else}
 	<div
 		role="img"

--- a/tenvy-server/src/lib/components/plugins/MarketplaceGrid.svelte
+++ b/tenvy-server/src/lib/components/plugins/MarketplaceGrid.svelte
@@ -70,7 +70,8 @@
 		{:else}
 			<div class="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
 				{#each listings as listing (listing.id)}
-					{@const listingSignature = signatureBadge(listing.signature)}
+                                        {@const listingSignature = signatureBadge(listing.signature)}
+                                        {@const ListingSignatureIcon = listingSignature.icon}
 					<div
 						class="flex flex-col justify-between rounded-lg border border-border bg-card p-4 shadow-sm"
 					>
@@ -84,14 +85,14 @@
 								</div>
 								<div class="flex flex-col items-end gap-2">
 									<Badge class={statusStyles[listing.status]}>{listing.status}</Badge>
-									<Badge
+                                                                        <Badge
 										variant="outline"
 										class={cn(
 											'flex items-center gap-1 rounded-full border px-2 py-1 text-[10px] font-semibold tracking-wide uppercase',
 											listingSignature.class
 										)}
 									>
-										<svelte:component this={listingSignature.icon} class="h-3 w-3" />
+                                                                                <ListingSignatureIcon class="h-3 w-3" />
 										{listingSignature.label}
 									</Badge>
 								</div>
@@ -115,8 +116,8 @@
 									<ShieldCheck class="h-3.5 w-3.5" />
 									<span>{listing.manifest.license.spdxId}</span>
 								</div>
-								<div class="flex items-center gap-2">
-									<svelte:component this={listingSignature.icon} class="h-3.5 w-3.5" />
+                                                                <div class="flex items-center gap-2">
+                                                                        <ListingSignatureIcon class="h-3.5 w-3.5" />
 									<span>
 										{listing.signature.signer ??
 											listing.signature.publicKey ??

--- a/tenvy-server/src/lib/components/plugins/PluginCard.svelte
+++ b/tenvy-server/src/lib/components/plugins/PluginCard.svelte
@@ -44,14 +44,15 @@ const pluginSignatureBadge: SignatureBadge = $derived(signatureBadge(plugin.sign
 </script>
 
 <Card
-	class={cn(
-		'border-border/60 transition',
-		plugin.status === 'error' && 'border-red-500/40',
-		plugin.status === 'update' && 'border-amber-500/40',
-		!plugin.enabled && 'opacity-90'
-	)}
+        class={cn(
+                'border-border/60 transition',
+                plugin.status === 'error' && 'border-red-500/40',
+                plugin.status === 'update' && 'border-amber-500/40',
+                !plugin.enabled && 'opacity-90'
+        )}
 >
-	<CardHeader class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        {@const PluginSignatureIcon = pluginSignatureBadge.icon}
+        <CardHeader class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
 		<div class="space-y-2">
 			<div class="flex flex-wrap items-center gap-3">
 				<CardTitle class="text-base leading-tight font-semibold">{plugin.name}</CardTitle>
@@ -64,16 +65,16 @@ const pluginSignatureBadge: SignatureBadge = $derived(signatureBadge(plugin.sign
 				>
 					{pluginStatusLabels[plugin.status]}
 				</Badge>
-				<Badge
-					variant="outline"
-					class={cn(
-						'flex items-center gap-1 px-2.5 py-1 text-xs font-medium',
-						pluginSignatureBadge.class
-					)}
-				>
-					<svelte:component this={pluginSignatureBadge.icon} class="h-3.5 w-3.5" />
-					{pluginSignatureBadge.label}
-				</Badge>
+                                <Badge
+                                        variant="outline"
+                                        class={cn(
+                                                'flex items-center gap-1 px-2.5 py-1 text-xs font-medium',
+                                                pluginSignatureBadge.class
+                                        )}
+                                >
+                                        <PluginSignatureIcon class="h-3.5 w-3.5" />
+                                        {pluginSignatureBadge.label}
+                                </Badge>
 			</div>
 			<CardDescription class="max-w-2xl text-sm text-muted-foreground"
 				>{plugin.description}</CardDescription
@@ -116,10 +117,10 @@ const pluginSignatureBadge: SignatureBadge = $derived(signatureBadge(plugin.sign
 		<div class="grid gap-4 text-sm text-muted-foreground md:grid-cols-2 xl:grid-cols-3">
 			<div class="space-y-1 rounded-md border border-border/60 px-3 py-2">
 				<span class="text-xs tracking-wide uppercase">Signature</span>
-				<p class="flex items-center gap-2 text-sm font-semibold text-foreground">
-					<svelte:component this={pluginSignatureBadge.icon} class="h-4 w-4" />
-					{pluginSignatureBadge.label}
-				</p>
+                                <p class="flex items-center gap-2 text-sm font-semibold text-foreground">
+                                        <PluginSignatureIcon class="h-4 w-4" />
+                                        {pluginSignatureBadge.label}
+                                </p>
 				{#if plugin.signature.error}
 					<p class="text-xs text-muted-foreground">{plugin.signature.error}</p>
 				{:else if plugin.signature.signer}

--- a/tenvy-server/src/routes/(app)/build/+page.svelte
+++ b/tenvy-server/src/routes/(app)/build/+page.svelte
@@ -730,9 +730,9 @@
 						</TabsList>
 
 						<TabsContent value="connection" class="space-y-6">
-							{#if tabComponents.connection}
-								<svelte:component
-									this={tabComponents.connection}
+                                                        {#if tabComponents.connection}
+                                                                {@const ConnectionTabComponent = tabComponents.connection}
+                                                                <ConnectionTabComponent
 									bind:host
 									bind:port
 									bind:outputFilename
@@ -768,9 +768,9 @@
 							{/if}
 						</TabsContent>
 						<TabsContent value="persistence" class="space-y-6">
-							{#if tabComponents.persistence}
-								<svelte:component
-									this={tabComponents.persistence}
+                                                        {#if tabComponents.persistence}
+                                                                {@const PersistenceTabComponent = tabComponents.persistence}
+                                                                <PersistenceTabComponent
 									bind:installationPath
 									bind:mutexName
 									bind:meltAfterRun
@@ -795,9 +795,9 @@
 							{/if}
 						</TabsContent>
 						<TabsContent value="execution" class="space-y-6">
-							{#if tabComponents.execution}
-								<svelte:component
-									this={tabComponents.execution}
+                                                        {#if tabComponents.execution}
+                                                                {@const ExecutionTabComponent = tabComponents.execution}
+                                                                <ExecutionTabComponent
 									bind:executionDelaySeconds
 									bind:executionMinUptimeMinutes
 									bind:executionAllowedUsernames
@@ -815,9 +815,9 @@
 							{/if}
 						</TabsContent>
 						<TabsContent value="presentation" class="space-y-6">
-							{#if tabComponents.presentation}
-								<svelte:component
-									this={tabComponents.presentation}
+                                                        {#if tabComponents.presentation}
+                                                                {@const PresentationTabComponent = tabComponents.presentation}
+                                                                <PresentationTabComponent
 									{fileIconName}
 									{fileIconError}
 									{handleIconSelection}


### PR DESCRIPTION
## Summary
- replace dynamic <svelte:component> usages with runes-compatible component constants
- update plugin marketplace and card icons to use reusable component variables
- adjust lazy client presence map to render imported component via constant

## Testing
- bun check *(fails: existing repository type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68fa9e91e00c832b9bf3834db21ddd33