### PR TITLE
Implement loader bootstrap stub

### DIFF
--- a/tenvy-client/cmd/main.go
+++ b/tenvy-client/cmd/main.go
@@ -1,4 +1,174 @@
 package main
 
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/rootbay/tenvy-client/internal/bootstrap"
+)
+
+var buildVersion = "dev"
+
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	logger := log.New(os.Stdout, "[tenvy-bootstrap] ", log.LstdFlags|log.Lmsgprefix)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	stubPath, err := os.Executable()
+	if err != nil {
+		logger.Printf("resolve executable: %v", err)
+		return 1
+	}
+
+	stubPath, err = filepath.Abs(stubPath)
+	if err != nil {
+		logger.Printf("resolve executable path: %v", err)
+		return 1
+	}
+
+	override := strings.TrimSpace(firstNonEmpty(
+		os.Getenv("TENVY_LOADER_PATH"),
+		os.Getenv("TENVY_LOADER_EXECUTABLE"),
+	))
+
+	searchDirs := parseSearchDirs(os.Getenv("TENVY_LOADER_SEARCH_PATHS"))
+
+	opts := bootstrap.Options{
+		ExecutablePath: stubPath,
+		OverridePath:   override,
+		LoaderArgs:     os.Args[1:],
+		AdditionalEnv: map[string]string{
+			"TENVY_PARENT_PID":      strconv.Itoa(os.Getpid()),
+			"TENVY_STUB_EXECUTABLE": stubPath,
+			"TENVY_STUB_DIRECTORY":  filepath.Dir(stubPath),
+			"TENVY_STUB_VERSION":    buildVersion,
+		},
+		SearchDirs: searchDirs,
+	}
+
+	cmd, err := bootstrap.Command(ctx, opts)
+	if err != nil {
+		logger.Printf("bootstrap error: %v", err)
+		return 1
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		logger.Printf("capture loader stdout: %v", err)
+		return 1
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		logger.Printf("capture loader stderr: %v", err)
+		return 1
+	}
+
+	logger.Printf("starting loader: %s", cmd.Path)
+	if err := cmd.Start(); err != nil {
+		logger.Printf("failed to start loader: %v", err)
+		return 1
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go streamPipe(&wg, stdout, logger, "stdout")
+	go streamPipe(&wg, stderr, logger, "stderr")
+
+	exitCode := 0
+	if err := cmd.Wait(); err != nil {
+		switch {
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			logger.Printf("loader cancelled: %v", err)
+			exitCode = 1
+		default:
+			var exitErr *os.SyscallError
+			if errors.As(err, &exitErr) {
+				logger.Printf("loader syscall error: %v", exitErr)
+				exitCode = 1
+			} else if exitStatus := exitCodeFromError(err); exitStatus >= 0 {
+				exitCode = exitStatus
+				if exitCode != 0 {
+					logger.Printf("loader exited with code %d", exitCode)
+				}
+			} else {
+				logger.Printf("loader execution error: %v", err)
+				exitCode = 1
+			}
+		}
+	} else if cmd.ProcessState != nil {
+		exitCode = cmd.ProcessState.ExitCode()
+	}
+
+	wg.Wait()
+
+	if exitCode == 0 {
+		logger.Printf("loader exited successfully")
+	}
+
+	return exitCode
+}
+
+func streamPipe(wg *sync.WaitGroup, reader io.Reader, logger *log.Logger, name string) {
+	defer wg.Done()
+
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		logger.Printf("%s: %s", name, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		logger.Printf("%s stream error: %v", name, err)
+	}
+}
+
+func parseSearchDirs(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := filepath.SplitList(raw)
+	dirs := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			dirs = append(dirs, trimmed)
+		}
+	}
+	return dirs
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func exitCodeFromError(err error) int {
+	type exitCoder interface {
+		ExitCode() int
+	}
+	var coder exitCoder
+	if errors.As(err, &coder) {
+		return coder.ExitCode()
+	}
+	return -1
 }

--- a/tenvy-client/internal/bootstrap/bootstrap.go
+++ b/tenvy-client/internal/bootstrap/bootstrap.go
@@ -1,0 +1,210 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// FileSystem abstracts stat calls so loader discovery can be tested without touching the real disk.
+type FileSystem interface {
+	Stat(name string) (fs.FileInfo, error)
+}
+
+type realFileSystem struct{}
+
+func (realFileSystem) Stat(name string) (fs.FileInfo, error) {
+	return os.Stat(name)
+}
+
+// Options control how the loader command is constructed.
+type Options struct {
+	// ExecutablePath is the absolute path to the stub executable. It is required.
+	ExecutablePath string
+	// OverridePath explicitly points to the loader executable, bypassing discovery when provided.
+	OverridePath string
+	// LoaderArgs are forwarded to the loader invocation.
+	LoaderArgs []string
+	// BaseEnv is the environment inherited by the loader. Defaults to os.Environ when nil.
+	BaseEnv []string
+	// AdditionalEnv defines extra environment variables to inject for the loader.
+	AdditionalEnv map[string]string
+	// SearchDirs are additional directories (absolute or relative to ExecutablePath) inspected for the loader.
+	SearchDirs []string
+	// CandidateNames are filenames considered when looking for the loader.
+	CandidateNames []string
+	// FileSystem powers file discovery. Defaults to the real OS filesystem when nil.
+	FileSystem FileSystem
+}
+
+// Command builds an exec.Cmd ready to launch the loader process based on the provided options.
+func Command(ctx context.Context, opts Options) (*exec.Cmd, error) {
+	if strings.TrimSpace(opts.ExecutablePath) == "" {
+		return nil, errors.New("executable path is required")
+	}
+
+	fsys := opts.FileSystem
+	if fsys == nil {
+		fsys = realFileSystem{}
+	}
+
+	loaderPath, err := discoverLoader(opts, fsys)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, loaderPath, opts.LoaderArgs...)
+	cmd.Env = buildEnvironment(opts, loaderPath)
+	cmd.Dir = filepath.Dir(loaderPath)
+	cmd.Stdin = os.Stdin
+	return cmd, nil
+}
+
+func discoverLoader(opts Options, fsys FileSystem) (string, error) {
+	override := strings.TrimSpace(opts.OverridePath)
+	if override != "" {
+		path := normalizePath(opts.ExecutablePath, override)
+		if err := ensureFile(path, fsys); err != nil {
+			return "", fmt.Errorf("loader override %q invalid: %w", override, err)
+		}
+		return path, nil
+	}
+
+	stubDir := filepath.Dir(opts.ExecutablePath)
+	searchDirs := buildSearchDirs(stubDir, opts.SearchDirs)
+	candidateNames := opts.CandidateNames
+	if len(candidateNames) == 0 {
+		candidateNames = defaultCandidateNames()
+	}
+
+	visited := make(map[string]struct{})
+	for _, dir := range searchDirs {
+		for _, name := range candidateNames {
+			candidate := name
+			if !filepath.IsAbs(candidate) {
+				candidate = filepath.Join(dir, candidate)
+			}
+			cleaned := filepath.Clean(candidate)
+			if _, seen := visited[cleaned]; seen {
+				continue
+			}
+			visited[cleaned] = struct{}{}
+
+			if err := ensureFile(cleaned, fsys); err == nil {
+				return cleaned, nil
+			}
+		}
+	}
+
+	return "", errors.New("loader executable not found")
+}
+
+func buildEnvironment(opts Options, loaderPath string) []string {
+	base := opts.BaseEnv
+	if base == nil {
+		base = os.Environ()
+	}
+
+	merged := make(map[string]string, len(base)+len(opts.AdditionalEnv)+1)
+	for _, entry := range base {
+		if entry == "" {
+			continue
+		}
+		key, value, found := strings.Cut(entry, "=")
+		if !found {
+			merged[key] = ""
+			continue
+		}
+		merged[key] = value
+	}
+
+	for key, value := range opts.AdditionalEnv {
+		merged[key] = value
+	}
+
+	merged["TENVY_LOADER_EXECUTABLE"] = loaderPath
+
+	keys := make([]string, 0, len(merged))
+	for key := range merged {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	env := make([]string, 0, len(keys))
+	for _, key := range keys {
+		env = append(env, key+"="+merged[key])
+	}
+	return env
+}
+
+func ensureFile(path string, fsys FileSystem) error {
+	if path == "" {
+		return errors.New("empty path")
+	}
+	info, err := fsys.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s is a directory", path)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", path)
+	}
+	return nil
+}
+
+func buildSearchDirs(stubDir string, extra []string) []string {
+	dirs := make([]string, 0, len(extra)+3)
+	seen := make(map[string]struct{})
+	add := func(path string) {
+		cleaned := filepath.Clean(path)
+		if _, exists := seen[cleaned]; exists {
+			return
+		}
+		seen[cleaned] = struct{}{}
+		dirs = append(dirs, cleaned)
+	}
+
+	if stubDir != "" {
+		add(stubDir)
+		add(filepath.Join(stubDir, "loader"))
+		add(filepath.Join(stubDir, "bin"))
+	}
+
+	for _, dir := range extra {
+		if strings.TrimSpace(dir) == "" {
+			continue
+		}
+		candidate := dir
+		if !filepath.IsAbs(candidate) {
+			candidate = filepath.Join(stubDir, candidate)
+		}
+		add(candidate)
+	}
+
+	return dirs
+}
+
+func defaultCandidateNames() []string {
+	return []string{
+		"tenvy-client-loader",
+		"tenvy-client-loader.exe",
+		"loader",
+		"loader.exe",
+	}
+}
+
+func normalizePath(stubExecutable, path string) string {
+	cleaned := filepath.Clean(path)
+	if filepath.IsAbs(cleaned) {
+		return cleaned
+	}
+	return filepath.Join(filepath.Dir(stubExecutable), cleaned)
+}

--- a/tenvy-client/internal/bootstrap/bootstrap_test.go
+++ b/tenvy-client/internal/bootstrap/bootstrap_test.go
@@ -1,0 +1,232 @@
+package bootstrap
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCommandUsesOverride(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	stubPath := filepath.Join(tempDir, "stub")
+	loaderPath := filepath.Join(tempDir, "loader.exe")
+
+	if err := os.WriteFile(stubPath, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write stub file: %v", err)
+	}
+	if err := os.WriteFile(loaderPath, []byte("loader"), 0o644); err != nil {
+		t.Fatalf("failed to write loader file: %v", err)
+	}
+
+	ctx := context.Background()
+	cmd, err := Command(ctx, Options{
+		ExecutablePath: stubPath,
+		OverridePath:   loaderPath,
+		LoaderArgs:     []string{"--hello", "world"},
+		BaseEnv:        []string{"FOO=BAR"},
+		AdditionalEnv:  map[string]string{"EXTRA": "1"},
+	})
+	if err != nil {
+		t.Fatalf("Command returned error: %v", err)
+	}
+
+	if cmd.Path != loaderPath {
+		t.Fatalf("expected loader path %q, got %q", loaderPath, cmd.Path)
+	}
+
+	expectedArgs := append([]string{loaderPath}, "--hello", "world")
+	if !slicesEqual(cmd.Args, expectedArgs) {
+		t.Fatalf("unexpected args: got %v, want %v", cmd.Args, expectedArgs)
+	}
+
+	env := envMap(cmd.Env)
+	if env["FOO"] != "BAR" {
+		t.Fatalf("expected FOO=BAR in environment, got %q", env["FOO"])
+	}
+	if env["EXTRA"] != "1" {
+		t.Fatalf("expected EXTRA=1 in environment, got %q", env["EXTRA"])
+	}
+	if env["TENVY_LOADER_EXECUTABLE"] != loaderPath {
+		t.Fatalf("expected TENVY_LOADER_EXECUTABLE=%q, got %q", loaderPath, env["TENVY_LOADER_EXECUTABLE"])
+	}
+}
+
+func TestCommandDiscoversLoaderRelativeToStub(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	stubPath := filepath.Join(tempDir, "stub")
+	loaderDir := filepath.Join(tempDir, "loader")
+	loaderPath := filepath.Join(loaderDir, "tenvy-client-loader")
+
+	if err := os.WriteFile(stubPath, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write stub file: %v", err)
+	}
+	if err := os.MkdirAll(loaderDir, 0o755); err != nil {
+		t.Fatalf("failed to create loader dir: %v", err)
+	}
+	if err := os.WriteFile(loaderPath, []byte("loader"), 0o644); err != nil {
+		t.Fatalf("failed to write loader file: %v", err)
+	}
+
+	cmd, err := Command(context.Background(), Options{
+		ExecutablePath: stubPath,
+	})
+	if err != nil {
+		t.Fatalf("Command returned error: %v", err)
+	}
+
+	if cmd.Path != loaderPath {
+		t.Fatalf("expected loader path %q, got %q", loaderPath, cmd.Path)
+	}
+
+	if cmd.Dir != loaderDir {
+		t.Fatalf("expected command dir %q, got %q", loaderDir, cmd.Dir)
+	}
+}
+
+func TestCommandAcceptsRelativeOverride(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	stubPath := filepath.Join(tempDir, "stub")
+	loaderPath := filepath.Join(tempDir, "bin", "loader.exe")
+
+	if err := os.WriteFile(stubPath, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write stub file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(loaderPath), 0o755); err != nil {
+		t.Fatalf("failed to create loader dir: %v", err)
+	}
+	if err := os.WriteFile(loaderPath, []byte("loader"), 0o644); err != nil {
+		t.Fatalf("failed to write loader file: %v", err)
+	}
+
+	cmd, err := Command(context.Background(), Options{
+		ExecutablePath: stubPath,
+		OverridePath:   filepath.Join("bin", "loader.exe"),
+	})
+	if err != nil {
+		t.Fatalf("Command returned error: %v", err)
+	}
+
+	if cmd.Path != loaderPath {
+		t.Fatalf("expected loader path %q, got %q", loaderPath, cmd.Path)
+	}
+}
+
+func TestCommandMissingLoader(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	stubPath := filepath.Join(tempDir, "stub")
+	if err := os.WriteFile(stubPath, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write stub file: %v", err)
+	}
+
+	if _, err := Command(context.Background(), Options{ExecutablePath: stubPath}); err == nil {
+		t.Fatalf("expected error when loader missing")
+	}
+}
+
+func TestBuildSearchDirsIncludesAdditionalPaths(t *testing.T) {
+	t.Parallel()
+
+	stubDir := filepath.Join("/tmp", "stub")
+	dirs := buildSearchDirs(stubDir, []string{"bin", "/opt/tenvy"})
+
+	expected := []string{
+		filepath.Clean(stubDir),
+		filepath.Join(filepath.Clean(stubDir), "loader"),
+		filepath.Join(filepath.Clean(stubDir), "bin"),
+		filepath.Clean("/opt/tenvy"),
+	}
+	if !slicesEqual(dirs, expected) {
+		t.Fatalf("unexpected dirs: got %v, want %v", dirs, expected)
+	}
+}
+
+func TestEnvironmentDefaultBase(t *testing.T) {
+	stubPath := mustWriteTempFile(t)
+	loaderPath := mustWriteTempFile(t)
+
+	t.Setenv("TEST_ENV_KEY", "VALUE")
+	cmd, err := Command(context.Background(), Options{
+		ExecutablePath: stubPath,
+		OverridePath:   loaderPath,
+		AdditionalEnv:  map[string]string{"CUSTOM": "yes"},
+	})
+	if err != nil {
+		t.Fatalf("Command returned error: %v", err)
+	}
+
+	env := envMap(cmd.Env)
+	if env["CUSTOM"] != "yes" {
+		t.Fatalf("expected CUSTOM env override, got %q", env["CUSTOM"])
+	}
+	if env["TEST_ENV_KEY"] != "VALUE" {
+		t.Fatalf("expected TEST_ENV_KEY inherited, got %q", env["TEST_ENV_KEY"])
+	}
+}
+
+func mustWriteTempFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	return path
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func envMap(env []string) map[string]string {
+	result := make(map[string]string, len(env))
+	for _, entry := range env {
+		if entry == "" {
+			continue
+		}
+		key, value, found := strings.Cut(entry, "=")
+		if !found {
+			result[entry] = ""
+			continue
+		}
+		result[key] = value
+	}
+	return result
+}
+
+func TestEnsureFileRejectsDirectories(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	if err := ensureFile(tempDir, realFileSystem{}); err == nil {
+		t.Fatalf("expected directory to be rejected")
+	}
+}
+
+func TestNormalizePath(t *testing.T) {
+	t.Parallel()
+
+	stubPath := filepath.Join("/opt", "tenvy", "stub")
+	rel := filepath.Join("..", "bin", "loader")
+	normalized := normalizePath(stubPath, rel)
+	expected := filepath.Join("/opt", "tenvy", "..", "bin", "loader")
+	if normalized != filepath.Clean(expected) {
+		t.Fatalf("unexpected normalized path: got %q, want %q", normalized, filepath.Clean(expected))
+	}
+}


### PR DESCRIPTION
## Summary
- replace the top-level client stub with a bootstrapper that locates the loader, forwards its IO, and exits with the loader status
- add an internal bootstrap package that handles loader discovery, environment preparation, and argument wiring with automated tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fbdda403a0832bb400909c2d1e7343