### PR TITLE
Align plugin telemetry timestamp fields

### DIFF
--- a/shared/pluginmanifest/manifest.go
+++ b/shared/pluginmanifest/manifest.go
@@ -123,13 +123,12 @@ var (
 )
 
 type InstallationTelemetry struct {
-	PluginID       string              `json:"pluginId"`
-	Version        string              `json:"version"`
-	Status         PluginInstallStatus `json:"status"`
-	Hash           string              `json:"hash,omitempty"`
-	LastDeployedAt *string             `json:"lastDeployedAt,omitempty"`
-	LastCheckedAt  *string             `json:"lastCheckedAt,omitempty"`
-	Error          string              `json:"error,omitempty"`
+	PluginID  string              `json:"pluginId"`
+	Version   string              `json:"version"`
+	Status    PluginInstallStatus `json:"status"`
+	Hash      string              `json:"hash,omitempty"`
+	Timestamp *string             `json:"timestamp,omitempty"`
+	Error     string              `json:"error,omitempty"`
 }
 
 type SyncPayload struct {

--- a/shared/types/plugin-manifest.ts
+++ b/shared/types/plugin-manifest.ts
@@ -108,8 +108,7 @@ export interface PluginInstallationTelemetry {
   version: string;
   status: PluginInstallStatus;
   hash?: string;
-  lastDeployedAt?: string | null;
-  lastCheckedAt?: string | null;
+  timestamp?: string | null;
   error?: string;
 }
 

--- a/tenvy-client/internal/plugins/status.go
+++ b/tenvy-client/internal/plugins/status.go
@@ -15,11 +15,11 @@ import (
 const statusFileName = ".status.json"
 
 type installationStatusRecord struct {
-	ID            string                       `json:"pluginId,omitempty"`
-	Version       string                       `json:"version,omitempty"`
-	Status        manifest.PluginInstallStatus `json:"status,omitempty"`
-	Error         string                       `json:"error,omitempty"`
-	LastCheckedAt string                       `json:"lastCheckedAt,omitempty"`
+	ID        string                       `json:"pluginId,omitempty"`
+	Version   string                       `json:"version,omitempty"`
+	Status    manifest.PluginInstallStatus `json:"status,omitempty"`
+	Error     string                       `json:"error,omitempty"`
+	Timestamp string                       `json:"timestamp,omitempty"`
 }
 
 func (r *installationStatusRecord) PluginID(defaultID string) string {
@@ -100,11 +100,11 @@ func (m *Manager) recordInstallStatusLocked(pluginID, version string, status man
 	dir := filepath.Join(m.root, pluginID)
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 	record := installationStatusRecord{
-		ID:            pluginID,
-		Version:       strings.TrimSpace(version),
-		Status:        status,
-		Error:         strings.TrimSpace(message),
-		LastCheckedAt: now,
+		ID:        pluginID,
+		Version:   strings.TrimSpace(version),
+		Status:    status,
+		Error:     strings.TrimSpace(message),
+		Timestamp: now,
 	}
 	return writeInstallationStatus(dir, record)
 }

--- a/tenvy-server/src/lib/server/plugins/telemetry-store.test.ts
+++ b/tenvy-server/src/lib/server/plugins/telemetry-store.test.ts
@@ -143,8 +143,7 @@ describe('PluginTelemetryStore', () => {
 				version: '1.0.0',
 				status: 'installed',
 				hash: 'abc123',
-				lastDeployedAt: now,
-				lastCheckedAt: now,
+				timestamp: now,
 				error: null
 			}
 		]);
@@ -179,8 +178,7 @@ describe('PluginTelemetryStore', () => {
 				version: '1.0.0',
 				status: 'installed',
 				hash: 'deadbeef',
-				lastDeployedAt: now,
-				lastCheckedAt: now,
+				timestamp: now,
 				error: null
 			}
 		]);
@@ -220,8 +218,7 @@ describe('PluginTelemetryStore', () => {
 				version: '1.0.0',
 				status: 'installed',
 				hash: 'abc123',
-				lastDeployedAt: now,
-				lastCheckedAt: now,
+				timestamp: now,
 				error: null
 			}
 		]);

--- a/tenvy-server/src/lib/server/plugins/telemetry-store.ts
+++ b/tenvy-server/src/lib/server/plugins/telemetry-store.ts
@@ -257,8 +257,9 @@ export class PluginTelemetryStore {
 				}
 			}
 
-			const lastDeployedAt = toDate(installation.lastDeployedAt);
-			const lastCheckedAt = toDate(installation.lastCheckedAt) ?? now;
+			const observedAt = toDate(installation.timestamp) ?? now;
+			const lastDeployedAt = installation.status === 'installed' ? observedAt : null;
+			const lastCheckedAt = observedAt;
 			const payload = {
 				pluginId: installation.pluginId,
 				agentId,


### PR DESCRIPTION
## Summary
- replace the lastDeployedAt/lastCheckedAt fields in PluginInstallationTelemetry with the documented timestamp property across Go and TypeScript definitions
- update the Go plugin manager and status persistence to emit the unified timestamp while preserving hash/status overrides
- adjust the server telemetry ingestion and tests to consume timestamp, deriving lastDeployedAt/lastCheckedAt from the new value

## Testing
- go test ./... *(fails: command cancelled after hanging during module compilation)*
- bun test tests/plugins-repository.test.ts *(fails: cannot resolve $env/dynamic/private in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fc6fa9aee4832b896deb014ea43ff6