### PR TITLE
Handle plugin manifest removal for remote desktop engine

### DIFF
--- a/tenvy-client/internal/agent/plugins_sync_test.go
+++ b/tenvy-client/internal/agent/plugins_sync_test.go
@@ -1,0 +1,156 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	remotedesktop "github.com/rootbay/tenvy-client/internal/modules/control/remotedesktop"
+	"github.com/rootbay/tenvy-client/internal/plugins"
+	"github.com/rootbay/tenvy-client/internal/protocol"
+	manifest "github.com/rootbay/tenvy-client/shared/pluginmanifest"
+)
+
+func TestApplyPluginManifestDeltaRemovesRemoteDesktopPlugin(t *testing.T) {
+	t.Parallel()
+
+	pluginRoot := t.TempDir()
+	manager, err := plugins.NewManager(pluginRoot, log.New(io.Discard, "", 0), manifest.VerifyOptions{})
+	if err != nil {
+		t.Fatalf("new plugin manager: %v", err)
+	}
+
+	stagedDir := filepath.Join(manager.Root(), plugins.RemoteDesktopEnginePluginID)
+	if err := os.MkdirAll(stagedDir, 0o755); err != nil {
+		t.Fatalf("create plugin dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stagedDir, "manifest.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stagedDir, ".status.json"), []byte(`{"status":"installed"}`), 0o644); err != nil {
+		t.Fatalf("write status: %v", err)
+	}
+
+	agent := &Agent{
+		id:       "agent-1",
+		plugins:  manager,
+		modules:  newDefaultModuleManager(),
+		logger:   log.New(io.Discard, "", 0),
+		metadata: protocol.AgentMetadata{OS: "windows", Architecture: "amd64", Version: "1.0.0"},
+	}
+	agent.setPluginManifestList(&manifest.ManifestList{
+		Version: "1",
+		Manifests: []manifest.ManifestDescriptor{
+			{
+				PluginID:       plugins.RemoteDesktopEnginePluginID,
+				ManifestDigest: "digest-1",
+				Version:        "1.0.0",
+			},
+		},
+	})
+
+	if err := agent.modules.RegisterModuleExtension("remote-desktop", ModuleExtension{
+		Source:  plugins.RemoteDesktopEnginePluginID,
+		Version: "1.0.0",
+		Capabilities: []ModuleCapability{
+			{ID: "remote-desktop.transport.quic", Name: "remote-desktop.transport.quic"},
+		},
+	}); err != nil {
+		t.Fatalf("register extension: %v", err)
+	}
+
+	remote := agent.modules.remoteDesktopModule()
+	if remote == nil {
+		t.Fatal("remote desktop module not registered")
+	}
+	engine := &fakeRemoteDesktopEngine{}
+	remote.mu.Lock()
+	remote.engine = engine
+	remote.requiredVersion = "1.0.0"
+	remote.mu.Unlock()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(manifest.ManifestList{Version: "2"})
+	}))
+	defer server.Close()
+
+	agent.baseURL = server.URL
+	agent.client = server.Client()
+	agent.buildVersion = "1.0.0"
+
+	delta := &manifest.ManifestDelta{Version: "2", Removed: []string{plugins.RemoteDesktopEnginePluginID}}
+	if err := agent.applyPluginManifestDelta(context.Background(), delta); err != nil {
+		t.Fatalf("apply delta: %v", err)
+	}
+
+	if _, err := os.Stat(stagedDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected plugin directory removed, stat error = %v", err)
+	}
+
+	if snapshot := agent.plugins.Snapshot(); snapshot != nil {
+		t.Fatalf("expected plugin snapshot to be nil, got %+v", snapshot)
+	}
+
+	remote.mu.Lock()
+	currentEngine := remote.engine
+	requiredVersion := remote.requiredVersion
+	remote.mu.Unlock()
+
+	if currentEngine == nil {
+		t.Fatal("expected remote desktop engine to be reinitialized")
+	}
+	if _, ok := currentEngine.(*remotedesktop.RemoteDesktopStreamer); !ok {
+		t.Fatalf("expected built-in streamer engine, got %T", currentEngine)
+	}
+	if requiredVersion != "" {
+		t.Fatalf("expected required version cleared, got %q", requiredVersion)
+	}
+	if !engine.shutdownCalled {
+		t.Fatal("expected previous engine to be shut down")
+	}
+
+	metadata := agent.modules.Metadata()
+	var remoteMetadata *ModuleMetadata
+	for index := range metadata {
+		if metadata[index].ID == "remote-desktop" {
+			remoteMetadata = &metadata[index]
+			break
+		}
+	}
+	if remoteMetadata == nil {
+		t.Fatal("remote desktop metadata missing")
+	}
+	if len(remoteMetadata.Extensions) != 0 {
+		t.Fatalf("expected no extensions, got %d", len(remoteMetadata.Extensions))
+	}
+	if len(remoteMetadata.Capabilities) != 2 {
+		t.Fatalf("expected base capabilities preserved, got %d", len(remoteMetadata.Capabilities))
+	}
+
+	payload := agent.pluginSyncPayload()
+	if payload == nil {
+		t.Fatal("expected plugin telemetry payload")
+	}
+	if payload.Installations != nil && len(payload.Installations) > 0 {
+		t.Fatalf("expected installations to be empty, got %+v", payload.Installations)
+	}
+	if payload.Manifests == nil {
+		t.Fatal("expected manifest state to be present")
+	}
+	if payload.Manifests.Version != "2" {
+		t.Fatalf("unexpected manifest version %q", payload.Manifests.Version)
+	}
+	if payload.Manifests.Digests != nil {
+		if _, ok := payload.Manifests.Digests[plugins.RemoteDesktopEnginePluginID]; ok {
+			t.Fatalf("expected remote desktop digest removed, got %+v", payload.Manifests.Digests)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- teach `applyPluginManifestDelta` to delete removed plugin artifacts, clear install status, and rebuild the remote desktop engine without an external plugin
- allow modules to unregister plugin-provided capabilities and reset the remote desktop module's extension state
- add coverage for module extension removal and manifest delta removals to ensure telemetry reflects uninstalled plugins

## Testing
- go test ./internal/agent
- go test ./internal/plugins

------
https://chatgpt.com/codex/tasks/task_e_68fc97f40788832ba66a8ea0bd2e0b62