### PR TITLE
Add HTTP loader bootstrap configuration and tests

### DIFF
--- a/tenvy-client/cmd/bootstrap_config.go
+++ b/tenvy-client/cmd/bootstrap_config.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type bootstrapConfig struct {
+	Controller controllerConfig `json:"controller"`
+	Loader     loaderConfig     `json:"loader"`
+}
+
+type controllerConfig struct {
+	BaseURL string `json:"baseUrl"`
+}
+
+type loaderConfig struct {
+	Version      string `json:"version"`
+	Checksum     string `json:"checksum"`
+	Signature    string `json:"signature"`
+	Executable   string `json:"executable"`
+	ArtifactURL  string `json:"artifactUrl"`
+	ArtifactType string `json:"artifactType"`
+	Mode         string `json:"mode"`
+}
+
+var defaultBootstrapConfigEncoded = ""
+
+func loadBootstrapConfig(logger *log.Logger, stubPath string) (*bootstrapConfig, error) {
+	if override := strings.TrimSpace(os.Getenv("TENVY_BOOTSTRAP_CONFIG")); override != "" {
+		return readBootstrapConfigFromFile(override)
+	}
+
+	if stubPath != "" {
+		diskPath := filepath.Join(filepath.Dir(stubPath), "tenvy-bootstrap.json")
+		if cfg, err := readBootstrapConfigFromFile(diskPath); err == nil {
+			return cfg, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+	}
+
+	encoded := strings.TrimSpace(defaultBootstrapConfigEncoded)
+	if encoded == "" {
+		return nil, errors.New("bootstrap configuration unavailable")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		if logger != nil {
+			logger.Printf("embedded bootstrap config invalid: %v", err)
+		}
+		return nil, errors.New("bootstrap configuration unavailable")
+	}
+	return parseBootstrapConfig(decoded)
+}
+
+func readBootstrapConfigFromFile(path string) (*bootstrapConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := parseBootstrapConfig(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse bootstrap config %q: %w", path, err)
+	}
+	return cfg, nil
+}
+
+func parseBootstrapConfig(data []byte) (*bootstrapConfig, error) {
+	var cfg bootstrapConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("decode bootstrap config: %w", err)
+	}
+	cfg.Controller.BaseURL = strings.TrimSpace(cfg.Controller.BaseURL)
+	if cfg.Controller.BaseURL == "" {
+		return nil, errors.New("controller.baseUrl is required")
+	}
+	base, err := url.Parse(cfg.Controller.BaseURL)
+	if err != nil || !base.IsAbs() || base.Host == "" {
+		return nil, fmt.Errorf("controller.baseUrl invalid: %v", err)
+	}
+
+	cfg.Loader.Version = strings.TrimSpace(cfg.Loader.Version)
+	cfg.Loader.Checksum = strings.TrimSpace(cfg.Loader.Checksum)
+	cfg.Loader.Signature = strings.TrimSpace(cfg.Loader.Signature)
+	cfg.Loader.Executable = strings.TrimSpace(cfg.Loader.Executable)
+	cfg.Loader.ArtifactURL = strings.TrimSpace(cfg.Loader.ArtifactURL)
+	cfg.Loader.ArtifactType = strings.ToLower(strings.TrimSpace(cfg.Loader.ArtifactType))
+	cfg.Loader.Mode = strings.TrimSpace(cfg.Loader.Mode)
+
+	if cfg.Loader.ArtifactURL == "" {
+		return nil, errors.New("loader.artifactUrl is required")
+	}
+	if _, err := url.Parse(cfg.Loader.ArtifactURL); err != nil {
+		return nil, fmt.Errorf("loader.artifactUrl invalid: %v", err)
+	}
+	return &cfg, nil
+}
+
+func (l loaderConfig) resolvedArtifactURL(base string) (string, error) {
+	parsedBase, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parse base url: %w", err)
+	}
+	artifact, err := url.Parse(l.ArtifactURL)
+	if err != nil {
+		return "", fmt.Errorf("parse artifact url: %w", err)
+	}
+	if artifact.IsAbs() {
+		if artifact.Scheme == "" || artifact.Host == "" {
+			return "", errors.New("loader artifact url missing scheme or host")
+		}
+		return artifact.String(), nil
+	}
+	resolved := parsedBase.ResolveReference(artifact)
+	return resolved.String(), nil
+}
+
+func (l loaderConfig) parsedMode() (os.FileMode, error) {
+	trimmed := strings.TrimSpace(l.Mode)
+	if trimmed == "" {
+		return 0, nil
+	}
+	value, err := strconv.ParseUint(trimmed, 0, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse loader mode: %w", err)
+	}
+	return os.FileMode(value), nil
+}

--- a/tenvy-client/internal/bootstrap/http_downloader.go
+++ b/tenvy-client/internal/bootstrap/http_downloader.go
@@ -1,0 +1,90 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// HTTPDownloaderConfig configures the HTTP-based loader downloader.
+type HTTPDownloaderConfig struct {
+	// Client is the HTTP client used for requests. When nil, http.DefaultClient is used.
+	Client *http.Client
+	// URL is the absolute URL of the loader artifact.
+	URL string
+	// ArtifactType indicates whether the remote payload is a zip archive or raw binary.
+	ArtifactType LoaderArtifactType
+	// Mode specifies the filesystem mode to apply to binary payloads. A zero value
+	// defers to the installer defaults.
+	Mode fs.FileMode
+}
+
+// LoaderArtifactType enumerates supported artifact encodings.
+type LoaderArtifactType string
+
+const (
+	// LoaderArtifactTypeBinary indicates the remote payload is a single executable.
+	LoaderArtifactTypeBinary LoaderArtifactType = "binary"
+	// LoaderArtifactTypeArchive indicates the remote payload is a zip archive containing the loader files.
+	LoaderArtifactTypeArchive LoaderArtifactType = "zip"
+)
+
+// NewHTTPDownloader constructs a LoaderDownloader implementation that retrieves the loader
+// artifact over HTTP based on the provided configuration.
+func NewHTTPDownloader(cfg HTTPDownloaderConfig) (LoaderDownloader, error) {
+	trimmedURL := strings.TrimSpace(cfg.URL)
+	if trimmedURL == "" {
+		return nil, errors.New("loader downloader requires url")
+	}
+	artifactType := cfg.ArtifactType
+	if artifactType == "" {
+		artifactType = LoaderArtifactTypeBinary
+	}
+	switch artifactType {
+	case LoaderArtifactTypeBinary, LoaderArtifactTypeArchive:
+		// supported
+	default:
+		return nil, fmt.Errorf("unsupported loader artifact type: %s", artifactType)
+	}
+	client := cfg.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return LoaderDownloaderFunc(func(ctx context.Context, metadata LoaderMetadata) (LoaderPackage, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, trimmedURL, nil)
+		if err != nil {
+			return LoaderPackage{}, fmt.Errorf("build loader request: %w", err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return LoaderPackage{}, fmt.Errorf("fetch loader: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return LoaderPackage{}, fmt.Errorf("fetch loader: unexpected status %d", resp.StatusCode)
+		}
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return LoaderPackage{}, fmt.Errorf("read loader: %w", err)
+		}
+		pkg := LoaderPackage{}
+		switch artifactType {
+		case LoaderArtifactTypeArchive:
+			pkg.Archive = data
+		case LoaderArtifactTypeBinary:
+			pkg.Binary = data
+			pkg.Mode = cfg.Mode
+		}
+		return pkg, nil
+	}), nil
+}
+
+// DefaultHTTPClient returns an HTTP client tuned for loader downloads.
+func DefaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: 60 * time.Second}
+}

--- a/tenvy-client/internal/bootstrap/loader_signature.go
+++ b/tenvy-client/internal/bootstrap/loader_signature.go
@@ -1,0 +1,114 @@
+package bootstrap
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+type loaderSignature struct {
+	Algorithm string `json:"algorithm"`
+	PublicKey string `json:"publicKey,omitempty"`
+	Signature string `json:"signature"`
+}
+
+// NewLoaderSignatureVerifier constructs a LoaderSignatureVerifier that understands
+// SHA-256 and Ed25519 signatures encoded within LoaderMetadata.Signature.
+func NewLoaderSignatureVerifier() LoaderSignatureVerifier {
+	return LoaderSignatureVerifierFunc(func(ctx context.Context, loaderPath string, metadata LoaderMetadata) error {
+		parsed, err := parseLoaderSignature(metadata.Signature)
+		if err != nil {
+			return err
+		}
+		if parsed == nil {
+			return nil
+		}
+		digest, err := computeFileSHA256(loaderPath)
+		if err != nil {
+			return fmt.Errorf("compute loader digest: %w", err)
+		}
+		switch parsed.Algorithm {
+		case "", "sha256":
+			if !strings.EqualFold(digest, parsed.Signature) {
+				return fmt.Errorf("loader signature mismatch: expected %s, got %s", parsed.Signature, digest)
+			}
+			return nil
+		case "ed25519":
+			publicKeyBytes, err := hex.DecodeString(strings.TrimSpace(parsed.PublicKey))
+			if err != nil {
+				return fmt.Errorf("loader signature: invalid public key: %w", err)
+			}
+			if len(publicKeyBytes) != ed25519.PublicKeySize {
+				return fmt.Errorf("loader signature: unexpected public key length %d", len(publicKeyBytes))
+			}
+			signatureBytes, err := hex.DecodeString(strings.TrimSpace(parsed.Signature))
+			if err != nil {
+				return fmt.Errorf("loader signature: invalid signature encoding: %w", err)
+			}
+			if len(signatureBytes) != ed25519.SignatureSize {
+				return fmt.Errorf("loader signature: unexpected signature length %d", len(signatureBytes))
+			}
+			if !ed25519.Verify(ed25519.PublicKey(publicKeyBytes), []byte(strings.ToLower(digest)), signatureBytes) {
+				return errors.New("loader signature verification failed")
+			}
+			return nil
+		default:
+			return fmt.Errorf("unsupported loader signature algorithm: %s", parsed.Algorithm)
+		}
+	})
+}
+
+func computeFileSHA256(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	hasher := sha256.New()
+	if _, err := io.Copy(hasher, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func parseLoaderSignature(raw string) (*loaderSignature, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	var payload loaderSignature
+	if strings.HasPrefix(trimmed, "{") {
+		if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
+			return nil, fmt.Errorf("decode loader signature: %w", err)
+		}
+		payload.Algorithm = strings.ToLower(strings.TrimSpace(payload.Algorithm))
+		payload.Signature = strings.TrimSpace(payload.Signature)
+		payload.PublicKey = strings.TrimSpace(payload.PublicKey)
+	} else {
+		parts := strings.Split(trimmed, ":")
+		switch len(parts) {
+		case 1:
+			payload = loaderSignature{Algorithm: "sha256", Signature: strings.TrimSpace(parts[0])}
+		case 2:
+			payload = loaderSignature{Algorithm: strings.ToLower(strings.TrimSpace(parts[0])), Signature: strings.TrimSpace(parts[1])}
+		case 3:
+			payload = loaderSignature{Algorithm: strings.ToLower(strings.TrimSpace(parts[0])), PublicKey: strings.TrimSpace(parts[1]), Signature: strings.TrimSpace(parts[2])}
+		default:
+			return nil, errors.New("invalid loader signature format")
+		}
+	}
+	if payload.Signature == "" {
+		return nil, errors.New("loader signature missing signature value")
+	}
+	if payload.Algorithm == "ed25519" && strings.TrimSpace(payload.PublicKey) == "" {
+		return nil, errors.New("loader signature public key required for ed25519")
+	}
+	return &payload, nil
+}


### PR DESCRIPTION
## Summary
- load the controller-provided bootstrap manifest to set desired loader metadata, downloader, and signature verifier
- add reusable HTTP downloader and signature verifier helpers for the loader bootstrap path
- extend bootstrap tests to cover HTTP downloads and signature verification scenarios

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fc82dc08f0832b84ae9a651a61a204