### PR TITLE
Implement agent plugin sync endpoints and manifest workflow

### DIFF
--- a/shared/pluginmanifest/manifest.go
+++ b/shared/pluginmanifest/manifest.go
@@ -134,6 +134,38 @@ type InstallationTelemetry struct {
 
 type SyncPayload struct {
 	Installations []InstallationTelemetry `json:"installations"`
+	Manifests     *ManifestState          `json:"manifests,omitempty"`
+}
+
+type ManifestDescriptor struct {
+	PluginID       string           `json:"pluginId"`
+	Version        string           `json:"version"`
+	ManifestDigest string           `json:"manifestDigest"`
+	ArtifactHash   string           `json:"artifactHash,omitempty"`
+	ArtifactSize   int64            `json:"artifactSizeBytes,omitempty"`
+	ApprovedAt     string           `json:"approvedAt,omitempty"`
+	Distribution   ManifestBriefing `json:"distribution"`
+}
+
+type ManifestBriefing struct {
+	DefaultMode DeliveryMode `json:"defaultMode"`
+	AutoUpdate  bool         `json:"autoUpdate"`
+}
+
+type ManifestList struct {
+	Version   string               `json:"version"`
+	Manifests []ManifestDescriptor `json:"manifests"`
+}
+
+type ManifestState struct {
+	Version string            `json:"version,omitempty"`
+	Digests map[string]string `json:"digests,omitempty"`
+}
+
+type ManifestDelta struct {
+	Version string               `json:"version"`
+	Updated []ManifestDescriptor `json:"updated"`
+	Removed []string             `json:"removed"`
 }
 
 func (m Manifest) Validate() error {

--- a/shared/types/messages.ts
+++ b/shared/types/messages.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig } from "./config";
 import type { AgentMetrics, AgentStatus } from "./agent";
-import type { PluginSyncPayload } from "./plugin-manifest";
+import type { PluginSyncPayload, PluginManifestDelta } from "./plugin-manifest";
 import type {
   RemoteDesktopCommandPayload,
   RemoteDesktopInputBurst,
@@ -119,6 +119,7 @@ export interface AgentSyncResponse {
   commands: Command[];
   config: AgentConfig;
   serverTime: string;
+  pluginManifests?: PluginManifestDelta;
 }
 
 export type CommandDeliveryMode = "session" | "queued";

--- a/shared/types/plugin-manifest.ts
+++ b/shared/types/plugin-manifest.ts
@@ -115,6 +115,36 @@ export interface PluginInstallationTelemetry {
 
 export interface PluginSyncPayload {
   installations: PluginInstallationTelemetry[];
+  manifests?: AgentPluginManifestState;
+}
+
+export interface AgentPluginManifestState {
+  version?: string;
+  digests?: Record<string, string>;
+}
+
+export interface PluginManifestDescriptor {
+  pluginId: string;
+  version: string;
+  manifestDigest: string;
+  artifactHash?: string | null;
+  artifactSizeBytes?: number | null;
+  approvedAt?: string | null;
+  distribution: {
+    defaultMode: PluginDeliveryMode;
+    autoUpdate: boolean;
+  };
+}
+
+export interface PluginManifestSnapshot {
+  version: string;
+  manifests: PluginManifestDescriptor[];
+}
+
+export interface PluginManifestDelta {
+  version: string;
+  updated: PluginManifestDescriptor[];
+  removed: string[];
 }
 
 export type PluginSignatureVerificationErrorCode =

--- a/tenvy-client/internal/agent/agent.go
+++ b/tenvy-client/internal/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -47,6 +48,10 @@ type Agent struct {
 	requestHeaders               []CustomHeader
 	requestCookies               []CustomCookie
 	options                      *options.Manager
+	pluginManifestMu             sync.RWMutex
+	pluginManifestVersion        string
+	pluginManifestDigests        map[string]string
+	pluginManifestDescriptors    map[string]manifest.ManifestDescriptor
 }
 
 func (a *Agent) AgentID() string {
@@ -62,12 +67,90 @@ func (a *Agent) AgentStartTime() time.Time {
 }
 
 func (a *Agent) pluginSyncPayload() *manifest.SyncPayload {
-	if a.plugins == nil {
+	var installations []manifest.InstallationTelemetry
+	if a.plugins != nil {
+		if snapshot := a.plugins.Snapshot(); snapshot != nil && len(snapshot.Installations) > 0 {
+			installations = snapshot.Installations
+		}
+	}
+
+	state := a.currentManifestState()
+	if len(installations) == 0 && state == nil {
 		return nil
 	}
-	payload := a.plugins.Snapshot()
-	if payload == nil || len(payload.Installations) == 0 {
-		return nil
+
+	payload := &manifest.SyncPayload{}
+	if len(installations) > 0 {
+		payload.Installations = installations
+	}
+	if state != nil {
+		payload.Manifests = state
 	}
 	return payload
+}
+
+func (a *Agent) currentManifestState() *manifest.ManifestState {
+	a.pluginManifestMu.RLock()
+	defer a.pluginManifestMu.RUnlock()
+
+	if a.pluginManifestVersion == "" && len(a.pluginManifestDigests) == 0 {
+		return nil
+	}
+
+	state := &manifest.ManifestState{Version: a.pluginManifestVersion}
+	if len(a.pluginManifestDigests) > 0 {
+		state.Digests = make(map[string]string, len(a.pluginManifestDigests))
+		for id, digest := range a.pluginManifestDigests {
+			state.Digests[id] = digest
+		}
+	}
+	return state
+}
+
+func (a *Agent) setPluginManifestList(list *manifest.ManifestList) {
+	a.pluginManifestMu.Lock()
+	defer a.pluginManifestMu.Unlock()
+
+	if list == nil {
+		a.pluginManifestVersion = ""
+		a.pluginManifestDigests = nil
+		a.pluginManifestDescriptors = nil
+		return
+	}
+
+	a.pluginManifestVersion = strings.TrimSpace(list.Version)
+
+	if len(list.Manifests) == 0 {
+		a.pluginManifestDigests = make(map[string]string)
+		a.pluginManifestDescriptors = make(map[string]manifest.ManifestDescriptor)
+		return
+	}
+
+	digests := make(map[string]string, len(list.Manifests))
+	descriptors := make(map[string]manifest.ManifestDescriptor, len(list.Manifests))
+	for _, entry := range list.Manifests {
+		id := strings.TrimSpace(entry.PluginID)
+		if id == "" {
+			continue
+		}
+		digests[id] = entry.ManifestDigest
+		descriptors[id] = entry
+	}
+	a.pluginManifestDigests = digests
+	a.pluginManifestDescriptors = descriptors
+}
+
+func (a *Agent) pluginManifestSnapshot() map[string]manifest.ManifestDescriptor {
+	a.pluginManifestMu.RLock()
+	defer a.pluginManifestMu.RUnlock()
+
+	if len(a.pluginManifestDescriptors) == 0 {
+		return nil
+	}
+
+	snapshot := make(map[string]manifest.ManifestDescriptor, len(a.pluginManifestDescriptors))
+	for id, descriptor := range a.pluginManifestDescriptors {
+		snapshot[id] = descriptor
+	}
+	return snapshot
 }

--- a/tenvy-client/internal/agent/lifecycle.go
+++ b/tenvy-client/internal/agent/lifecycle.go
@@ -126,6 +126,11 @@ func (a *Agent) sync(ctx context.Context, status string) error {
 	if a.plugins != nil {
 		a.plugins.UpdateVerification(deriveSignatureVerifyOptions(a.config, a.logger))
 	}
+	if payload.PluginManifests != nil {
+		if err := a.applyPluginManifestDelta(ctx, payload.PluginManifests); err != nil && a.logger != nil {
+			a.logger.Printf("plugin manifest sync failed: %v", err)
+		}
+	}
 	if a.modules != nil {
 		if err := a.modules.UpdateConfig(a.moduleRuntime()); err != nil {
 			a.logger.Printf("module configuration update failed: %v", err)

--- a/tenvy-client/internal/agent/plugins_sync.go
+++ b/tenvy-client/internal/agent/plugins_sync.go
@@ -1,0 +1,169 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/rootbay/tenvy-client/internal/plugins"
+	manifest "github.com/rootbay/tenvy-client/shared/pluginmanifest"
+)
+
+func (a *Agent) fetchApprovedPluginList(ctx context.Context) (*manifest.ManifestList, error) {
+	if a.client == nil {
+		return nil, errors.New("http client not configured")
+	}
+	base := strings.TrimSpace(a.baseURL)
+	agentID := strings.TrimSpace(a.id)
+	if base == "" || agentID == "" {
+		return nil, errors.New("agent identity not established")
+	}
+
+	endpoint := fmt.Sprintf("%s/api/agents/%s/plugins", strings.TrimRight(base, "/"), url.PathEscape(agentID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", a.userAgent())
+	if key := strings.TrimSpace(a.key); key != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
+	}
+	applyRequestDecorations(req, a.requestHeaders, a.requestCookies)
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		message := strings.TrimSpace(string(body))
+		if message == "" {
+			message = fmt.Sprintf("status %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("fetch plugin manifests: %s", message)
+	}
+
+	var snapshot manifest.ManifestList
+	decoder := json.NewDecoder(io.LimitReader(resp.Body, 1<<20))
+	if err := decoder.Decode(&snapshot); err != nil {
+		return nil, fmt.Errorf("decode manifest snapshot: %w", err)
+	}
+	return &snapshot, nil
+}
+
+func (a *Agent) refreshApprovedPlugins(ctx context.Context) error {
+	if a.plugins == nil || a.client == nil {
+		return nil
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	snapshot, err := a.fetchApprovedPluginList(requestCtx)
+	if err != nil {
+		return err
+	}
+	a.setPluginManifestList(snapshot)
+	return a.stagePluginsFromList(requestCtx, snapshot)
+}
+
+func (a *Agent) applyPluginManifestDelta(ctx context.Context, delta *manifest.ManifestDelta) error {
+	if delta == nil {
+		return nil
+	}
+
+	a.pluginManifestMu.RLock()
+	currentVersion := a.pluginManifestVersion
+	a.pluginManifestMu.RUnlock()
+
+	if strings.TrimSpace(delta.Version) == currentVersion && len(delta.Updated) == 0 && len(delta.Removed) == 0 {
+		return nil
+	}
+
+	if a.plugins == nil || a.client == nil {
+		return nil
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	snapshot, err := a.fetchApprovedPluginList(requestCtx)
+	if err != nil {
+		return err
+	}
+	a.setPluginManifestList(snapshot)
+	return a.stagePluginsFromList(requestCtx, snapshot)
+}
+
+func (a *Agent) stagePluginsFromList(ctx context.Context, snapshot *manifest.ManifestList) error {
+	if snapshot == nil || len(snapshot.Manifests) == 0 {
+		return nil
+	}
+	if a.plugins == nil || a.client == nil {
+		return nil
+	}
+
+	var resultErr error
+	for _, entry := range snapshot.Manifests {
+		if !strings.EqualFold(strings.TrimSpace(entry.PluginID), plugins.RemoteDesktopEnginePluginID) {
+			continue
+		}
+
+		stageCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		facts := a.remoteDesktopRuntimeFacts()
+		if _, err := plugins.StageRemoteDesktopEngine(
+			stageCtx,
+			a.plugins,
+			a.client,
+			a.baseURL,
+			a.id,
+			a.key,
+			a.userAgent(),
+			facts,
+			entry,
+		); err != nil {
+			if resultErr == nil {
+				resultErr = err
+			}
+		}
+		cancel()
+	}
+
+	return resultErr
+}
+
+func (a *Agent) remoteDesktopRuntimeFacts() manifest.RuntimeFacts {
+	metadata := a.metadata
+	version := strings.TrimSpace(metadata.Version)
+	if version == "" {
+		version = strings.TrimSpace(a.buildVersion)
+	}
+
+	var activeModules []string
+	if a.modules != nil {
+		meta := a.modules.Metadata()
+		activeModules = make([]string, 0, len(meta))
+		for _, entry := range meta {
+			if id := strings.TrimSpace(entry.ID); id != "" {
+				activeModules = append(activeModules, id)
+			}
+		}
+	}
+
+	return manifest.RuntimeFacts{
+		Platform:       metadata.OS,
+		Architecture:   metadata.Architecture,
+		AgentVersion:   version,
+		EnabledModules: append([]string(nil), activeModules...),
+	}
+}

--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -168,6 +168,12 @@ func runAgentOnce(ctx context.Context, opts RuntimeOptions) error {
 		agent.plugins = manager
 	}
 
+	if agent.plugins != nil {
+		if err := agent.refreshApprovedPlugins(ctx); err != nil && opts.Logger != nil {
+			opts.Logger.Printf("plugin manifest refresh failed: %v", err)
+		}
+	}
+
 	modules := newDefaultModuleManager()
 	agent.modules = modules
 	if err := modules.Init(ctx, agent.moduleRuntime()); err != nil {

--- a/tenvy-client/internal/protocol/types.go
+++ b/tenvy-client/internal/protocol/types.go
@@ -423,10 +423,11 @@ type AgentSyncRequest struct {
 }
 
 type AgentSyncResponse struct {
-	AgentID    string      `json:"agentId"`
-	Commands   []Command   `json:"commands"`
-	Config     AgentConfig `json:"config"`
-	ServerTime string      `json:"serverTime"`
+	AgentID         string                  `json:"agentId"`
+	Commands        []Command               `json:"commands"`
+	Config          AgentConfig             `json:"config"`
+	ServerTime      string                  `json:"serverTime"`
+	PluginManifests *manifest.ManifestDelta `json:"pluginManifests,omitempty"`
 }
 
 type PingCommandPayload struct {

--- a/tenvy-server/src/lib/data/plugin-manifests.ts
+++ b/tenvy-server/src/lib/data/plugin-manifests.ts
@@ -14,9 +14,10 @@ import {
 import { getVerificationOptions } from '$lib/server/plugins/signature-policy.js';
 
 export interface LoadedPluginManifest {
-	source: string;
-	manifest: PluginManifest;
-	verification: PluginSignatureVerificationSummary;
+        source: string;
+        manifest: PluginManifest;
+        verification: PluginSignatureVerificationSummary;
+        raw: string;
 }
 
 const defaultManifestDirectory = resolve(process.cwd(), 'resources/plugin-manifests');
@@ -133,10 +134,10 @@ export async function loadPluginManifests(
 		}
 
 		const source = join(directory, entry.name);
-		try {
-			const fileContents = await readFile(source, 'utf8');
-			const manifest = JSON.parse(fileContents) as PluginManifest;
-			const errors = validatePluginManifest(manifest);
+                try {
+                        const fileContents = await readFile(source, 'utf8');
+                        const manifest = JSON.parse(fileContents) as PluginManifest;
+                        const errors = validatePluginManifest(manifest);
 
 			if (errors.length > 0) {
 				console.warn(`Skipping invalid plugin manifest at ${source}`, errors);
@@ -161,7 +162,7 @@ export async function loadPluginManifests(
 				);
 			}
 
-			manifests.push({ source, manifest, verification });
+                        manifests.push({ source, manifest, verification, raw: fileContents });
 		} catch (error) {
 			console.warn(`Failed to load plugin manifest at ${source}`, error);
 		}

--- a/tenvy-server/src/lib/server/plugins/telemetry-store.ts
+++ b/tenvy-server/src/lib/server/plugins/telemetry-store.ts
@@ -2,11 +2,15 @@ import { createHash, randomUUID } from 'crypto';
 import { and, eq, sql } from 'drizzle-orm';
 import type { AgentMetadata } from '../../../../../shared/types/agent.js';
 import {
-	pluginInstallStatuses,
-	type PluginInstallationTelemetry,
-	type PluginManifest,
-	type PluginPlatform,
-	type PluginArchitecture
+        pluginInstallStatuses,
+        type PluginInstallationTelemetry,
+        type PluginManifest,
+        type PluginPlatform,
+        type PluginArchitecture,
+        type PluginManifestDescriptor,
+        type PluginManifestDelta,
+        type AgentPluginManifestState,
+        type PluginManifestSnapshot
 } from '../../../../../shared/types/plugin-manifest.js';
 import { loadPluginManifests, type LoadedPluginManifest } from '$lib/data/plugin-manifests.js';
 import { db } from '$lib/server/db/index.js';
@@ -118,19 +122,24 @@ function isArchitectureCompatible(
 }
 
 function buildAuditPayload(details: Record<string, unknown>): {
-	payloadHash: string;
-	result: string;
+        payloadHash: string;
+        result: string;
 } {
-	const serialized = JSON.stringify(details);
-	const hash = createHash('sha256').update(serialized, 'utf8').digest('hex');
-	return { payloadHash: hash, result: serialized };
+        const serialized = JSON.stringify(details);
+        const hash = createHash('sha256').update(serialized, 'utf8').digest('hex');
+        return { payloadHash: hash, result: serialized };
+}
+
+function computeManifestDigest(record: LoadedPluginManifest): string {
+        const raw = record.raw ?? JSON.stringify(record.manifest);
+        return createHash('sha256').update(raw, 'utf8').digest('hex');
 }
 
 function verificationBlockReason(record: LoadedPluginManifest): string | null {
-	const { verification, manifest } = record;
-	if (!verification || verification.status === 'trusted') {
-		return null;
-	}
+        const { verification, manifest } = record;
+        if (!verification || verification.status === 'trusted') {
+                return null;
+        }
 
 	let message: string;
 	switch (verification.status) {
@@ -158,21 +167,26 @@ function verificationBlockReason(record: LoadedPluginManifest): string | null {
 }
 
 export class PluginTelemetryStore {
-	private readonly runtimeStore: PluginRuntimeStore;
-	private readonly manifestDirectory?: string;
-	private manifestCache = new Map<string, LoadedPluginManifest>();
-	private manifestLoadedAt = 0;
+        private readonly runtimeStore: PluginRuntimeStore;
+        private readonly manifestDirectory?: string;
+        private manifestCache = new Map<string, LoadedPluginManifest>();
+        private manifestLoadedAt = 0;
+        private manifestSnapshot: {
+                version: string;
+                entries: PluginManifestDescriptor[];
+                digests: Map<string, string>;
+        } | null = null;
 
 	constructor(options: PluginTelemetryStoreOptions = {}) {
 		this.runtimeStore = options.runtimeStore ?? createPluginRuntimeStore();
 		this.manifestDirectory = options.manifestDirectory;
 	}
 
-	async syncAgent(
-		agentId: string,
-		metadata: AgentMetadata,
-		installations: PluginInstallationTelemetry[]
-	): Promise<void> {
+        async syncAgent(
+                agentId: string,
+                metadata: AgentMetadata,
+                installations: PluginInstallationTelemetry[]
+        ): Promise<void> {
 		if (installations.length === 0) {
 			return;
 		}
@@ -288,16 +302,100 @@ export class PluginTelemetryStore {
 			processed.add(installation.pluginId);
 		}
 
-		for (const pluginId of processed) {
-			await this.refreshAggregates(pluginId);
-		}
-	}
+                for (const pluginId of processed) {
+                        await this.refreshAggregates(pluginId);
+                }
+        }
 
-	async getAgentPlugin(agentId: string, pluginId: string): Promise<AgentPluginRecord | null> {
-		await this.ensureManifestIndex();
-		const [row] = await db
-			.select({
-				pluginId: pluginInstallationTable.pluginId,
+        async getManifestSnapshot(): Promise<PluginManifestSnapshot> {
+                const snapshot = await this.ensureManifestSnapshot();
+                const manifests = snapshot.entries.map((entry) => ({
+                        pluginId: entry.pluginId,
+                        version: entry.version,
+                        manifestDigest: entry.manifestDigest,
+                        artifactHash: entry.artifactHash ?? null,
+                        artifactSizeBytes: entry.artifactSizeBytes ?? null,
+                        approvedAt: entry.approvedAt ?? null,
+                        distribution: { ...entry.distribution }
+                } satisfies PluginManifestDescriptor));
+
+                return { version: snapshot.version, manifests } satisfies PluginManifestSnapshot;
+        }
+
+        async getManifestDelta(state?: AgentPluginManifestState): Promise<PluginManifestDelta> {
+                const snapshot = await this.ensureManifestSnapshot();
+                const knownVersion = state?.version?.trim() ?? '';
+                const knownDigests = state?.digests ?? {};
+
+                if (knownVersion && knownVersion === snapshot.version) {
+                        return { version: snapshot.version, updated: [], removed: [] } satisfies PluginManifestDelta;
+                }
+
+                const serverIndex = new Map(snapshot.entries.map((entry) => [entry.pluginId, entry]));
+                const removed: string[] = [];
+                for (const pluginId of Object.keys(knownDigests)) {
+                        if (!serverIndex.has(pluginId)) {
+                                removed.push(pluginId);
+                        }
+                }
+
+                const updated: PluginManifestDescriptor[] = [];
+                for (const entry of snapshot.entries) {
+                        const digest = knownDigests?.[entry.pluginId];
+                        if (!digest || digest !== entry.manifestDigest) {
+                                updated.push({
+                                        pluginId: entry.pluginId,
+                                        version: entry.version,
+                                        manifestDigest: entry.manifestDigest,
+                                        artifactHash: entry.artifactHash ?? null,
+                                        artifactSizeBytes: entry.artifactSizeBytes ?? null,
+                                        approvedAt: entry.approvedAt ?? null,
+                                        distribution: { ...entry.distribution }
+                                });
+                        }
+                }
+
+                return { version: snapshot.version, updated, removed } satisfies PluginManifestDelta;
+        }
+
+        async getApprovedManifest(
+                pluginId: string
+        ): Promise<{ record: LoadedPluginManifest; descriptor: PluginManifestDescriptor } | null> {
+                const trimmed = pluginId.trim();
+                if (trimmed.length === 0) {
+                        return null;
+                }
+
+                const snapshot = await this.ensureManifestSnapshot();
+                const descriptor = snapshot.entries.find((entry) => entry.pluginId === trimmed);
+                if (!descriptor) {
+                        return null;
+                }
+
+                const record = this.manifestCache.get(trimmed);
+                if (!record) {
+                        return null;
+                }
+
+                return {
+                        record,
+                        descriptor: {
+                                pluginId: descriptor.pluginId,
+                                version: descriptor.version,
+                                manifestDigest: descriptor.manifestDigest,
+                                artifactHash: descriptor.artifactHash ?? null,
+                                artifactSizeBytes: descriptor.artifactSizeBytes ?? null,
+                                approvedAt: descriptor.approvedAt ?? null,
+                                distribution: { ...descriptor.distribution }
+                        }
+                };
+        }
+
+        async getAgentPlugin(agentId: string, pluginId: string): Promise<AgentPluginRecord | null> {
+                await this.ensureManifestIndex();
+                const [row] = await db
+                        .select({
+                                pluginId: pluginInstallationTable.pluginId,
 				agentId: pluginInstallationTable.agentId,
 				status: pluginInstallationTable.status,
 				version: pluginInstallationTable.version,
@@ -377,11 +475,11 @@ export class PluginTelemetryStore {
 		}));
 	}
 
-	async updateAgentPlugin(
-		agentId: string,
-		pluginId: string,
-		patch: Partial<{ enabled: boolean }>
-	): Promise<void> {
+        async updateAgentPlugin(
+                agentId: string,
+                pluginId: string,
+                patch: Partial<{ enabled: boolean }>
+        ): Promise<void> {
 		if (patch.enabled === undefined) {
 			return;
 		}
@@ -413,23 +511,86 @@ export class PluginTelemetryStore {
 				})
 				.onConflictDoNothing();
 		}
-		await this.refreshAggregates(pluginId);
-	}
+                await this.refreshAggregates(pluginId);
+        }
 
-	private async ensureManifestIndex(): Promise<void> {
-		const now = Date.now();
-		if (now - this.manifestLoadedAt < MANIFEST_CACHE_TTL_MS && this.manifestCache.size > 0) {
-			return;
-		}
+        private async ensureManifestSnapshot(): Promise<{
+                version: string;
+                entries: PluginManifestDescriptor[];
+                digests: Map<string, string>;
+        }> {
+                if (!this.manifestSnapshot) {
+                        await this.buildManifestSnapshot();
+                }
 
-		const records = await loadPluginManifests({ directory: this.manifestDirectory });
-		const index = new Map<string, LoadedPluginManifest>();
-		for (const record of records) {
-			index.set(record.manifest.id, record);
-		}
-		this.manifestCache = index;
-		this.manifestLoadedAt = now;
-	}
+                if (!this.manifestSnapshot) {
+                        this.manifestSnapshot = { version: '', entries: [], digests: new Map() };
+                }
+
+                return this.manifestSnapshot;
+        }
+
+        private async buildManifestSnapshot(): Promise<void> {
+                await this.ensureManifestIndex();
+
+                const entries: PluginManifestDescriptor[] = [];
+                for (const record of this.manifestCache.values()) {
+                        if (record.verification.status !== 'trusted') {
+                                continue;
+                        }
+
+                        const runtime = await this.runtimeStore.ensure(record);
+                        if (runtime.approvalStatus !== 'approved') {
+                                continue;
+                        }
+
+                        const digest = computeManifestDigest(record);
+                        const approvedAt = runtime.approvedAt ? runtime.approvedAt.toISOString() : null;
+                        const size =
+                                typeof record.manifest.package.sizeBytes === 'number'
+                                        ? record.manifest.package.sizeBytes
+                                        : null;
+
+                        entries.push({
+                                pluginId: record.manifest.id,
+                                version: record.manifest.version,
+                                manifestDigest: digest,
+                                artifactHash: record.manifest.package.hash ?? null,
+                                artifactSizeBytes: size,
+                                approvedAt,
+                                distribution: {
+                                        defaultMode: record.manifest.distribution.defaultMode,
+                                        autoUpdate: record.manifest.distribution.autoUpdate
+                                }
+                        });
+                }
+
+                entries.sort((a, b) => a.pluginId.localeCompare(b.pluginId));
+
+                const digests = new Map(entries.map((entry) => [entry.pluginId, entry.manifestDigest]));
+                const versionSeed = entries
+                        .map((entry) => `${entry.pluginId}:${entry.manifestDigest}`)
+                        .join('|');
+                const version = createHash('sha256').update(versionSeed, 'utf8').digest('hex');
+
+                this.manifestSnapshot = { version, entries, digests };
+        }
+
+        private async ensureManifestIndex(): Promise<void> {
+                const now = Date.now();
+                if (now - this.manifestLoadedAt < MANIFEST_CACHE_TTL_MS && this.manifestCache.size > 0) {
+                        return;
+                }
+
+                const records = await loadPluginManifests({ directory: this.manifestDirectory });
+                const index = new Map<string, LoadedPluginManifest>();
+                for (const record of records) {
+                        index.set(record.manifest.id, record);
+                }
+                this.manifestCache = index;
+                this.manifestLoadedAt = now;
+                this.manifestSnapshot = null;
+        }
 
 	private async refreshAggregates(pluginId: string): Promise<void> {
 		const [row] = await db

--- a/tenvy-server/src/lib/server/rat/store.ts
+++ b/tenvy-server/src/lib/server/rat/store.ts
@@ -1157,23 +1157,28 @@ export class AgentRegistry {
 		const commands = record.pendingCommands.map((command) => ({ ...command }));
 		record.pendingCommands = [];
 
-		if (payload.plugins?.installations?.length) {
-			await this.pluginTelemetry.syncAgent(
-				record.id,
-				record.metadata,
-				payload.plugins.installations
-			);
-		}
+                if (payload.plugins?.installations?.length) {
+                        await this.pluginTelemetry.syncAgent(
+                                record.id,
+                                record.metadata,
+                                payload.plugins.installations
+                        );
+                }
 
-		this.schedulePersist();
+                const manifestDelta = await this.pluginTelemetry.getManifestDelta(
+                        payload.plugins?.manifests
+                );
 
-		return {
-			agentId: id,
-			commands,
-			config: { ...record.config },
-			serverTime: new Date().toISOString()
-		};
-	}
+                this.schedulePersist();
+
+                return {
+                        agentId: id,
+                        commands,
+                        config: { ...record.config },
+                        serverTime: new Date().toISOString(),
+                        pluginManifests: manifestDelta
+                };
+        }
 
 	queueCommand(
 		id: string,

--- a/tenvy-server/src/routes/api/agents/[id]/plugins/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/plugins/+server.ts
@@ -1,0 +1,28 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { registry, RegistryError } from '$lib/server/rat/store.js';
+import { telemetryStore, getBearerToken } from './_shared.js';
+
+export const GET: RequestHandler = async ({ params, request }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        const token = getBearerToken(request.headers.get('authorization'));
+        if (!token) {
+                throw error(401, 'Missing agent key');
+        }
+
+        try {
+            registry.authorizeAgent(id, token);
+        } catch (err) {
+                if (err instanceof RegistryError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to authorize agent');
+        }
+
+        const snapshot = await telemetryStore.getManifestSnapshot();
+        return json(snapshot);
+};

--- a/tenvy-server/src/routes/api/agents/[id]/plugins/[pluginId]/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/plugins/[pluginId]/+server.ts
@@ -1,0 +1,41 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { registry, RegistryError } from '$lib/server/rat/store.js';
+import { telemetryStore, getBearerToken } from '../_shared.js';
+
+export const GET: RequestHandler = async ({ params, request }) => {
+        const id = params.id;
+        const pluginId = params.pluginId;
+        if (!id || !pluginId) {
+                throw error(400, 'Missing identifiers');
+        }
+
+        const token = getBearerToken(request.headers.get('authorization'));
+        if (!token) {
+                throw error(401, 'Missing agent key');
+        }
+
+        try {
+                registry.authorizeAgent(id, token);
+        } catch (err) {
+                if (err instanceof RegistryError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to authorize agent');
+        }
+
+        const approved = await telemetryStore.getApprovedManifest(pluginId);
+        if (!approved) {
+                throw error(404, 'Plugin manifest not found');
+        }
+
+        const etag = `"${approved.descriptor.manifestDigest}"`;
+
+        return new Response(approved.record.raw, {
+                headers: {
+                        'Content-Type': 'application/json',
+                        'Cache-Control': 'no-store',
+                        ETag: etag
+                }
+        });
+};

--- a/tenvy-server/src/routes/api/agents/[id]/plugins/[pluginId]/artifact/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/plugins/[pluginId]/artifact/+server.ts
@@ -1,0 +1,74 @@
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { dirname, resolve, normalize, isAbsolute, sep } from 'node:path';
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { registry, RegistryError } from '$lib/server/rat/store.js';
+import { telemetryStore, getBearerToken } from '../../_shared.js';
+
+export const GET: RequestHandler = async ({ params, request }) => {
+        const id = params.id;
+        const pluginId = params.pluginId;
+        if (!id || !pluginId) {
+                throw error(400, 'Missing identifiers');
+        }
+
+        const token = getBearerToken(request.headers.get('authorization'));
+        if (!token) {
+                throw error(401, 'Missing agent key');
+        }
+
+        try {
+                registry.authorizeAgent(id, token);
+        } catch (err) {
+                if (err instanceof RegistryError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to authorize agent');
+        }
+
+        const approved = await telemetryStore.getApprovedManifest(pluginId);
+        if (!approved) {
+                throw error(404, 'Plugin artifact not found');
+        }
+
+        const artifactRef = approved.record.manifest.package?.artifact ?? '';
+        const trimmed = artifactRef.trim();
+        if (!trimmed) {
+                throw error(404, 'Plugin artifact not found');
+        }
+
+        const normalized = normalize(trimmed);
+        if (normalized === '' || normalized.startsWith('..') || isAbsolute(normalized)) {
+                throw error(404, 'Plugin artifact not found');
+        }
+
+        const baseDir = dirname(approved.record.source);
+        const artifactPath = resolve(baseDir, normalized);
+        const safeBase = baseDir.endsWith(sep) ? baseDir : `${baseDir}${sep}`;
+        if (!artifactPath.startsWith(safeBase)) {
+                throw error(404, 'Plugin artifact not found');
+        }
+
+        let info: Awaited<ReturnType<typeof stat>>;
+        try {
+                info = await stat(artifactPath);
+        } catch (err) {
+                throw error(404, 'Plugin artifact not found');
+        }
+
+        if (!info.isFile()) {
+                throw error(404, 'Plugin artifact not found');
+        }
+
+        const stream = createReadStream(artifactPath);
+        const headers: Record<string, string> = {
+                'Content-Type': 'application/octet-stream',
+                'Cache-Control': 'no-store'
+        };
+        if (info.size >= 0) {
+                headers['Content-Length'] = info.size.toString();
+        }
+
+        return new Response(stream as unknown as BodyInit, { headers });
+};

--- a/tenvy-server/src/routes/api/agents/[id]/plugins/_shared.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/plugins/_shared.ts
@@ -1,0 +1,11 @@
+import { PluginTelemetryStore } from '$lib/server/plugins/telemetry-store.js';
+
+export const telemetryStore = new PluginTelemetryStore();
+
+export function getBearerToken(header: string | null): string | undefined {
+        if (!header) {
+                return undefined;
+        }
+        const match = header.match(/^Bearer\s+(.+)$/i);
+        return match?.[1]?.trim();
+}

--- a/tenvy-server/tests/agent-plugin-api.test.ts
+++ b/tenvy-server/tests/agent-plugin-api.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { db } from '$lib/server/db/index.js';
+import { plugin as pluginTable } from '$lib/server/db/schema.js';
+import { eq } from 'drizzle-orm';
+
+const mockEnv = { env: {} };
+
+vi.mock('$env/dynamic/private', () => mockEnv, { virtual: true });
+
+const authorizeAgent = vi.fn();
+
+vi.mock('$lib/server/rat/store.js', async () => {
+        const mod = await vi.importActual<typeof import('$lib/server/rat/store.js')>(
+                '$lib/server/rat/store.js'
+        );
+        return {
+                ...mod,
+                registry: {
+                        ...mod.registry,
+                        authorizeAgent
+                },
+                RegistryError: mod.RegistryError
+        };
+});
+
+describe('agent plugin API', () => {
+        let manifestDir: string;
+        let trustPath: string;
+        const manifestId = 'test-plugin';
+        const artifactContent = 'artifact payload';
+
+        beforeEach(async () => {
+                manifestDir = mkdtempSync(join(tmpdir(), 'tenvy-agent-manifests-'));
+                const manifestPath = join(manifestDir, `${manifestId}.json`);
+                const artifactPath = join(manifestDir, 'pkg.zip');
+                writeFileSync(
+                        manifestPath,
+                        JSON.stringify({
+                                id: manifestId,
+                                name: 'Test Plugin',
+                                version: '1.0.0',
+                                entry: 'plugin.exe',
+                                repositoryUrl: 'https://github.com/rootbay/test-plugin',
+                                license: { spdxId: 'MIT' },
+                                requirements: {},
+                                distribution: {
+                                        defaultMode: 'automatic',
+                                        autoUpdate: true,
+                                        signature: { type: 'sha256', hash: 'abc123', signature: 'abc123' }
+                                },
+                                package: { artifact: 'pkg.zip', hash: 'abc123' }
+                        })
+                );
+                writeFileSync(artifactPath, artifactContent);
+
+                trustPath = join(manifestDir, 'trust.json');
+                writeFileSync(trustPath, JSON.stringify({ sha256AllowList: ['abc123'] }));
+
+                process.env.TENVY_PLUGIN_MANIFEST_DIR = manifestDir;
+                process.env.TENVY_PLUGIN_TRUST_CONFIG = trustPath;
+                mockEnv.env = {
+                        TENVY_PLUGIN_MANIFEST_DIR: manifestDir,
+                        TENVY_PLUGIN_TRUST_CONFIG: trustPath
+                };
+
+                authorizeAgent.mockReset();
+        });
+
+        afterEach(async () => {
+                await db.delete(pluginTable);
+                rmSync(manifestDir, { recursive: true, force: true });
+                delete process.env.TENVY_PLUGIN_MANIFEST_DIR;
+                delete process.env.TENVY_PLUGIN_TRUST_CONFIG;
+                mockEnv.env = {};
+        });
+
+        it('returns manifest snapshots and artifacts for authorized agents', async () => {
+                const sharedModule = await import('../src/routes/api/agents/[id]/plugins/_shared.js');
+                const { telemetryStore } = sharedModule;
+                await telemetryStore.getManifestSnapshot();
+                await db
+                        .update(pluginTable)
+                        .set({ approvalStatus: 'approved', approvedAt: new Date() })
+                        .where(eq(pluginTable.id, manifestId));
+                (telemetryStore as { manifestSnapshot?: unknown }).manifestSnapshot = null;
+
+                const listModule = await import('../src/routes/api/agents/[id]/plugins/+server.js');
+                const manifestModule = await import(
+                        '../src/routes/api/agents/[id]/plugins/[pluginId]/+server.js'
+                );
+                const artifactModule = await import(
+                        '../src/routes/api/agents/[id]/plugins/[pluginId]/artifact/+server.js'
+                );
+
+                const requestHeaders = { Authorization: 'Bearer agent-key' };
+
+                const listResponse = await listModule.GET({
+                        params: { id: 'agent-1' },
+                        request: new Request('https://controller.test', { headers: requestHeaders })
+                } as Parameters<typeof listModule.GET>[0]);
+
+                expect(authorizeAgent).toHaveBeenCalledWith('agent-1', 'agent-key');
+
+                const snapshot = (await listResponse.json()) as {
+                        version: string;
+                        manifests: Array<{ pluginId: string; manifestDigest: string }>;
+                };
+                expect(snapshot.manifests[0]?.pluginId).toBe(manifestId);
+
+                const manifestResponse = await manifestModule.GET({
+                        params: { id: 'agent-1', pluginId: manifestId },
+                        request: new Request('https://controller.test', { headers: requestHeaders })
+                } as Parameters<typeof manifestModule.GET>[0]);
+
+                const manifestText = await manifestResponse.text();
+                expect(manifestText).toContain(`"id":"${manifestId}"`);
+
+                const artifactResponse = await artifactModule.GET({
+                        params: { id: 'agent-1', pluginId: manifestId },
+                        request: new Request('https://controller.test', { headers: requestHeaders })
+                } as Parameters<typeof artifactModule.GET>[0]);
+
+                const artifactBuffer = await artifactResponse.arrayBuffer();
+                expect(Buffer.from(artifactBuffer).toString()).toBe(artifactContent);
+        });
+});


### PR DESCRIPTION
## Summary
- add `/api/agents/[id]/plugins` routes that authorize agents and stream approved plugin manifests and artifacts
- extend the telemetry store and shared types to compute manifest snapshots/deltas and expose approved descriptors
- update the Go agent to track manifest state, fetch/stage approved plugins, and adjust remote desktop plugin staging/tests

## Testing
- `go test ./internal/plugins/...`
- `bun test` *(fails: Playwright/Vitest mocks unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fbf53bda74832b8a58ce35a2264554