### PR TITLE
Align plugin install statuses with documented values

### DIFF
--- a/shared/pluginmanifest/manifest.go
+++ b/shared/pluginmanifest/manifest.go
@@ -135,11 +135,10 @@ const (
 	ArchitectureX8664 PluginArchitecture = "x86_64"
 	ArchitectureARM64 PluginArchitecture = "arm64"
 
-	InstallPending    PluginInstallStatus = "pending"
-	InstallInstalling PluginInstallStatus = "installing"
-	InstallInstalled  PluginInstallStatus = "installed"
-	InstallFailed     PluginInstallStatus = "failed"
-	InstallBlocked    PluginInstallStatus = "blocked"
+	InstallInstalled PluginInstallStatus = "installed"
+	InstallBlocked   PluginInstallStatus = "blocked"
+	InstallError     PluginInstallStatus = "error"
+	InstallDisabled  PluginInstallStatus = "disabled"
 
 	ApprovalPending  PluginApprovalStatus = "pending"
 	ApprovalApproved PluginApprovalStatus = "approved"
@@ -151,7 +150,7 @@ var (
 	knownSignatureTypes = []SignatureType{SignatureSHA256, SignatureEd25519}
 	knownPlatforms      = []PluginPlatform{PlatformWindows, PlatformLinux, PlatformMacOS}
 	knownArchitectures  = []PluginArchitecture{ArchitectureX8664, ArchitectureARM64}
-	knownInstallStates  = []PluginInstallStatus{InstallPending, InstallInstalling, InstallInstalled, InstallFailed, InstallBlocked}
+	knownInstallStates  = []PluginInstallStatus{InstallBlocked, InstallDisabled, InstallError, InstallInstalled}
 	knownApprovalStates = []PluginApprovalStatus{ApprovalPending, ApprovalApproved, ApprovalRejected}
 	semverPattern       = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$`)
 	registeredModules   = map[string]struct{}{

--- a/shared/types/plugin-manifest.ts
+++ b/shared/types/plugin-manifest.ts
@@ -22,11 +22,10 @@ export const pluginArchitectures = ["x86_64", "arm64"] as const;
 export type PluginArchitecture = (typeof pluginArchitectures)[number];
 
 export const pluginInstallStatuses = [
-  "pending",
-  "installing",
   "installed",
-  "failed",
   "blocked",
+  "error",
+  "disabled",
 ] as const;
 export type PluginInstallStatus = (typeof pluginInstallStatuses)[number];
 

--- a/tenvy-client/internal/plugins/engines/remotedesktop/external.go
+++ b/tenvy-client/internal/plugins/engines/remotedesktop/external.go
@@ -278,19 +278,19 @@ func (p *engineProcess) ensureStartedLocked() error {
 
 	if strings.TrimSpace(p.path) == "" {
 		message := "engine entry path not configured"
-		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallFailed, message)
+		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallError, message)
 		return errors.New(message)
 	}
 
 	info, err := os.Stat(p.path)
 	if err != nil {
 		message := fmt.Sprintf("engine binary unavailable: %v", err)
-		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallFailed, message)
+		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallError, message)
 		return errors.New(message)
 	}
 	if info.IsDir() {
 		message := "engine entry path resolves to a directory"
-		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallFailed, message)
+		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallError, message)
 		return errors.New(message)
 	}
 
@@ -301,7 +301,7 @@ func (p *engineProcess) ensureStartedLocked() error {
 	if err != nil {
 		cancel()
 		message := fmt.Sprintf("engine stdin pipe: %v", err)
-		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallFailed, message)
+		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallError, message)
 		return errors.New(message)
 	}
 	stdout, err := cmd.StdoutPipe()
@@ -309,7 +309,7 @@ func (p *engineProcess) ensureStartedLocked() error {
 		stdin.Close()
 		cancel()
 		message := fmt.Sprintf("engine stdout pipe: %v", err)
-		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallFailed, message)
+		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallError, message)
 		return errors.New(message)
 	}
 	stderr, err := cmd.StderrPipe()
@@ -318,7 +318,7 @@ func (p *engineProcess) ensureStartedLocked() error {
 		stdout.Close()
 		cancel()
 		message := fmt.Sprintf("engine stderr pipe: %v", err)
-		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallFailed, message)
+		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallError, message)
 		return errors.New(message)
 	}
 
@@ -328,7 +328,7 @@ func (p *engineProcess) ensureStartedLocked() error {
 		stderr.Close()
 		cancel()
 		message := fmt.Sprintf("engine launch failed: %v", err)
-		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallFailed, message)
+		plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, p.version, manifest.InstallError, message)
 		return fmt.Errorf("remote desktop engine launch: %w", err)
 	}
 
@@ -428,7 +428,7 @@ func (p *engineProcess) wait(cmd *exec.Cmd) {
 		message = fmt.Sprintf("%s; output: %s", message, output)
 	}
 
-	plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, version, manifest.InstallFailed, message)
+	plugins.RecordInstallStatus(p.manager, plugins.RemoteDesktopEnginePluginID, version, manifest.InstallError, message)
 	if logger != nil {
 		logger.Printf("remote desktop engine: %s", message)
 	}

--- a/tenvy-client/internal/plugins/remotedesktop_test.go
+++ b/tenvy-client/internal/plugins/remotedesktop_test.go
@@ -157,7 +157,7 @@ func TestStageRemoteDesktopEngineRecordsFailure(t *testing.T) {
 		t.Fatalf("expected failure snapshot entry, got %#v", snapshot)
 	}
 	install := snapshot.Installations[0]
-	if install.Status != manifest.InstallFailed {
+	if install.Status != manifest.InstallError {
 		t.Fatalf("expected failure status, got %s", install.Status)
 	}
 	if !strings.Contains(install.Error, "boom") {


### PR DESCRIPTION
## Summary
- replace plugin install status enums in Go and TypeScript with the documented set of installed, blocked, error, and disabled
- normalize persisted plugin statuses and map manager and staging flows onto the new enum, including disabled overrides
- extend plugin manager tests to verify telemetry snapshots only emit documented statuses

## Testing
- go test ./... (from tenvy-client)


------
https://chatgpt.com/codex/tasks/task_e_68fc8ae49f64832b9b35f0b519795144