### PR TITLE
Remove unsigned plugin manifest support

### DIFF
--- a/docs/plugins-and-modules-architecture.md
+++ b/docs/plugins-and-modules-architecture.md
@@ -254,7 +254,6 @@ PATCH /api/clients/:id/plugins/:pluginId → enable/disable
 
 ```json
 {
-  "allowUnsigned": false,
   "sha256AllowList": [],
   "ed25519PublicKeys": {
     "release": "aabbcc..."

--- a/shared/pluginmanifest/manifest.go
+++ b/shared/pluginmanifest/manifest.go
@@ -82,7 +82,6 @@ const (
 	DeliveryManual    DeliveryMode = "manual"
 	DeliveryAutomatic DeliveryMode = "automatic"
 
-	SignatureNone    SignatureType = "none"
 	SignatureSHA256  SignatureType = "sha256"
 	SignatureEd25519 SignatureType = "ed25519"
 
@@ -106,7 +105,7 @@ const (
 
 var (
 	knownDeliveryModes  = []DeliveryMode{DeliveryManual, DeliveryAutomatic}
-	knownSignatureTypes = []SignatureType{SignatureNone, SignatureSHA256, SignatureEd25519}
+	knownSignatureTypes = []SignatureType{SignatureSHA256, SignatureEd25519}
 	knownPlatforms      = []PluginPlatform{PlatformWindows, PlatformLinux, PlatformMacOS}
 	knownArchitectures  = []PluginArchitecture{ArchitectureX8664, ArchitectureARM64}
 	knownInstallStates  = []PluginInstallStatus{InstallPending, InstallInstalling, InstallInstalled, InstallFailed, InstallBlocked}
@@ -231,7 +230,6 @@ func (m Manifest) validateDistribution() error {
 	}
 
 	switch sig.Type {
-	case SignatureNone:
 	case SignatureSHA256:
 		if strings.TrimSpace(sig.Hash) == "" {
 			return errors.New("sha256 signature requires hash")
@@ -245,13 +243,11 @@ func (m Manifest) validateDistribution() error {
 		}
 	}
 
-	if sig.Type != SignatureNone {
-		if strings.TrimSpace(m.Package.Hash) == "" {
-			return errors.New("signed packages must include a hash")
-		}
-		if strings.TrimSpace(sig.Signature) == "" {
-			return errors.New("signed manifests must provide signature value")
-		}
+	if strings.TrimSpace(m.Package.Hash) == "" {
+		return errors.New("signed packages must include a hash")
+	}
+	if strings.TrimSpace(sig.Signature) == "" {
+		return errors.New("signed manifests must provide signature value")
 	}
 
 	return nil

--- a/shared/types/config.ts
+++ b/shared/types/config.ts
@@ -1,58 +1,53 @@
 export interface AgentPluginSignaturePolicy {
-        /**
-         * Whether unsigned manifests may be processed by the agent. When disabled the
-         * agent blocks telemetry for plugins that omit signatures.
-         */
-        allowUnsigned?: boolean;
-        /**
-         * Optional list of SHA-256 hashes that may be installed without a public-key
-         * signature. Hashes are compared case-insensitively.
-         */
-        sha256AllowList?: string[];
-        /**
-         * Mapping of signer identifiers to Ed25519 public keys (hex encoded).
-         */
-        ed25519PublicKeys?: Record<string, string>;
-        /**
-         * Maximum accepted age for signatures in milliseconds. Omit to disable the
-         * expiration check.
-         */
-        maxSignatureAgeMs?: number;
+  /**
+   * Optional list of SHA-256 hashes that may be installed without a public-key
+   * signature. Hashes are compared case-insensitively.
+   */
+  sha256AllowList?: string[];
+  /**
+   * Mapping of signer identifiers to Ed25519 public keys (hex encoded).
+   */
+  ed25519PublicKeys?: Record<string, string>;
+  /**
+   * Maximum accepted age for signatures in milliseconds. Omit to disable the
+   * expiration check.
+   */
+  maxSignatureAgeMs?: number;
 }
 
 export interface AgentPluginConfig {
-        signaturePolicy?: AgentPluginSignaturePolicy;
+  signaturePolicy?: AgentPluginSignaturePolicy;
 }
 
 export interface AgentConfig {
-        /**
-         * Base interval in milliseconds used by the agent to poll the controller for new work.
-         */
-        pollIntervalMs: number;
-        /**
-         * Maximum backoff interval in milliseconds applied when network issues occur.
-         */
-        maxBackoffMs: number;
-        /**
-         * Randomisation factor applied to poll intervals to avoid detection patterns.
-         */
-        jitterRatio: number;
-        /**
-         * Plugin specific configuration pushed from the controller.
-         */
-        plugins?: AgentPluginConfig;
+  /**
+   * Base interval in milliseconds used by the agent to poll the controller for new work.
+   */
+  pollIntervalMs: number;
+  /**
+   * Maximum backoff interval in milliseconds applied when network issues occur.
+   */
+  maxBackoffMs: number;
+  /**
+   * Randomisation factor applied to poll intervals to avoid detection patterns.
+   */
+  jitterRatio: number;
+  /**
+   * Plugin specific configuration pushed from the controller.
+   */
+  plugins?: AgentPluginConfig;
 }
 
 export const defaultAgentConfig: AgentConfig = Object.freeze({
-        pollIntervalMs: 5_000,
-        maxBackoffMs: 60_000,
-        jitterRatio: 0.2
+  pollIntervalMs: 5_000,
+  maxBackoffMs: 60_000,
+  jitterRatio: 0.2,
 } satisfies AgentConfig);
 
 export interface ServerAgentConfig {
-        agent: AgentConfig;
+  agent: AgentConfig;
 }
 
 export const defaultServerAgentConfig: ServerAgentConfig = Object.freeze({
-        agent: defaultAgentConfig
+  agent: defaultAgentConfig,
 });

--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -276,7 +276,6 @@ func deriveSignatureVerifyOptions(cfg protocol.AgentConfig, logger *log.Logger) 
 	}
 
 	policy := cfg.Plugins.SignaturePolicy
-	opts.AllowUnsigned = policy.AllowUnsigned
 
 	if len(policy.SHA256AllowList) > 0 {
 		opts.SHA256AllowList = make([]string, 0, len(policy.SHA256AllowList))

--- a/tenvy-client/internal/plugins/manager.go
+++ b/tenvy-client/internal/plugins/manager.go
@@ -113,11 +113,7 @@ func (m *Manager) Snapshot() *manifest.SyncPayload {
 			continue
 		}
 
-		trusted := verificationResult != nil && verificationResult.Trusted
-		if !trusted && verificationResult != nil && verificationResult.SignatureType == manifest.SignatureNone {
-			trusted = true
-		}
-		if !trusted {
+		if verificationResult == nil || !verificationResult.Trusted {
 			installation.Status = manifest.InstallBlocked
 			installation.Error = fmt.Sprintf("signature: %s", signatureUntrustedReason(mf, verificationResult))
 			installation.LastCheckedAt = &now
@@ -268,8 +264,6 @@ func signatureUntrustedReason(mf manifest.Manifest, result *manifest.Verificatio
 	}
 
 	switch result.SignatureType {
-	case manifest.SignatureNone:
-		return "unsigned plugin"
 	case manifest.SignatureSHA256:
 		return "hash not trusted"
 	case manifest.SignatureEd25519:

--- a/tenvy-client/internal/plugins/remotedesktop.go
+++ b/tenvy-client/internal/plugins/remotedesktop.go
@@ -86,11 +86,7 @@ func StageRemoteDesktopEngine(
 		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallBlocked, message)
 		return result, fmt.Errorf(message)
 	}
-	trusted := verificationResult != nil && verificationResult.Trusted
-	if !trusted && verificationResult != nil && verificationResult.SignatureType == manifest.SignatureNone {
-		trusted = true
-	}
-	if !trusted {
+	if verificationResult == nil || !verificationResult.Trusted {
 		message := fmt.Sprintf("signature not trusted: %s", signatureUntrustedReason(mf, verificationResult))
 		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallBlocked, message)
 		return result, errors.New(message)

--- a/tenvy-client/internal/plugins/remotedesktop_test.go
+++ b/tenvy-client/internal/plugins/remotedesktop_test.go
@@ -115,8 +115,7 @@ func TestStageRemoteDesktopEngineRecordsFailure(t *testing.T) {
 	defer server.Close()
 
 	root := t.TempDir()
-	opts := manifest.VerifyOptions{AllowUnsigned: true}
-	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
+	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), manifest.VerifyOptions{})
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
 	}
@@ -142,7 +141,8 @@ func TestStageRemoteDesktopEngineRecordsFailure(t *testing.T) {
 func TestStageRemoteDesktopEngineBlocksIncompatiblePlatform(t *testing.T) {
 	t.Parallel()
 
-	manifestJSON := `{
+	hashHex := strings.Repeat("ab", 32)
+	manifestJSON := fmt.Sprintf(`{
                 "id": "remote-desktop-engine",
                 "name": "Remote Desktop Engine",
                 "version": "1.0.0",
@@ -150,9 +150,9 @@ func TestStageRemoteDesktopEngineBlocksIncompatiblePlatform(t *testing.T) {
                 "repositoryUrl": "https://github.com/rootbay/tenvy-client",
                 "license": {"spdxId": "MIT"},
                 "requirements": {"platforms": ["windows"]},
-                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": {"type": "none"}},
-                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip"}
-        }`
+                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": {"type": "sha256", "hash": "%[1]s", "signature": "%[1]s"}},
+                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip", "hash": "%[1]s"}
+        }`, hashHex)
 
 	var artifactRequested atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -168,7 +168,7 @@ func TestStageRemoteDesktopEngineBlocksIncompatiblePlatform(t *testing.T) {
 	defer server.Close()
 
 	root := t.TempDir()
-	opts := manifest.VerifyOptions{AllowUnsigned: true}
+	opts := manifest.VerifyOptions{SHA256AllowList: []string{hashHex}}
 	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
@@ -208,7 +208,8 @@ func TestStageRemoteDesktopEngineBlocksIncompatiblePlatform(t *testing.T) {
 func TestStageRemoteDesktopEngineBlocksIncompatibleArchitecture(t *testing.T) {
 	t.Parallel()
 
-	manifestJSON := `{
+	hashHex := strings.Repeat("cd", 32)
+	manifestJSON := fmt.Sprintf(`{
                 "id": "remote-desktop-engine",
                 "name": "Remote Desktop Engine",
                 "version": "1.0.0",
@@ -216,9 +217,9 @@ func TestStageRemoteDesktopEngineBlocksIncompatibleArchitecture(t *testing.T) {
                 "repositoryUrl": "https://github.com/rootbay/tenvy-client",
                 "license": {"spdxId": "MIT"},
                 "requirements": {"architectures": ["arm64"]},
-                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": {"type": "none"}},
-                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip"}
-        }`
+                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": {"type": "sha256", "hash": "%[1]s", "signature": "%[1]s"}},
+                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip", "hash": "%[1]s"}
+        }`, hashHex)
 
 	var artifactRequested atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -234,7 +235,7 @@ func TestStageRemoteDesktopEngineBlocksIncompatibleArchitecture(t *testing.T) {
 	defer server.Close()
 
 	root := t.TempDir()
-	opts := manifest.VerifyOptions{AllowUnsigned: true}
+	opts := manifest.VerifyOptions{SHA256AllowList: []string{hashHex}}
 	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
@@ -274,7 +275,8 @@ func TestStageRemoteDesktopEngineBlocksIncompatibleArchitecture(t *testing.T) {
 func TestStageRemoteDesktopEngineBlocksIncompatibleAgentVersion(t *testing.T) {
 	t.Parallel()
 
-	manifestJSON := `{
+	hashHex := strings.Repeat("ef", 32)
+	manifestJSON := fmt.Sprintf(`{
                 "id": "remote-desktop-engine",
                 "name": "Remote Desktop Engine",
                 "version": "1.0.0",
@@ -282,9 +284,9 @@ func TestStageRemoteDesktopEngineBlocksIncompatibleAgentVersion(t *testing.T) {
                 "repositoryUrl": "https://github.com/rootbay/tenvy-client",
                 "license": {"spdxId": "MIT"},
                 "requirements": {"minAgentVersion": "5.0.0"},
-                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": {"type": "none"}},
-                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip"}
-        }`
+                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": {"type": "sha256", "hash": "%[1]s", "signature": "%[1]s"}},
+                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip", "hash": "%[1]s"}
+        }`, hashHex)
 
 	var artifactRequested atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -300,7 +302,7 @@ func TestStageRemoteDesktopEngineBlocksIncompatibleAgentVersion(t *testing.T) {
 	defer server.Close()
 
 	root := t.TempDir()
-	opts := manifest.VerifyOptions{AllowUnsigned: true}
+	opts := manifest.VerifyOptions{SHA256AllowList: []string{hashHex}}
 	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
 	if err != nil {
 		t.Fatalf("new manager: %v", err)

--- a/tenvy-client/internal/protocol/types.go
+++ b/tenvy-client/internal/protocol/types.go
@@ -18,7 +18,6 @@ const (
 var ErrUnauthorized = errors.New("unauthorized")
 
 type PluginSignaturePolicy struct {
-	AllowUnsigned     bool              `json:"allowUnsigned,omitempty"`
 	SHA256AllowList   []string          `json:"sha256AllowList,omitempty"`
 	Ed25519PublicKeys map[string]string `json:"ed25519PublicKeys,omitempty"`
 	MaxSignatureAgeMs int64             `json:"maxSignatureAgeMs,omitempty"`

--- a/tenvy-server/src/lib/server/plugins/signature-policy.ts
+++ b/tenvy-server/src/lib/server/plugins/signature-policy.ts
@@ -5,17 +5,15 @@ import type { AgentPluginSignaturePolicy } from '../../../../../../shared/types/
 import type { PluginSignatureVerificationOptions } from '../../../../../../shared/types/plugin-manifest.js';
 
 type ServerSignaturePolicy = {
-	allowUnsigned: boolean;
-	sha256AllowList: string[];
-	ed25519PublicKeys: Record<string, string>;
-	maxSignatureAgeMs?: number;
+        sha256AllowList: string[];
+        ed25519PublicKeys: Record<string, string>;
+        maxSignatureAgeMs?: number;
 };
 
 const DEFAULT_POLICY: ServerSignaturePolicy = {
-	allowUnsigned: false,
-	sha256AllowList: [],
-	ed25519PublicKeys: {},
-	maxSignatureAgeMs: undefined
+        sha256AllowList: [],
+        ed25519PublicKeys: {},
+        maxSignatureAgeMs: undefined
 };
 
 let cachedPolicy: ServerSignaturePolicy | null = null;
@@ -35,12 +33,15 @@ const parsePolicy = (raw: unknown): ServerSignaturePolicy => {
 	}
 
 	const input = raw as Record<string, unknown>;
-	const policy: ServerSignaturePolicy = {
-		allowUnsigned: Boolean(input.allowUnsigned),
-		sha256AllowList: [],
-		ed25519PublicKeys: {},
-		maxSignatureAgeMs: undefined
-	};
+        const policy: ServerSignaturePolicy = {
+                sha256AllowList: [],
+                ed25519PublicKeys: {},
+                maxSignatureAgeMs: undefined
+        };
+
+        if (input.allowUnsigned) {
+                console.warn("Ignoring deprecated allowUnsigned flag in plugin signature policy");
+        }
 
 	if (Array.isArray(input.sha256AllowList)) {
 		policy.sha256AllowList = input.sha256AllowList
@@ -71,11 +72,7 @@ const parsePolicy = (raw: unknown): ServerSignaturePolicy => {
 		policy.maxSignatureAgeMs = Math.floor(maxAge);
 	}
 
-	if (!policy.allowUnsigned) {
-		policy.allowUnsigned = false;
-	}
-
-	return policy;
+        return policy;
 };
 
 const loadPolicyFromDisk = (): ServerSignaturePolicy => {
@@ -133,12 +130,11 @@ const ed25519KeyBytes = (policy: ServerSignaturePolicy): Record<string, Uint8Arr
 };
 
 export const getVerificationOptions = (): PluginSignatureVerificationOptions => {
-	const policy = getSignaturePolicy();
-	const options: PluginSignatureVerificationOptions = {
-		allowUnsigned: policy.allowUnsigned,
-		sha256AllowList: policy.sha256AllowList,
-		ed25519PublicKeys: ed25519KeyBytes(policy)
-	};
+        const policy = getSignaturePolicy();
+        const options: PluginSignatureVerificationOptions = {
+                sha256AllowList: policy.sha256AllowList,
+                ed25519PublicKeys: ed25519KeyBytes(policy)
+        };
 	if (policy.maxSignatureAgeMs && policy.maxSignatureAgeMs > 0) {
 		options.maxSignatureAgeMs = policy.maxSignatureAgeMs;
 	}
@@ -146,12 +142,11 @@ export const getVerificationOptions = (): PluginSignatureVerificationOptions => 
 };
 
 export const getAgentSignaturePolicy = (): AgentPluginSignaturePolicy => {
-	const policy = getSignaturePolicy();
-	const agentPolicy: AgentPluginSignaturePolicy = {
-		allowUnsigned: policy.allowUnsigned,
-		sha256AllowList: policy.sha256AllowList,
-		ed25519PublicKeys: policy.ed25519PublicKeys
-	};
+        const policy = getSignaturePolicy();
+        const agentPolicy: AgentPluginSignaturePolicy = {
+                sha256AllowList: policy.sha256AllowList,
+                ed25519PublicKeys: policy.ed25519PublicKeys
+        };
 	if (policy.maxSignatureAgeMs && policy.maxSignatureAgeMs > 0) {
 		agentPolicy.maxSignatureAgeMs = policy.maxSignatureAgeMs;
 	}

--- a/tenvy-server/src/lib/server/rat/store.test.ts
+++ b/tenvy-server/src/lib/server/rat/store.test.ts
@@ -255,17 +255,15 @@ describe('AgentRegistry database integration', () => {
 
 	it('preserves custom plugin configuration when refreshing agent config', async () => {
 		const signaturePolicyModule = await import('../plugins/signature-policy.js');
-		const initialPolicy = {
-			allowUnsigned: true,
-			sha256AllowList: ['cafebabe'],
-			ed25519PublicKeys: { controller: 'a'.repeat(64) }
-		};
-		const refreshedPolicy = {
-			allowUnsigned: false,
-			sha256AllowList: ['deadbeef'],
-			ed25519PublicKeys: { controller: 'b'.repeat(64) },
-			maxSignatureAgeMs: 86_400_000
-		};
+                const initialPolicy = {
+                        sha256AllowList: ['cafebabe'],
+                        ed25519PublicKeys: { controller: 'a'.repeat(64) }
+                };
+                const refreshedPolicy = {
+                        sha256AllowList: ['deadbeef'],
+                        ed25519PublicKeys: { controller: 'b'.repeat(64) },
+                        maxSignatureAgeMs: 86_400_000
+                };
 
 		const policySpy = vi
 			.spyOn(signaturePolicyModule, 'getAgentSignaturePolicy')


### PR DESCRIPTION
## Summary
- drop the `none` signature type from shared manifest definitions and enforce required fields
- fail verification for missing or unsupported signatures and align agent runtime and remote desktop staging logic
- update server signature policy plumbing, documentation, and tests to ignore attempts to enable unsigned plugins

## Testing
- `cd tenvy-client && go test ./...`
- `cd tenvy-server && bun test` *(fails: Vitest browser helpers unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fbe91c26a8832bafb3bed0996c9492