### PR TITLE
Switch plugin telemetry timestamps to epoch milliseconds

### DIFF
--- a/shared/pluginmanifest/manifest.go
+++ b/shared/pluginmanifest/manifest.go
@@ -279,7 +279,7 @@ type InstallationTelemetry struct {
 	Version   string              `json:"version"`
 	Status    PluginInstallStatus `json:"status"`
 	Hash      string              `json:"hash,omitempty"`
-	Timestamp *string             `json:"timestamp,omitempty"`
+	Timestamp *int64              `json:"timestamp,omitempty"`
 	Error     string              `json:"error,omitempty"`
 }
 

--- a/shared/types/plugin-manifest.ts
+++ b/shared/types/plugin-manifest.ts
@@ -108,7 +108,7 @@ export interface PluginInstallationTelemetry {
   version: string;
   status: PluginInstallStatus;
   hash?: string;
-  timestamp?: string | null;
+  timestamp?: number | null;
   error?: string;
 }
 

--- a/tenvy-client/internal/plugins/manager.go
+++ b/tenvy-client/internal/plugins/manager.go
@@ -57,7 +57,7 @@ func (m *Manager) Snapshot() *manifest.SyncPayload {
 		return nil
 	}
 
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+	now := time.Now().UTC().UnixMilli()
 	payload := manifest.SyncPayload{Installations: make([]manifest.InstallationTelemetry, 0, len(entries))}
 
 	for _, entry := range entries {
@@ -79,8 +79,8 @@ func (m *Manager) Snapshot() *manifest.SyncPayload {
 				if status.Error != "" {
 					telemetry.Error = status.Error
 				}
-				if ts := status.Timestamp; ts != "" {
-					telemetry.Timestamp = &ts
+				if ts := status.Timestamp; ts != nil {
+					telemetry.Timestamp = ts
 				}
 				payload.Installations = append(payload.Installations, telemetry)
 			} else if !errors.Is(err, fs.ErrNotExist) {
@@ -169,8 +169,8 @@ func (m *Manager) Snapshot() *manifest.SyncPayload {
 			if status.Error != "" {
 				installation.Error = status.Error
 			}
-			if ts := status.Timestamp; ts != "" {
-				installation.Timestamp = &ts
+			if ts := status.Timestamp; ts != nil {
+				installation.Timestamp = ts
 			}
 			if version := status.Version; version != "" {
 				installation.Version = version

--- a/tenvy-server/src/lib/server/plugins/telemetry-store.ts
+++ b/tenvy-server/src/lib/server/plugins/telemetry-store.ts
@@ -44,11 +44,32 @@ export interface AgentPluginRecord {
 
 const MANIFEST_CACHE_TTL_MS = 30_000;
 
-function toDate(value: string | Date | null | undefined): Date | null {
-	if (!value) return null;
-	if (value instanceof Date) return new Date(value);
-	const parsed = new Date(value);
-	return Number.isNaN(parsed.getTime()) ? null : parsed;
+function toDate(value: number | string | Date | null | undefined): Date | null {
+        if (value == null) return null;
+        if (value instanceof Date) return new Date(value);
+        if (typeof value === 'number') {
+                if (!Number.isFinite(value)) {
+                        return null;
+                }
+                const parsed = new Date(value);
+                return Number.isNaN(parsed.getTime()) ? null : parsed;
+        }
+        if (typeof value === 'string') {
+                const trimmed = value.trim();
+                if (trimmed === '') {
+                        return null;
+                }
+                const numeric = Number(trimmed);
+                if (!Number.isNaN(numeric)) {
+                        const numericDate = new Date(numeric);
+                        if (!Number.isNaN(numericDate.getTime())) {
+                                return numericDate;
+                        }
+                }
+                const parsed = new Date(trimmed);
+                return Number.isNaN(parsed.getTime()) ? null : parsed;
+        }
+        return null;
 }
 
 function normalizeStatus(status: string | undefined): string {


### PR DESCRIPTION
## Summary
- store plugin installation telemetry timestamps as epoch milliseconds in the shared manifest types
- update the Go plugin manager/status persistence to emit numeric timestamps while parsing legacy RFC3339 data
- teach the server telemetry store to coerce numeric timestamps and cover the new format in Vitest specs

## Testing
- `cd tenvy-client && go test ./...`
- `cd tenvy-server && bun x vitest run src/lib/server/plugins/telemetry-store.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68fc9cbbb880832bbcce47932c750616