### PR TITLE
Refactor agent module interface to use Config and error results

### DIFF
--- a/tenvy-client/internal/agent/lifecycle.go
+++ b/tenvy-client/internal/agent/lifecycle.go
@@ -127,7 +127,7 @@ func (a *Agent) sync(ctx context.Context, status string) error {
 		a.plugins.UpdateVerification(deriveSignatureVerifyOptions(a.config, a.logger))
 	}
 	if a.modules != nil {
-		if err := a.modules.UpdateConfig(ctx, a.moduleRuntime()); err != nil {
+		if err := a.modules.UpdateConfig(a.moduleRuntime()); err != nil {
 			a.logger.Printf("module configuration update failed: %v", err)
 		}
 	}
@@ -270,7 +270,7 @@ func (a *Agent) reRegister(ctx context.Context) error {
 	a.startTime = time.Now()
 
 	if a.modules != nil {
-		if err := a.modules.UpdateConfig(ctx, a.moduleRuntime()); err != nil {
+		if err := a.modules.UpdateConfig(a.moduleRuntime()); err != nil {
 			return fmt.Errorf("update modules: %w", err)
 		}
 	}
@@ -470,7 +470,9 @@ func (a *Agent) userAgent() string {
 func (a *Agent) shutdown(ctx context.Context) {
 	a.stopRemoteDesktopInputWorker()
 	if a.modules != nil {
-		a.modules.Shutdown(ctx)
+		if err := a.modules.Shutdown(ctx); err != nil {
+			a.logger.Printf("module shutdown failed: %v", err)
+		}
 	}
 	if err := a.sync(ctx, statusOffline); err != nil {
 		a.logger.Printf("failed to send offline heartbeat: %v", err)


### PR DESCRIPTION
## Summary
- replace the module runtime wiring with a reusable Config and expose the documented Module interface that now returns errors
- update all built-in agent modules and lifecycle plumbing to satisfy the new contract and wrap protocol.CommandResult values where needed
- adjust module tests and integration coverage to unwrap error-based results under the new API

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fbd0e93d48832b9b9aaca761d7c4c7