### PR TITLE
Align plugin manifest schema with simplified signature contract

### DIFF
--- a/shared/pluginmanifest/verify_test.go
+++ b/shared/pluginmanifest/verify_test.go
@@ -12,9 +12,7 @@ func TestVerifySignatureSHA256AllowList(t *testing.T) {
 	manifest := Manifest{
 		Distribution: Distribution{
 			Signature: Signature{
-				Type:      SignatureSHA256,
-				Hash:      "abcdef",
-				Signature: "ignored",
+				Type: SignatureSHA256,
 			},
 		},
 		Package: PackageDescriptor{Hash: "abcdef"},
@@ -36,9 +34,7 @@ func TestVerifySignatureSHA256Disallowed(t *testing.T) {
 	manifest := Manifest{
 		Distribution: Distribution{
 			Signature: Signature{
-				Type:      SignatureSHA256,
-				Hash:      "abcdef",
-				Signature: "ignored",
+				Type: SignatureSHA256,
 			},
 		},
 		Package: PackageDescriptor{Hash: "abcdef"},
@@ -46,6 +42,34 @@ func TestVerifySignatureSHA256Disallowed(t *testing.T) {
 
 	if _, err := VerifySignature(manifest, VerifyOptions{SHA256AllowList: []string{"123456"}}); err != ErrHashNotAllowed {
 		t.Fatalf("expected ErrHashNotAllowed, got %v", err)
+	}
+}
+
+func TestVerifySignatureHashMismatch(t *testing.T) {
+	manifest := Manifest{
+		Distribution: Distribution{
+			Signature: Signature{
+				Type: SignatureSHA256,
+				Hash: "123456",
+			},
+		},
+		Package: PackageDescriptor{Hash: "abcdef"},
+	}
+
+	if _, err := VerifySignature(manifest, VerifyOptions{}); err != ErrSignatureMismatch {
+		t.Fatalf("expected ErrSignatureMismatch, got %v", err)
+	}
+}
+
+func TestVerifySignatureMissingPackageHash(t *testing.T) {
+	manifest := Manifest{
+		Distribution: Distribution{
+			Signature: Signature{Type: SignatureSHA256},
+		},
+	}
+
+	if _, err := VerifySignature(manifest, VerifyOptions{}); err == nil {
+		t.Fatalf("expected error when package hash missing")
 	}
 }
 

--- a/tenvy-client/internal/agent/remote_desktop_integration_test.go
+++ b/tenvy-client/internal/agent/remote_desktop_integration_test.go
@@ -45,7 +45,7 @@ func TestRemoteDesktopModuleNegotiationWithManagedEngine(t *testing.T) {
 			"remote-desktop.transport.quic",
 			"remote-desktop.codec.hevc",
 		},
-		License: manifest.LicenseInfo{SPDXID: "MIT"},
+		License: &manifest.LicenseInfo{SPDXID: "MIT"},
 		Requirements: manifest.Requirements{
 			MinAgentVersion: "0.1.0",
 			RequiredModules: []string{"remote-desktop"},

--- a/tenvy-server/src/lib/components/plugins/MarketplaceGrid.svelte.test.ts
+++ b/tenvy-server/src/lib/components/plugins/MarketplaceGrid.svelte.test.ts
@@ -38,11 +38,11 @@ const baseListing: MarketplaceListing = {
 		categories: [],
 		capabilities: [],
 		requirements: {},
-		distribution: {
-			defaultMode: 'manual',
-			autoUpdate: false,
-			signature: { type: 'none' }
-		},
+                distribution: {
+                        defaultMode: 'manual',
+                        autoUpdate: false,
+                        signature: 'sha256'
+                },
 		package: { artifact: 'plugin.zip' }
 	},
 	submittedBy: 'author-1',

--- a/tenvy-server/src/lib/server/plugins/runtime-store.test.ts
+++ b/tenvy-server/src/lib/server/plugins/runtime-store.test.ts
@@ -65,11 +65,7 @@ const baseManifest: PluginManifest = {
         distribution: {
                 defaultMode: 'automatic',
                 autoUpdate: true,
-                signature: {
-                        type: 'sha256',
-                        hash: '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff',
-                        signature: 'ffeeddccbbaa99887766554433221100'
-                }
+                signature: 'sha256'
         },
         package: {
                 artifact: 'runtime-test.dll',
@@ -82,7 +78,7 @@ const baseVerification: PluginSignatureVerificationSummary = {
         trusted: false,
         signatureType: 'sha256',
         status: 'untrusted',
-        hash: baseManifest.distribution.signature.hash,
+        hash: baseManifest.package.hash,
         signer: null,
         publicKey: null,
         certificateChain: undefined,

--- a/tenvy-server/src/routes/api/marketplace/plugins/+server.ts
+++ b/tenvy-server/src/routes/api/marketplace/plugins/+server.ts
@@ -27,13 +27,17 @@ interface GitHubRepositoryCoordinates {
 }
 
 const resolveRepository = (manifest: PluginManifest): GitHubRepositoryCoordinates => {
-	try {
-		const parsed = new URL(manifest.repositoryUrl);
-		const segments = parsed.pathname.split('/').filter(Boolean);
-		if (segments.length < 2) throw new Error('missing owner or repository segment');
-		const owner = segments[0];
-		const repo = segments[1].replace(/\.git$/i, '');
-		return { owner, repo };
+        const repoUrl = manifest.repositoryUrl?.trim();
+        if (!repoUrl) {
+                throw error(400, 'Repository URL is required for marketplace submissions');
+        }
+        try {
+                const parsed = new URL(repoUrl);
+                const segments = parsed.pathname.split('/').filter(Boolean);
+                if (segments.length < 2) throw new Error('missing owner or repository segment');
+                const owner = segments[0];
+                const repo = segments[1].replace(/\.git$/i, '');
+                return { owner, repo };
 	} catch (cause) {
 		throw error(400, `Invalid GitHub repository URL: ${(cause as Error).message}`);
 	}
@@ -65,15 +69,18 @@ const ensureRepositoryMetadata = async (manifest: PluginManifest) => {
 
 	const repoLicense = typeof repoData.license === 'object' ? repoData.license : null;
 	const repoSpdx = typeof repoLicense?.spdx_id === 'string' ? repoLicense.spdx_id : '';
-	if (
-		manifest.license.spdxId.trim().toLowerCase() !== repoSpdx.trim().toLowerCase() &&
-		repoSpdx.trim().toLowerCase() !== 'noassertion'
-	) {
-		throw error(
-			400,
-			`Repository license mismatch. Expected ${manifest.license.spdxId}, received ${repoSpdx || 'unknown'}`
-		);
-	}
+        const manifestSpdx = manifest.license?.spdxId?.trim().toLowerCase() ?? '';
+        const normalizedRepoSpdx = repoSpdx.trim().toLowerCase();
+        if (
+                manifestSpdx &&
+                manifestSpdx !== normalizedRepoSpdx &&
+                normalizedRepoSpdx !== 'noassertion'
+        ) {
+                throw error(
+                        400,
+                        `Repository license mismatch. Expected ${manifest.license?.spdxId ?? 'unknown'}, received ${repoSpdx || 'unknown'}`
+                );
+        }
 
 	const release = await fetchGitHub(
 		`/repos/${owner}/${repo}/releases/tags/v${manifest.version}`

--- a/tenvy-server/tests/agent-plugin-api.test.ts
+++ b/tenvy-server/tests/agent-plugin-api.test.ts
@@ -52,7 +52,7 @@ describe('agent plugin API', () => {
                                 distribution: {
                                         defaultMode: 'automatic',
                                         autoUpdate: true,
-                                        signature: { type: 'sha256', hash: 'abc123', signature: 'abc123' }
+                                        signature: 'sha256'
                                 },
                                 package: { artifact: 'pkg.zip', hash: 'abc123' }
                         })

--- a/tenvy-server/tests/plugin-manifest-signature.test.ts
+++ b/tenvy-server/tests/plugin-manifest-signature.test.ts
@@ -22,15 +22,11 @@ describe('verifyPluginSignature', () => {
 			repositoryUrl: 'https://github.com/rootbay/demo',
 			license: { spdxId: 'MIT' },
 			requirements: {},
-			distribution: {
-				defaultMode: 'manual',
-				autoUpdate: false,
-				signature: {
-					type: 'sha256',
-					hash: 'abcdef',
-					signature: 'ignored'
-				}
-			},
+                distribution: {
+                        defaultMode: 'manual',
+                        autoUpdate: false,
+                        signature: 'sha256'
+                },
 			package: {
 				artifact: 'demo.dll',
 				hash: 'abcdef'
@@ -54,15 +50,11 @@ describe('verifyPluginSignature', () => {
 			repositoryUrl: 'https://github.com/rootbay/demo',
 			license: { spdxId: 'MIT' },
 			requirements: {},
-			distribution: {
-				defaultMode: 'manual',
-				autoUpdate: false,
-				signature: {
-					type: 'sha256',
-					hash: 'abcdef',
-					signature: 'ignored'
-				}
-			},
+                distribution: {
+                        defaultMode: 'manual',
+                        autoUpdate: false,
+                        signature: 'sha256'
+                },
 			package: {
 				artifact: 'demo.dll',
 				hash: 'abcdef'
@@ -126,11 +118,11 @@ describe('verifyPluginSignature', () => {
 		expect(validated).toBe(true);
 	});
 
-	it('rejects unknown ed25519 signers', async () => {
-		const manifest: PluginManifest = {
-			id: 'demo',
-			name: 'Demo',
-			version: '1.0.0',
+        it('rejects unknown ed25519 signers', async () => {
+                const manifest: PluginManifest = {
+                        id: 'demo',
+                        name: 'Demo',
+                        version: '1.0.0',
 			entry: 'demo.dll',
 			repositoryUrl: 'https://github.com/rootbay/demo',
 			license: { spdxId: 'MIT' },
@@ -151,8 +143,33 @@ describe('verifyPluginSignature', () => {
 			}
 		};
 
-		await expect(verifyPluginSignature(manifest)).rejects.toMatchObject({
-			code: 'UNTRUSTED_SIGNER'
-		});
-	});
+                await expect(verifyPluginSignature(manifest)).rejects.toMatchObject({
+                        code: 'UNTRUSTED_SIGNER'
+                });
+        });
+
+        it('rejects ed25519 manifests that omit legacy metadata', async () => {
+                const manifest: PluginManifest = {
+                        id: 'demo',
+                        name: 'Demo',
+                        version: '1.0.0',
+                        entry: 'demo.dll',
+                        repositoryUrl: 'https://github.com/rootbay/demo',
+                        license: { spdxId: 'MIT' },
+                        requirements: {},
+                        distribution: {
+                                defaultMode: 'manual',
+                                autoUpdate: false,
+                                signature: 'ed25519'
+                        },
+                        package: {
+                                artifact: 'demo.dll',
+                                hash: 'abcdef'
+                        }
+                };
+
+                await expect(verifyPluginSignature(manifest)).rejects.toMatchObject({
+                        code: 'UNTRUSTED_SIGNER'
+                });
+        });
 });

--- a/tenvy-server/tests/plugin-manifests.test.ts
+++ b/tenvy-server/tests/plugin-manifests.test.ts
@@ -37,11 +37,7 @@ describe('loadPluginManifests', () => {
                         distribution: {
                                 defaultMode: 'manual',
                                 autoUpdate: false,
-                                signature: {
-                                        type: 'sha256',
-                                        hash: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-                                        signature: 'fedcba9876543210fedcba9876543210'
-                                }
+                                signature: 'sha256'
                         },
                         requirements: {
                                 platforms: ['windows'],


### PR DESCRIPTION
## Summary
- Relax the Go manifest schema by making repository and license metadata optional, teaching signature parsing to accept enum strings, and relying on package hashes for verification.
- Update the shared TypeScript manifest definitions and verifiers to resolve legacy signature objects, validate only the documented fields, and surface normalized signature data to callers.
- Adjust marketplace and telemetry helpers plus associated tests to consume the new helpers while keeping compatibility with manifests that still ship legacy signature metadata.

## Testing
- `go test ./...` (from `shared/pluginmanifest`) 
- `npm run test:unit -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68fc86b6d268832ba6015d4e5d9b3362