### PR TITLE
Ensure bootstrap manages loader integrity updates

### DIFF
--- a/tenvy-client/internal/bootstrap/bootstrap.go
+++ b/tenvy-client/internal/bootstrap/bootstrap.go
@@ -1,15 +1,22 @@
 package bootstrap
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 // FileSystem abstracts stat calls so loader discovery can be tested without touching the real disk.
@@ -21,6 +28,48 @@ type realFileSystem struct{}
 
 func (realFileSystem) Stat(name string) (fs.FileInfo, error) {
 	return os.Stat(name)
+}
+
+// LoaderMetadata describes versioning and integrity information for the loader binary.
+type LoaderMetadata struct {
+	Version    string `json:"version"`
+	Checksum   string `json:"checksum"`
+	Signature  string `json:"signature,omitempty"`
+	Executable string `json:"executable"`
+}
+
+// LoaderPackage represents the payload returned by a loader downloader.
+// Exactly one of Archive or Binary must be populated.
+type LoaderPackage struct {
+	Archive []byte
+	Binary  []byte
+	Mode    fs.FileMode
+}
+
+// LoaderDownloader fetches loader artifacts when the local copy is missing or outdated.
+type LoaderDownloader interface {
+	Download(ctx context.Context, metadata LoaderMetadata) (LoaderPackage, error)
+}
+
+// LoaderDownloaderFunc adapts a function to the LoaderDownloader interface.
+type LoaderDownloaderFunc func(ctx context.Context, metadata LoaderMetadata) (LoaderPackage, error)
+
+// Download implements LoaderDownloader.
+func (f LoaderDownloaderFunc) Download(ctx context.Context, metadata LoaderMetadata) (LoaderPackage, error) {
+	return f(ctx, metadata)
+}
+
+// LoaderSignatureVerifier validates signatures for a loader binary.
+type LoaderSignatureVerifier interface {
+	Verify(ctx context.Context, loaderPath string, metadata LoaderMetadata) error
+}
+
+// LoaderSignatureVerifierFunc adapts a function to LoaderSignatureVerifier.
+type LoaderSignatureVerifierFunc func(ctx context.Context, loaderPath string, metadata LoaderMetadata) error
+
+// Verify implements LoaderSignatureVerifier.
+func (f LoaderSignatureVerifierFunc) Verify(ctx context.Context, loaderPath string, metadata LoaderMetadata) error {
+	return f(ctx, loaderPath, metadata)
 }
 
 // Options control how the loader command is constructed.
@@ -41,6 +90,15 @@ type Options struct {
 	CandidateNames []string
 	// FileSystem powers file discovery. Defaults to the real OS filesystem when nil.
 	FileSystem FileSystem
+	// DesiredLoader describes the loader release that must be present.
+	DesiredLoader *LoaderMetadata
+	// LoaderDownloader fetches loader updates when the current loader is missing or outdated.
+	LoaderDownloader LoaderDownloader
+	// LoaderSignatureVerifier validates loader signatures when provided.
+	LoaderSignatureVerifier LoaderSignatureVerifier
+	// LoaderInstallDir overrides the directory where loader artifacts are stored. It may be relative to the
+	// stub executable directory.
+	LoaderInstallDir string
 }
 
 // Command builds an exec.Cmd ready to launch the loader process based on the provided options.
@@ -52,6 +110,10 @@ func Command(ctx context.Context, opts Options) (*exec.Cmd, error) {
 	fsys := opts.FileSystem
 	if fsys == nil {
 		fsys = realFileSystem{}
+	}
+
+	if err := ensureLoaderReady(ctx, opts); err != nil {
+		return nil, err
 	}
 
 	loaderPath, err := discoverLoader(opts, fsys)
@@ -207,4 +269,392 @@ func normalizePath(stubExecutable, path string) string {
 		return cleaned
 	}
 	return filepath.Join(filepath.Dir(stubExecutable), cleaned)
+}
+
+const (
+	defaultLoaderDirectory  = "loader"
+	loaderMetadataFileName  = "loader-metadata.json"
+	metadataTempFilePattern = "loader-metadata-*.tmp"
+)
+
+var (
+	errChecksumMismatch = errors.New("loader checksum mismatch")
+	errInvalidMetadata  = errors.New("invalid loader metadata")
+)
+
+func ensureLoaderReady(ctx context.Context, opts Options) error {
+	if strings.TrimSpace(opts.OverridePath) != "" {
+		// External overrides bypass loader management.
+		return nil
+	}
+
+	if opts.DesiredLoader == nil {
+		return nil
+	}
+
+	target, err := normalizeLoaderMetadata(*opts.DesiredLoader)
+	if err != nil {
+		return err
+	}
+
+	installDir := resolveInstallDir(opts.ExecutablePath, strings.TrimSpace(opts.LoaderInstallDir))
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		return fmt.Errorf("prepare loader directory: %w", err)
+	}
+
+	metadataPath := filepath.Join(installDir, loaderMetadataFileName)
+	loaderPath := filepath.Join(installDir, target.Executable)
+
+	stored, err := readStoredLoaderMetadata(metadataPath)
+	if err == nil {
+		if loaderMetadataMatches(stored.LoaderMetadata, target) {
+			if err := verifyLoaderChecksum(loaderPath, target.Checksum); err == nil {
+				if err := verifyLoaderSignature(ctx, opts.LoaderSignatureVerifier, loaderPath, stored.LoaderMetadata); err != nil {
+					return err
+				}
+				return nil
+			} else if err != nil {
+				if errors.Is(err, errChecksumMismatch) || errors.Is(err, os.ErrNotExist) {
+					// Reinstall below.
+				} else {
+					return fmt.Errorf("verify loader checksum: %w", err)
+				}
+			}
+		}
+	} else if !errors.Is(err, os.ErrNotExist) && !errors.Is(err, errInvalidMetadata) {
+		return err
+	}
+
+	if opts.LoaderDownloader == nil {
+		return errors.New("loader unavailable and no downloader configured")
+	}
+
+	pkg, err := opts.LoaderDownloader.Download(ctx, target)
+	if err != nil {
+		return fmt.Errorf("download loader: %w", err)
+	}
+	if err := installLoaderPackage(pkg, installDir, target.Executable); err != nil {
+		return err
+	}
+	if err := verifyLoaderChecksum(loaderPath, target.Checksum); err != nil {
+		return fmt.Errorf("validate loader checksum: %w", err)
+	}
+	if err := verifyLoaderSignature(ctx, opts.LoaderSignatureVerifier, loaderPath, target); err != nil {
+		return err
+	}
+
+	record := storedLoaderMetadata{
+		LoaderMetadata: target,
+		InstalledAt:    time.Now().UTC(),
+	}
+	if err := writeStoredLoaderMetadata(metadataPath, record); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resolveInstallDir(stubPath, override string) string {
+	stubDir := filepath.Dir(stubPath)
+	if strings.TrimSpace(override) == "" {
+		return filepath.Join(stubDir, defaultLoaderDirectory)
+	}
+	cleaned := filepath.Clean(override)
+	if filepath.IsAbs(cleaned) {
+		return cleaned
+	}
+	return filepath.Join(stubDir, cleaned)
+}
+
+func normalizeLoaderMetadata(meta LoaderMetadata) (LoaderMetadata, error) {
+	trimmedVersion := strings.TrimSpace(meta.Version)
+	if trimmedVersion == "" {
+		return LoaderMetadata{}, errors.New("loader version is required")
+	}
+	cleanedExec, err := cleanRelativePath(meta.Executable)
+	if err != nil {
+		return LoaderMetadata{}, err
+	}
+	checksum := strings.ToLower(strings.TrimSpace(meta.Checksum))
+	if checksum == "" {
+		return LoaderMetadata{}, errors.New("loader checksum is required")
+	}
+	normalized := LoaderMetadata{
+		Version:    trimmedVersion,
+		Checksum:   checksum,
+		Signature:  strings.TrimSpace(meta.Signature),
+		Executable: cleanedExec,
+	}
+	return normalized, nil
+}
+
+func cleanRelativePath(path string) (string, error) {
+	cleaned := filepath.Clean(strings.TrimSpace(path))
+	if cleaned == "" || cleaned == "." {
+		return "", errors.New("loader executable is required")
+	}
+	if filepath.IsAbs(cleaned) {
+		return "", errors.New("loader executable must be relative")
+	}
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(os.PathSeparator)) {
+		return "", errors.New("loader executable escapes install directory")
+	}
+	return cleaned, nil
+}
+
+type storedLoaderMetadata struct {
+	LoaderMetadata
+	InstalledAt time.Time `json:"installedAt"`
+}
+
+func readStoredLoaderMetadata(path string) (storedLoaderMetadata, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return storedLoaderMetadata{}, err
+	}
+	var record storedLoaderMetadata
+	if err := json.Unmarshal(data, &record); err != nil {
+		return storedLoaderMetadata{}, fmt.Errorf("%w: decode loader metadata: %v", errInvalidMetadata, err)
+	}
+	normalized, err := normalizeLoaderMetadata(record.LoaderMetadata)
+	if err != nil {
+		return storedLoaderMetadata{}, fmt.Errorf("%w: %v", errInvalidMetadata, err)
+	}
+	record.LoaderMetadata = normalized
+	return record, nil
+}
+
+func writeStoredLoaderMetadata(path string, metadata storedLoaderMetadata) error {
+	payload := struct {
+		LoaderMetadata
+		InstalledAt time.Time `json:"installedAt"`
+	}{LoaderMetadata: metadata.LoaderMetadata, InstalledAt: metadata.InstalledAt}
+
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode loader metadata: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("prepare metadata directory: %w", err)
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), metadataTempFilePattern)
+	if err != nil {
+		return fmt.Errorf("create metadata temp file: %w", err)
+	}
+	tempPath := temp.Name()
+	if _, err := temp.Write(data); err != nil {
+		temp.Close()
+		os.Remove(tempPath)
+		return fmt.Errorf("write metadata temp file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("finalize metadata temp file: %w", err)
+	}
+	if err := os.Chmod(tempPath, 0o644); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("set metadata permissions: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("persist metadata file: %w", err)
+	}
+	return nil
+}
+
+func loaderMetadataMatches(current, target LoaderMetadata) bool {
+	return strings.EqualFold(current.Checksum, target.Checksum) &&
+		current.Version == target.Version &&
+		current.Signature == target.Signature &&
+		current.Executable == target.Executable
+}
+
+func verifyLoaderChecksum(path, expected string) error {
+	if strings.TrimSpace(expected) == "" {
+		return errors.New("expected loader checksum missing")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open loader: %w", err)
+	}
+	defer file.Close()
+
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return fmt.Errorf("compute loader checksum: %w", err)
+	}
+	actual := hex.EncodeToString(hasher.Sum(nil))
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("%w: expected %s, got %s", errChecksumMismatch, expected, actual)
+	}
+	return nil
+}
+
+func verifyLoaderSignature(ctx context.Context, verifier LoaderSignatureVerifier, loaderPath string, metadata LoaderMetadata) error {
+	if strings.TrimSpace(metadata.Signature) == "" {
+		if verifier == nil {
+			return nil
+		}
+		return verifier.Verify(ctx, loaderPath, metadata)
+	}
+	if verifier == nil {
+		return errors.New("loader signature provided but verifier unavailable")
+	}
+	if err := verifier.Verify(ctx, loaderPath, metadata); err != nil {
+		return fmt.Errorf("verify loader signature: %w", err)
+	}
+	return nil
+}
+
+func installLoaderPackage(pkg LoaderPackage, installDir, execRel string) error {
+	if len(pkg.Archive) > 0 && len(pkg.Binary) > 0 {
+		return errors.New("loader package ambiguous")
+	}
+	if len(pkg.Archive) == 0 && len(pkg.Binary) == 0 {
+		return errors.New("loader package missing payload")
+	}
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		return fmt.Errorf("prepare loader directory: %w", err)
+	}
+	if len(pkg.Archive) > 0 {
+		if err := installLoaderFromArchive(pkg.Archive, installDir); err != nil {
+			return err
+		}
+	} else {
+		if err := installLoaderBinary(pkg.Binary, installDir, execRel, pkg.Mode); err != nil {
+			return err
+		}
+	}
+
+	loaderPath := filepath.Join(installDir, execRel)
+	if err := ensureLoaderExecutable(loaderPath); err != nil {
+		return err
+	}
+	if _, err := os.Stat(loaderPath); err != nil {
+		return fmt.Errorf("loader executable missing after install: %w", err)
+	}
+	return nil
+}
+
+func installLoaderFromArchive(payload []byte, dest string) error {
+	reader := bytes.NewReader(payload)
+	archive, err := zip.NewReader(reader, int64(len(payload)))
+	if err != nil {
+		return fmt.Errorf("open loader archive: %w", err)
+	}
+	for _, entry := range archive.File {
+		if err := extractLoaderArchiveEntry(entry, dest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func extractLoaderArchiveEntry(entry *zip.File, dest string) error {
+	cleaned := filepath.Clean(entry.Name)
+	if cleaned == "" || cleaned == "." {
+		return nil
+	}
+	target := filepath.Join(dest, cleaned)
+	if !strings.HasPrefix(target, dest+string(os.PathSeparator)) && target != dest {
+		return fmt.Errorf("loader archive entry escapes destination: %s", entry.Name)
+	}
+	if entry.FileInfo().Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("loader archive entry is a symlink: %s", entry.Name)
+	}
+
+	if entry.FileInfo().IsDir() {
+		if err := os.MkdirAll(target, 0o755); err != nil {
+			return fmt.Errorf("create loader directory: %w", err)
+		}
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("prepare loader path: %w", err)
+	}
+
+	reader, err := entry.Open()
+	if err != nil {
+		return fmt.Errorf("open loader archive entry: %w", err)
+	}
+	defer reader.Close()
+
+	temp, err := os.CreateTemp(filepath.Dir(target), "loader-entry-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create loader temp file: %w", err)
+	}
+	tempPath := temp.Name()
+	if _, err := io.Copy(temp, reader); err != nil {
+		temp.Close()
+		os.Remove(tempPath)
+		return fmt.Errorf("write loader archive entry: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("finalize loader archive entry: %w", err)
+	}
+	if err := os.Rename(tempPath, target); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("persist loader archive entry: %w", err)
+	}
+	if mode := entry.Mode(); mode != 0 {
+		if err := os.Chmod(target, mode); err != nil {
+			return fmt.Errorf("set loader entry permissions: %w", err)
+		}
+	}
+	return nil
+}
+
+func installLoaderBinary(payload []byte, installDir, execRel string, mode fs.FileMode) error {
+	if len(payload) == 0 {
+		return errors.New("loader binary payload empty")
+	}
+	dest := filepath.Join(installDir, execRel)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return fmt.Errorf("prepare loader path: %w", err)
+	}
+	temp, err := os.CreateTemp(filepath.Dir(dest), "loader-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create loader temp file: %w", err)
+	}
+	tempPath := temp.Name()
+	if _, err := temp.Write(payload); err != nil {
+		temp.Close()
+		os.Remove(tempPath)
+		return fmt.Errorf("write loader binary: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("finalize loader binary: %w", err)
+	}
+	if err := os.Rename(tempPath, dest); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("persist loader binary: %w", err)
+	}
+	finalMode := mode
+	if finalMode == 0 {
+		finalMode = 0o755
+	}
+	if err := os.Chmod(dest, finalMode); err != nil {
+		return fmt.Errorf("set loader permissions: %w", err)
+	}
+	return nil
+}
+
+func ensureLoaderExecutable(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat loader: %w", err)
+	}
+	mode := info.Mode()
+	if mode.IsDir() {
+		return fmt.Errorf("loader path is a directory: %s", path)
+	}
+	if mode&0o111 != 0 {
+		return nil
+	}
+	if err := os.Chmod(path, mode|0o111); err != nil {
+		return fmt.Errorf("mark loader executable: %w", err)
+	}
+	return nil
 }

--- a/tenvy-client/internal/bootstrap/bootstrap_test.go
+++ b/tenvy-client/internal/bootstrap/bootstrap_test.go
@@ -1,12 +1,318 @@
 package bootstrap
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestCommandInstallsLoaderWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	stubPath := filepath.Join(tempDir, "stub")
+	if err := os.WriteFile(stubPath, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("failed to write stub file: %v", err)
+	}
+
+	payload := []byte("fresh-loader")
+	hash := sha256.Sum256(payload)
+	metadata := &LoaderMetadata{
+		Version:    "1.2.3",
+		Checksum:   fmt.Sprintf("%x", hash[:]),
+		Signature:  "signed",
+		Executable: "tenvy-client-loader",
+	}
+
+	downloads := 0
+	downloader := LoaderDownloaderFunc(func(ctx context.Context, meta LoaderMetadata) (LoaderPackage, error) {
+		downloads++
+		if meta.Version != metadata.Version {
+			t.Fatalf("unexpected version requested: %q", meta.Version)
+		}
+		archive := buildLoaderArchive(t, meta.Executable, payload)
+		return LoaderPackage{Archive: archive}, nil
+	})
+
+	var verified bool
+	verifier := LoaderSignatureVerifierFunc(func(ctx context.Context, path string, meta LoaderMetadata) error {
+		if meta.Signature != metadata.Signature {
+			return fmt.Errorf("unexpected signature %q", meta.Signature)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(data, payload) {
+			return fmt.Errorf("unexpected loader payload: %q", data)
+		}
+		verified = true
+		return nil
+	})
+
+	cmd, err := Command(context.Background(), Options{
+		ExecutablePath:          stubPath,
+		DesiredLoader:           metadata,
+		LoaderDownloader:        downloader,
+		LoaderSignatureVerifier: verifier,
+	})
+	if err != nil {
+		t.Fatalf("Command returned error: %v", err)
+	}
+
+	expectedLoaderPath := filepath.Join(tempDir, defaultLoaderDirectory, metadata.Executable)
+	if cmd.Path != expectedLoaderPath {
+		t.Fatalf("expected loader path %q, got %q", expectedLoaderPath, cmd.Path)
+	}
+
+	record, err := readStoredLoaderMetadata(filepath.Join(tempDir, defaultLoaderDirectory, loaderMetadataFileName))
+	if err != nil {
+		t.Fatalf("read loader metadata: %v", err)
+	}
+	if record.Version != metadata.Version {
+		t.Fatalf("expected stored version %q, got %q", metadata.Version, record.Version)
+	}
+	if !strings.EqualFold(record.Checksum, metadata.Checksum) {
+		t.Fatalf("expected stored checksum %q, got %q", metadata.Checksum, record.Checksum)
+	}
+	if record.Signature != metadata.Signature {
+		t.Fatalf("expected stored signature %q, got %q", metadata.Signature, record.Signature)
+	}
+	if record.Executable != metadata.Executable {
+		t.Fatalf("expected stored executable %q, got %q", metadata.Executable, record.Executable)
+	}
+	if record.InstalledAt.IsZero() {
+		t.Fatalf("expected installation timestamp recorded")
+	}
+	if downloads != 1 {
+		t.Fatalf("expected exactly one download, got %d", downloads)
+	}
+	if !verified {
+		t.Fatalf("expected signature verification to run")
+	}
+}
+
+func TestCommandUpdatesStaleLoader(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	stubPath := filepath.Join(tempDir, "stub")
+	if err := os.WriteFile(stubPath, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("failed to write stub file: %v", err)
+	}
+
+	loaderDir := filepath.Join(tempDir, defaultLoaderDirectory)
+	if err := os.MkdirAll(loaderDir, 0o755); err != nil {
+		t.Fatalf("failed to create loader dir: %v", err)
+	}
+
+	oldPayload := []byte("old-loader")
+	oldHash := sha256.Sum256(oldPayload)
+	loaderPath := filepath.Join(loaderDir, "tenvy-client-loader")
+	if err := os.WriteFile(loaderPath, oldPayload, 0o755); err != nil {
+		t.Fatalf("failed to seed loader file: %v", err)
+	}
+	originalRecord := storedLoaderMetadata{
+		LoaderMetadata: LoaderMetadata{
+			Version:    "0.1.0",
+			Checksum:   fmt.Sprintf("%x", oldHash[:]),
+			Executable: "tenvy-client-loader",
+		},
+		InstalledAt: time.Now().Add(-time.Hour),
+	}
+	if err := writeStoredLoaderMetadata(filepath.Join(loaderDir, loaderMetadataFileName), originalRecord); err != nil {
+		t.Fatalf("failed to write metadata: %v", err)
+	}
+
+	newPayload := []byte("new-loader")
+	newHash := sha256.Sum256(newPayload)
+	target := &LoaderMetadata{
+		Version:    "2.0.0",
+		Checksum:   fmt.Sprintf("%x", newHash[:]),
+		Executable: "tenvy-client-loader",
+	}
+
+	downloads := 0
+	downloader := LoaderDownloaderFunc(func(ctx context.Context, meta LoaderMetadata) (LoaderPackage, error) {
+		downloads++
+		if meta.Version != target.Version {
+			t.Fatalf("unexpected version requested: %q", meta.Version)
+		}
+		return LoaderPackage{Binary: append([]byte(nil), newPayload...), Mode: 0o755}, nil
+	})
+
+	cmd, err := Command(context.Background(), Options{
+		ExecutablePath:   stubPath,
+		DesiredLoader:    target,
+		LoaderDownloader: downloader,
+	})
+	if err != nil {
+		t.Fatalf("Command returned error: %v", err)
+	}
+	if downloads != 1 {
+		t.Fatalf("expected exactly one download, got %d", downloads)
+	}
+
+	expectedPath := filepath.Join(loaderDir, target.Executable)
+	if cmd.Path != expectedPath {
+		t.Fatalf("expected loader path %q, got %q", expectedPath, cmd.Path)
+	}
+	data, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("read loader: %v", err)
+	}
+	if !bytes.Equal(data, newPayload) {
+		t.Fatalf("unexpected loader contents: %q", data)
+	}
+
+	record, err := readStoredLoaderMetadata(filepath.Join(loaderDir, loaderMetadataFileName))
+	if err != nil {
+		t.Fatalf("read loader metadata: %v", err)
+	}
+	if record.Version != target.Version {
+		t.Fatalf("expected version %q, got %q", target.Version, record.Version)
+	}
+	if !strings.EqualFold(record.Checksum, target.Checksum) {
+		t.Fatalf("expected checksum %q, got %q", target.Checksum, record.Checksum)
+	}
+	if record.Signature != "" {
+		t.Fatalf("expected no signature, got %q", record.Signature)
+	}
+	if record.InstalledAt.Before(originalRecord.InstalledAt) {
+		t.Fatalf("expected installation timestamp to be updated")
+	}
+}
+
+func TestCommandRepairsCorruptedLoader(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	stubPath := filepath.Join(tempDir, "stub")
+	if err := os.WriteFile(stubPath, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("failed to write stub file: %v", err)
+	}
+
+	loaderDir := filepath.Join(tempDir, defaultLoaderDirectory)
+	if err := os.MkdirAll(loaderDir, 0o755); err != nil {
+		t.Fatalf("failed to create loader dir: %v", err)
+	}
+
+	expectedPayload := []byte("clean-loader")
+	hash := sha256.Sum256(expectedPayload)
+	metadata := &LoaderMetadata{
+		Version:    "3.1.4",
+		Checksum:   fmt.Sprintf("%x", hash[:]),
+		Executable: "tenvy-client-loader",
+	}
+
+	// Seed metadata indicating the loader is already at the expected version.
+	record := storedLoaderMetadata{
+		LoaderMetadata: *metadata,
+		InstalledAt:    time.Now().Add(-2 * time.Hour),
+	}
+	if err := writeStoredLoaderMetadata(filepath.Join(loaderDir, loaderMetadataFileName), record); err != nil {
+		t.Fatalf("failed to seed metadata: %v", err)
+	}
+
+	corruptedPath := filepath.Join(loaderDir, metadata.Executable)
+	if err := os.WriteFile(corruptedPath, []byte("tampered"), 0o755); err != nil {
+		t.Fatalf("failed to seed corrupted loader: %v", err)
+	}
+
+	downloads := 0
+	downloader := LoaderDownloaderFunc(func(ctx context.Context, meta LoaderMetadata) (LoaderPackage, error) {
+		downloads++
+		if meta.Version != metadata.Version {
+			t.Fatalf("unexpected version requested: %q", meta.Version)
+		}
+		return LoaderPackage{Binary: append([]byte(nil), expectedPayload...), Mode: 0o755}, nil
+	})
+
+	cmd, err := Command(context.Background(), Options{
+		ExecutablePath:   stubPath,
+		DesiredLoader:    metadata,
+		LoaderDownloader: downloader,
+	})
+	if err != nil {
+		t.Fatalf("Command returned error: %v", err)
+	}
+	if downloads != 1 {
+		t.Fatalf("expected repair download, got %d", downloads)
+	}
+
+	expectedPath := filepath.Join(loaderDir, metadata.Executable)
+	if cmd.Path != expectedPath {
+		t.Fatalf("expected loader path %q, got %q", expectedPath, cmd.Path)
+	}
+	data, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("read loader: %v", err)
+	}
+	if !bytes.Equal(data, expectedPayload) {
+		t.Fatalf("unexpected loader contents after repair: %q", data)
+	}
+
+	updated, err := readStoredLoaderMetadata(filepath.Join(loaderDir, loaderMetadataFileName))
+	if err != nil {
+		t.Fatalf("read loader metadata: %v", err)
+	}
+	if updated.Version != metadata.Version {
+		t.Fatalf("expected version %q, got %q", metadata.Version, updated.Version)
+	}
+	if !strings.EqualFold(updated.Checksum, metadata.Checksum) {
+		t.Fatalf("expected checksum %q, got %q", metadata.Checksum, updated.Checksum)
+	}
+	if updated.InstalledAt.Before(record.InstalledAt) {
+		t.Fatalf("expected refreshed installation timestamp")
+	}
+}
+
+func TestCommandFailsWhenChecksumMismatch(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	stubPath := filepath.Join(tempDir, "stub")
+	if err := os.WriteFile(stubPath, []byte("stub"), 0o755); err != nil {
+		t.Fatalf("failed to write stub file: %v", err)
+	}
+
+	expected := []byte("loader")
+	checksum := sha256.Sum256(expected)
+	metadata := &LoaderMetadata{
+		Version:    "9.9.9",
+		Checksum:   fmt.Sprintf("%x", checksum[:]),
+		Executable: "tenvy-client-loader",
+	}
+
+	downloader := LoaderDownloaderFunc(func(ctx context.Context, meta LoaderMetadata) (LoaderPackage, error) {
+		return LoaderPackage{Binary: []byte("corrupt")}, nil
+	})
+
+	_, err := Command(context.Background(), Options{
+		ExecutablePath:   stubPath,
+		DesiredLoader:    metadata,
+		LoaderDownloader: downloader,
+	})
+	if err == nil {
+		t.Fatalf("expected checksum error")
+	}
+	if !errors.Is(err, errChecksumMismatch) {
+		t.Fatalf("expected checksum mismatch error, got %v", err)
+	}
+
+	metadataPath := filepath.Join(tempDir, defaultLoaderDirectory, loaderMetadataFileName)
+	if _, statErr := os.Stat(metadataPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected metadata file to be absent, got %v", statErr)
+	}
+}
 
 func TestCommandUsesOverride(t *testing.T) {
 	t.Parallel()
@@ -171,6 +477,27 @@ func TestEnvironmentDefaultBase(t *testing.T) {
 	if env["TEST_ENV_KEY"] != "VALUE" {
 		t.Fatalf("expected TEST_ENV_KEY inherited, got %q", env["TEST_ENV_KEY"])
 	}
+}
+
+func buildLoaderArchive(t *testing.T, name string, payload []byte) []byte {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	header := &zip.FileHeader{Name: filepath.ToSlash(name)}
+	header.Method = zip.Deflate
+	header.SetMode(0o755)
+	entry, err := writer.CreateHeader(header)
+	if err != nil {
+		t.Fatalf("create archive entry: %v", err)
+	}
+	if _, err := entry.Write(payload); err != nil {
+		t.Fatalf("write archive entry: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close archive writer: %v", err)
+	}
+	return buffer.Bytes()
 }
 
 func mustWriteTempFile(t *testing.T) string {


### PR DESCRIPTION
## Summary
- add loader metadata, downloader, and signature verification support to the bootstrap helper
- persist loader metadata during installation and enforce checksum and signature validation
- cover loader install, update, repair, and checksum failure scenarios with new tests

## Testing
- go test ./internal/bootstrap -run TestCommand -count=1

------
https://chatgpt.com/codex/tasks/task_e_68fbe0a96714832b8fcfd9bd428fcbb5