### PR TITLE
Refactor plugin signature schema

### DIFF
--- a/shared/pluginmanifest/remote-desktop-engine.json
+++ b/shared/pluginmanifest/remote-desktop-engine.json
@@ -25,14 +25,11 @@
   "distribution": {
     "defaultMode": "automatic",
     "autoUpdate": true,
-    "signature": {
-      "type": "ed25519",
-      "hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-      "publicKey": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
-      "signature": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
-      "signedAt": "2025-01-01T00:00:00Z",
-      "signer": "release"
-    }
+    "signature": "ed25519",
+    "signatureHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    "signatureSigner": "release",
+    "signatureValue": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
+    "signatureTimestamp": "2025-01-01T00:00:00Z"
   },
   "package": {
     "artifact": "remote-desktop-engine/remote-desktop-engine.zip",

--- a/shared/pluginmanifest/verify_test.go
+++ b/shared/pluginmanifest/verify_test.go
@@ -11,9 +11,7 @@ import (
 func TestVerifySignatureSHA256AllowList(t *testing.T) {
 	manifest := Manifest{
 		Distribution: Distribution{
-			Signature: Signature{
-				Type: SignatureSHA256,
-			},
+			Signature: SignatureSHA256,
 		},
 		Package: PackageDescriptor{Hash: "abcdef"},
 	}
@@ -33,9 +31,7 @@ func TestVerifySignatureSHA256AllowList(t *testing.T) {
 func TestVerifySignatureSHA256Disallowed(t *testing.T) {
 	manifest := Manifest{
 		Distribution: Distribution{
-			Signature: Signature{
-				Type: SignatureSHA256,
-			},
+			Signature: SignatureSHA256,
 		},
 		Package: PackageDescriptor{Hash: "abcdef"},
 	}
@@ -48,10 +44,8 @@ func TestVerifySignatureSHA256Disallowed(t *testing.T) {
 func TestVerifySignatureHashMismatch(t *testing.T) {
 	manifest := Manifest{
 		Distribution: Distribution{
-			Signature: Signature{
-				Type: SignatureSHA256,
-				Hash: "123456",
-			},
+			Signature:     SignatureSHA256,
+			SignatureHash: "123456",
 		},
 		Package: PackageDescriptor{Hash: "abcdef"},
 	}
@@ -64,7 +58,7 @@ func TestVerifySignatureHashMismatch(t *testing.T) {
 func TestVerifySignatureMissingPackageHash(t *testing.T) {
 	manifest := Manifest{
 		Distribution: Distribution{
-			Signature: Signature{Type: SignatureSHA256},
+			Signature: SignatureSHA256,
 		},
 	}
 
@@ -84,13 +78,11 @@ func TestVerifySignatureEd25519(t *testing.T) {
 
 	manifest := Manifest{
 		Distribution: Distribution{
-			Signature: Signature{
-				Type:      SignatureEd25519,
-				Hash:      hash,
-				PublicKey: "key-1",
-				Signature: hex.EncodeToString(sig),
-				SignedAt:  time.Now().UTC().Format(time.RFC3339),
-			},
+			Signature:          SignatureEd25519,
+			SignatureHash:      hash,
+			SignatureSigner:    "key-1",
+			SignatureValue:     hex.EncodeToString(sig),
+			SignatureTimestamp: time.Now().UTC().Format(time.RFC3339),
 		},
 		Package: PackageDescriptor{Hash: hash},
 	}
@@ -108,7 +100,8 @@ func TestVerifySignatureEd25519(t *testing.T) {
 	if !result.Trusted {
 		t.Fatalf("expected trusted result")
 	}
-	if result.PublicKey != "key-1" {
+	expectedKey := hex.EncodeToString(pub)
+	if result.PublicKey != expectedKey {
 		t.Fatalf("unexpected public key: %s", result.PublicKey)
 	}
 }
@@ -126,13 +119,11 @@ func TestVerifySignatureEd25519CertificateValidation(t *testing.T) {
 
 	manifest := Manifest{
 		Distribution: Distribution{
-			Signature: Signature{
-				Type:      SignatureEd25519,
-				Hash:      hash,
-				Chain:     []string{"cert-a", "cert-b"},
-				Signature: hex.EncodeToString(sig),
-				PublicKey: "key-2",
-			},
+			Signature:                 SignatureEd25519,
+			SignatureHash:             hash,
+			SignatureValue:            hex.EncodeToString(sig),
+			SignatureSigner:           "key-2",
+			SignatureCertificateChain: []string{"cert-a", "cert-b"},
 		},
 		Package: PackageDescriptor{Hash: hash},
 	}
@@ -161,12 +152,10 @@ func TestVerifySignatureEd25519CertificateValidation(t *testing.T) {
 func TestVerifySignatureEd25519UntrustedSigner(t *testing.T) {
 	manifest := Manifest{
 		Distribution: Distribution{
-			Signature: Signature{
-				Type:      SignatureEd25519,
-				Hash:      "abcdef",
-				PublicKey: "missing",
-				Signature: hex.EncodeToString(make([]byte, ed25519.SignatureSize)),
-			},
+			Signature:       SignatureEd25519,
+			SignatureHash:   "abcdef",
+			SignatureSigner: "missing",
+			SignatureValue:  hex.EncodeToString(make([]byte, ed25519.SignatureSize)),
 		},
 		Package: PackageDescriptor{Hash: "abcdef"},
 	}
@@ -179,11 +168,9 @@ func TestVerifySignatureEd25519UntrustedSigner(t *testing.T) {
 func TestVerifySignatureExpired(t *testing.T) {
 	manifest := Manifest{
 		Distribution: Distribution{
-			Signature: Signature{
-				Type:     SignatureSHA256,
-				Hash:     "abcdef",
-				SignedAt: time.Now().UTC().Add(-48 * time.Hour).Format(time.RFC3339),
-			},
+			Signature:          SignatureSHA256,
+			SignatureHash:      "abcdef",
+			SignatureTimestamp: time.Now().UTC().Add(-48 * time.Hour).Format(time.RFC3339),
 		},
 		Package: PackageDescriptor{Hash: "abcdef"},
 	}

--- a/tenvy-client/internal/agent/remote_desktop_integration_test.go
+++ b/tenvy-client/internal/agent/remote_desktop_integration_test.go
@@ -51,13 +51,10 @@ func TestRemoteDesktopModuleNegotiationWithManagedEngine(t *testing.T) {
 			RequiredModules: []string{"remote-desktop"},
 		},
 		Distribution: manifest.Distribution{
-			DefaultMode: "automatic",
-			AutoUpdate:  true,
-			Signature: manifest.Signature{
-				Type:      manifest.SignatureSHA256,
-				Hash:      hashHex,
-				Signature: hashHex,
-			},
+			DefaultMode:   "automatic",
+			AutoUpdate:    true,
+			Signature:     manifest.SignatureSHA256,
+			SignatureHash: hashHex,
 		},
 		Package: manifest.PackageDescriptor{
 			Artifact: "remote-desktop-engine/engine.zip",

--- a/tenvy-client/internal/plugins/manager.go
+++ b/tenvy-client/internal/plugins/manager.go
@@ -270,8 +270,11 @@ func signatureUntrustedReason(mf manifest.Manifest, result *manifest.Verificatio
 		if strings.TrimSpace(result.Signer) != "" {
 			return fmt.Sprintf("untrusted signer %s", result.Signer)
 		}
-		if strings.TrimSpace(mf.Distribution.Signature.PublicKey) != "" {
-			return fmt.Sprintf("untrusted key %s", mf.Distribution.Signature.PublicKey)
+		if strings.TrimSpace(result.PublicKey) != "" {
+			return fmt.Sprintf("untrusted key %s", result.PublicKey)
+		}
+		if strings.TrimSpace(mf.Distribution.SignatureSigner) != "" {
+			return fmt.Sprintf("untrusted signer %s", mf.Distribution.SignatureSigner)
 		}
 		return "untrusted signer"
 	default:

--- a/tenvy-client/internal/plugins/manager_test.go
+++ b/tenvy-client/internal/plugins/manager_test.go
@@ -44,7 +44,7 @@ func TestSnapshotSkipsManifestWithUnsupportedSignature(t *testing.T) {
                 "repositoryUrl": "https://github.com/rootbay/unsigned",
                 "license": { "spdxId": "MIT" },
                 "requirements": {},
-                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": {"type": "none"}},
+                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": "none"},
                 "package": {"artifact": "plugin.dll"}
         }`))
 	writeFile(t, artifactPath, []byte("payload"))
@@ -90,12 +90,10 @@ func TestSnapshotAllowsTrustedSignature(t *testing.T) {
                 "distribution": {
                         "defaultMode": "manual",
                         "autoUpdate": false,
-                        "signature": {
-                                "type": "ed25519",
-                                "hash": "%s",
-                                "publicKey": "primary",
-                                "signature": "%s"
-                        }
+                        "signature": "ed25519",
+                        "signatureHash": "%s",
+                        "signatureSigner": "primary",
+                        "signatureValue": "%s"
                 },
                 "package": {"artifact": "plugin.bin", "hash": "%s"}
         }`, hash, hex.EncodeToString(signature), hash)
@@ -151,12 +149,10 @@ func TestSnapshotBlocksInvalidSignature(t *testing.T) {
                 "distribution": {
                         "defaultMode": "manual",
                         "autoUpdate": false,
-                        "signature": {
-                                "type": "ed25519",
-                                "hash": "%s",
-                                "publicKey": "primary",
-                                "signature": "%s"
-                        }
+                        "signature": "ed25519",
+                        "signatureHash": "%s",
+                        "signatureSigner": "primary",
+                        "signatureValue": "%s"
                 },
                 "package": {"artifact": "plugin.bin", "hash": "%s"}
         }`, hash, strings.Repeat("00", ed25519.SignatureSize), hash)
@@ -205,7 +201,7 @@ func TestSnapshotAppliesRecordedStatus(t *testing.T) {
                 "repositoryUrl": "https://github.com/rootbay/tenvy",
                 "license": { "spdxId": "MIT" },
                 "requirements": {},
-                "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": {"type": "sha256", "hash": "%[1]s", "signature": "%[1]s"}},
+                "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": "sha256", "signatureHash": "%[1]s"},
                 "package": {"artifact": "engine.bin", "hash": "%[1]s"}
         }`, hashHex)))
 
@@ -286,7 +282,7 @@ func TestSnapshotEmitsDocumentedStatuses(t *testing.T) {
                 "version": "1.0.0",
                 "entry": "plugin.bin",
                 "requirements": {},
-                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": {"type": "sha256", "hash": "%[1]s", "signature": "%[1]s"}},
+                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": "sha256", "signatureHash": "%[1]s"},
                 "package": {"artifact": "plugin.bin", "hash": "%[1]s"}
         }`, installedHash)
 	writeFile(t, filepath.Join(installedDir, "manifest.json"), []byte(installedManifest))
@@ -309,7 +305,7 @@ func TestSnapshotEmitsDocumentedStatuses(t *testing.T) {
                 "distribution": {
                         "defaultMode": "manual",
                         "autoUpdate": false,
-                        "signature": {"type": "ed25519", "hash": "%[1]s", "publicKey": "primary", "signature": "%[2]s"}
+                        "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "primary", "signatureValue": "%[2]s"
                 },
                 "package": {"artifact": "plugin.bin", "hash": "%[1]s"}
         }`, blockedHash, strings.Repeat("00", ed25519.SignatureSize))
@@ -323,7 +319,7 @@ func TestSnapshotEmitsDocumentedStatuses(t *testing.T) {
                 "version": "1.0.0",
                 "entry": "missing.bin",
                 "requirements": {},
-                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": {"type": "sha256", "hash": "%[1]s", "signature": "%[1]s"}},
+                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": "sha256", "signatureHash": "%[1]s"},
                 "package": {"artifact": "missing.bin", "hash": "%[1]s"}
         }`, errorHash)
 	writeFile(t, filepath.Join(errorDir, "manifest.json"), []byte(errorManifest))

--- a/tenvy-client/internal/plugins/remotedesktop_test.go
+++ b/tenvy-client/internal/plugins/remotedesktop_test.go
@@ -51,7 +51,7 @@ func TestStageRemoteDesktopEngineSuccess(t *testing.T) {
                 "repositoryUrl": "https://github.com/rootbay/tenvy-client",
                 "license": { "spdxId": "MIT" },
                 "requirements": {},
-                "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": {"type": "sha256", "hash": "%[1]s", "signature": "%[1]s"}},
+                "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": "sha256", "signatureHash": "%[1]s"},
                 "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip", "hash": "%s"}
         }`, hashHex, hashHex)
 
@@ -177,7 +177,7 @@ func TestStageRemoteDesktopEngineBlocksIncompatiblePlatform(t *testing.T) {
                 "repositoryUrl": "https://github.com/rootbay/tenvy-client",
                 "license": {"spdxId": "MIT"},
                 "requirements": {"platforms": ["windows"]},
-                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": {"type": "sha256", "hash": "%[1]s", "signature": "%[1]s"}},
+                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": "sha256", "signatureHash": "%[1]s"},
                 "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip", "hash": "%[1]s"}
         }`, hashHex)
 
@@ -251,7 +251,7 @@ func TestStageRemoteDesktopEngineBlocksIncompatibleArchitecture(t *testing.T) {
                 "repositoryUrl": "https://github.com/rootbay/tenvy-client",
                 "license": {"spdxId": "MIT"},
                 "requirements": {"architectures": ["arm64"]},
-                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": {"type": "sha256", "hash": "%[1]s", "signature": "%[1]s"}},
+                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": "sha256", "signatureHash": "%[1]s"},
                 "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip", "hash": "%[1]s"}
         }`, hashHex)
 
@@ -325,7 +325,7 @@ func TestStageRemoteDesktopEngineBlocksIncompatibleAgentVersion(t *testing.T) {
                 "repositoryUrl": "https://github.com/rootbay/tenvy-client",
                 "license": {"spdxId": "MIT"},
                 "requirements": {"minAgentVersion": "5.0.0"},
-                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": {"type": "sha256", "hash": "%[1]s", "signature": "%[1]s"}},
+                "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": "sha256", "signatureHash": "%[1]s"},
                 "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip", "hash": "%[1]s"}
         }`, hashHex)
 

--- a/tenvy-server/resources/plugin-manifests/clipboard-sync.json
+++ b/tenvy-server/resources/plugin-manifests/clipboard-sync.json
@@ -12,23 +12,17 @@
 		"url": "https://opensource.org/license/mit"
 	},
 	"categories": ["collection"],
-        "capabilities": [
-                "clipboard.capture",
-                "clipboard.push"
-        ],
-        "requirements": {
-                "minAgentVersion": "1.2.0",
-                "platforms": ["windows", "macos"],
+	"capabilities": ["clipboard.capture", "clipboard.push"],
+	"requirements": {
+		"minAgentVersion": "1.2.0",
+		"platforms": ["windows", "macos"],
 		"requiredModules": ["clipboard"]
 	},
 	"distribution": {
 		"defaultMode": "automatic",
 		"autoUpdate": true,
-		"signature": {
-			"type": "sha256",
-			"hash": "d8b8a0fb9c8f8e3a72d88e3f7a8c6d1f1fbb83c9f6c2ddacb12e3b45f1a8bbef",
-			"signature": "b3941f7d88da4bbdd89a2b1f2c41c8f93bc2330bb6b8ea3be97dc32d8d12a1ee"
-		}
+		"signature": "sha256",
+		"signatureHash": "d8b8a0fb9c8f8e3a72d88e3f7a8c6d1f1fbb83c9f6c2ddacb12e3b45f1a8bbef"
 	},
 	"package": {
 		"artifact": "clipboard-sync-1.4.2.dll",

--- a/tenvy-server/resources/plugin-manifests/incident-notes.json
+++ b/tenvy-server/resources/plugin-manifests/incident-notes.json
@@ -12,9 +12,7 @@
 		"url": "https://www.apache.org/licenses/LICENSE-2.0"
 	},
 	"categories": ["persistence"],
-        "capabilities": [
-                "notes.sync"
-        ],
+	"capabilities": ["notes.sync"],
 	"requirements": {
 		"minAgentVersion": "1.0.0",
 		"requiredModules": ["notes"]
@@ -22,11 +20,8 @@
 	"distribution": {
 		"defaultMode": "automatic",
 		"autoUpdate": true,
-		"signature": {
-			"type": "sha256",
-			"hash": "97f3dfb04f2bb1d0d07b0eac07c6f6a7c6d820b4d19d3fbfdcf7ee52b0cc3947",
-			"signature": "5d3b0ddf8b9e2a2227490ff8c3a6b55bdc6fa4e3f0bd5746d6193b82ba3f6e1c"
-		}
+		"signature": "sha256",
+		"signatureHash": "97f3dfb04f2bb1d0d07b0eac07c6f6a7c6d820b4d19d3fbfdcf7ee52b0cc3947"
 	},
 	"package": {
 		"artifact": "incident-notes-1.0.1.dll",

--- a/tenvy-server/resources/plugin-manifests/remote-desktop-engine.json
+++ b/tenvy-server/resources/plugin-manifests/remote-desktop-engine.json
@@ -1,42 +1,35 @@
 {
-        "id": "remote-desktop-engine",
-        "name": "Remote Desktop Engine",
-        "version": "0.1.0",
-        "description": "Standalone remote desktop capture and encoding engine.",
-        "entry": "remote-desktop-engine",
-        "author": "Rootbay",
-        "homepage": "https://github.com/rootbay/tenvy-client",
-        "repositoryUrl": "https://github.com/rootbay/tenvy-client",
-        "license": {
-                "spdxId": "MIT",
-                "url": "https://github.com/rootbay/tenvy-client/blob/main/LICENSE"
-        },
-        "capabilities": [
-                "remote-desktop.stream",
-                "remote-desktop.codec.hevc",
-                "remote-desktop.metrics"
-        ],
-        "requirements": {
-                "minAgentVersion": "0.1.0",
-                "platforms": ["windows", "linux", "macos"],
-                "architectures": ["x86_64", "arm64"],
-                "requiredModules": ["remote-desktop"]
-        },
-        "distribution": {
-                "defaultMode": "automatic",
-                "autoUpdate": true,
-                "signature": {
-                        "type": "ed25519",
-                        "hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-                        "publicKey": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
-                        "signature": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
-                        "signedAt": "2025-01-01T00:00:00Z",
-                        "signer": "release"
-                }
-        },
-        "package": {
-                "artifact": "remote-desktop-engine/remote-desktop-engine.zip",
-                "sizeBytes": 0,
-                "hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-        }
+	"id": "remote-desktop-engine",
+	"name": "Remote Desktop Engine",
+	"version": "0.1.0",
+	"description": "Standalone remote desktop capture and encoding engine.",
+	"entry": "remote-desktop-engine",
+	"author": "Rootbay",
+	"homepage": "https://github.com/rootbay/tenvy-client",
+	"repositoryUrl": "https://github.com/rootbay/tenvy-client",
+	"license": {
+		"spdxId": "MIT",
+		"url": "https://github.com/rootbay/tenvy-client/blob/main/LICENSE"
+	},
+	"capabilities": ["remote-desktop.stream", "remote-desktop.codec.hevc", "remote-desktop.metrics"],
+	"requirements": {
+		"minAgentVersion": "0.1.0",
+		"platforms": ["windows", "linux", "macos"],
+		"architectures": ["x86_64", "arm64"],
+		"requiredModules": ["remote-desktop"]
+	},
+	"distribution": {
+		"defaultMode": "automatic",
+		"autoUpdate": true,
+		"signature": "ed25519",
+		"signatureHash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"signatureSigner": "release",
+		"signatureValue": "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
+		"signatureTimestamp": "2025-01-01T00:00:00Z"
+	},
+	"package": {
+		"artifact": "remote-desktop-engine/remote-desktop-engine.zip",
+		"sizeBytes": 0,
+		"hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	}
 }

--- a/tenvy-server/resources/plugin-manifests/remote-vault.json
+++ b/tenvy-server/resources/plugin-manifests/remote-vault.json
@@ -12,10 +12,7 @@
 		"url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
 	},
 	"categories": ["collection", "operations"],
-        "capabilities": [
-                "vault.enumerate",
-                "vault.export"
-        ],
+	"capabilities": ["vault.enumerate", "vault.export"],
 	"requirements": {
 		"minAgentVersion": "1.3.0",
 		"requiredModules": ["system-info", "recovery"]
@@ -23,13 +20,11 @@
 	"distribution": {
 		"defaultMode": "manual",
 		"autoUpdate": false,
-		"signature": {
-			"type": "ed25519",
-			"hash": "9e4cba26f4f913a52fcb11f16a34f1db493f9204f0545d01b7a086764d814176",
-			"publicKey": "edpk1tVL7Ah5pPqgZRtM7Ypc9S8vUuB1yhXqn7t5u8XH2",
-			"signature": "6f1a27de6f72cd9f4bc216dc4f996f613e16c6b8785c90de5977d6b4e1db284abcc4da0ce0d63b1f0bba3d3f77f64101",
-			"signedAt": "2024-02-18T10:15:00Z"
-		}
+		"signature": "ed25519",
+		"signatureHash": "9e4cba26f4f913a52fcb11f16a34f1db493f9204f0545d01b7a086764d814176",
+		"signatureSigner": "release",
+		"signatureValue": "6f1a27de6f72cd9f4bc216dc4f996f613e16c6b8785c90de5977d6b4e1db284abcc4da0ce0d63b1f0bba3d3f77f64101",
+		"signatureTimestamp": "2024-02-18T10:15:00Z"
 	},
 	"package": {
 		"artifact": "remote-vault-0.9.5.dll",

--- a/tenvy-server/resources/plugin-manifests/stream-relay.json
+++ b/tenvy-server/resources/plugin-manifests/stream-relay.json
@@ -12,9 +12,7 @@
 		"url": "https://opensource.org/license/bsd-3-clause"
 	},
 	"categories": ["transport"],
-        "capabilities": [
-                "remote-desktop.metrics"
-        ],
+	"capabilities": ["remote-desktop.metrics"],
 	"requirements": {
 		"minAgentVersion": "1.1.0",
 		"requiredModules": ["remote-desktop"]
@@ -22,11 +20,8 @@
 	"distribution": {
 		"defaultMode": "automatic",
 		"autoUpdate": true,
-		"signature": {
-			"type": "sha256",
-			"hash": "4fa1e33f99de3c58a4f0b6cbb9df450c3a7fd41b944fdc0bb70a0e0c3a4c299a",
-			"signature": "8c2d5d5c6a2c478af61d7e8617d6c07f6c62b80758d9bcbb9d18ec62a4ebbb47"
-		}
+		"signature": "sha256",
+		"signatureHash": "4fa1e33f99de3c58a4f0b6cbb9df450c3a7fd41b944fdc0bb70a0e0c3a4c299a"
 	},
 	"package": {
 		"artifact": "stream-relay-2.1.0.dll",

--- a/tenvy-server/src/lib/server/plugins/marketplace/index.ts
+++ b/tenvy-server/src/lib/server/plugins/marketplace/index.ts
@@ -16,10 +16,10 @@ import type {
 	PluginSignatureType
 } from '../../../../../../shared/types/plugin-manifest.js';
 import {
-        validatePluginManifest,
-        verifyPluginSignature,
-        resolveManifestSignature,
-        isPluginSignatureType
+	validatePluginManifest,
+	verifyPluginSignature,
+	resolveManifestSignature,
+	isPluginSignatureType
 } from '../../../../../../shared/types/plugin-manifest.js';
 import { getVerificationOptions } from '$lib/server/plugins/signature-policy.js';
 
@@ -99,35 +99,33 @@ const parseManifest = (raw: string): PluginManifest => {
 const now = () => new Date();
 
 const licenseDetails = (license: PluginLicenseInfo | undefined) => ({
-        licenseSpdxId: license?.spdxId ?? 'UNKNOWN',
-        licenseName: license?.name ?? null,
-        licenseUrl: license?.url ?? null
+	licenseSpdxId: license?.spdxId ?? 'UNKNOWN',
+	licenseName: license?.name ?? null,
+	licenseUrl: license?.url ?? null
 });
 
 const normalizeHash = (value: string | undefined | null): string =>
 	value?.trim().toLowerCase() ?? '';
 
 const baseSignatureSummary = (manifest: PluginManifest): PluginSignatureVerificationSummary => {
-        const { type, metadata } = resolveManifestSignature(manifest);
-        const chain = metadata?.certificateChain?.length
-                ? [...metadata.certificateChain]
-                : undefined;
-        const resolvedType = isPluginSignatureType(type) ? type : 'sha256';
-        const normalizedHash = normalizeHash(metadata?.hash ?? manifest.package?.hash);
+	const metadata = resolveManifestSignature(manifest);
+	const chain = metadata.certificateChain?.length ? [...metadata.certificateChain] : undefined;
+	const resolvedType = isPluginSignatureType(metadata.type) ? metadata.type : 'sha256';
+	const normalizedHash = normalizeHash(metadata.hash ?? manifest.package?.hash);
 
-        return {
-                trusted: false,
-                signatureType: resolvedType,
-                hash: normalizedHash,
-                signer: metadata?.signer ?? null,
-                signedAt: metadata?.signedAt ? new Date(metadata.signedAt) : null,
-                publicKey: metadata?.publicKey ?? null,
-                certificateChain: chain,
-                checkedAt: new Date(),
-                status: !type || type === 'none' ? 'unsigned' : 'untrusted',
-                error: undefined,
-                errorCode: undefined
-        };
+	return {
+		trusted: false,
+		signatureType: resolvedType,
+		hash: normalizedHash,
+		signer: metadata.signer ?? null,
+		signedAt: metadata.timestamp ? new Date(metadata.timestamp) : null,
+		publicKey: null,
+		certificateChain: chain,
+		checkedAt: new Date(),
+		status: !metadata.type || metadata.type === 'none' ? 'unsigned' : 'untrusted',
+		error: undefined,
+		errorCode: undefined
+	};
 };
 
 const summarizeVerificationSuccess = (
@@ -190,15 +188,15 @@ const resolveSignatureSummary = async (
 };
 
 const signatureDetails = async (manifest: PluginManifest) => {
-        const summary = await resolveSignatureSummary(manifest);
-        const chain = summary.certificateChain?.length ? JSON.stringify(summary.certificateChain) : null;
-        const { metadata } = resolveManifestSignature(manifest);
-        const signature = metadata?.signature ?? '';
-        return {
-                signatureType: summary.signatureType,
-                signatureHash: summary.hash ?? '',
-                signaturePublicKey: summary.publicKey ?? null,
-                signature,
+	const summary = await resolveSignatureSummary(manifest);
+	const chain = summary.certificateChain?.length ? JSON.stringify(summary.certificateChain) : null;
+	const metadata = resolveManifestSignature(manifest);
+	const signature = metadata.value ?? '';
+	return {
+		signatureType: summary.signatureType,
+		signatureHash: summary.hash ?? '',
+		signaturePublicKey: summary.publicKey ?? null,
+		signature,
 		signedAt: summary.signedAt ?? null,
 		signatureStatus: summary.status,
 		signatureTrusted: summary.trusted,

--- a/tenvy-server/tests/plugin-manifest-signature.test.ts
+++ b/tenvy-server/tests/plugin-manifest-signature.test.ts
@@ -22,11 +22,12 @@ describe('verifyPluginSignature', () => {
 			repositoryUrl: 'https://github.com/rootbay/demo',
 			license: { spdxId: 'MIT' },
 			requirements: {},
-                distribution: {
-                        defaultMode: 'manual',
-                        autoUpdate: false,
-                        signature: 'sha256'
-                },
+			distribution: {
+				defaultMode: 'manual',
+				autoUpdate: false,
+				signature: 'sha256',
+				signatureHash: 'abcdef'
+			},
 			package: {
 				artifact: 'demo.dll',
 				hash: 'abcdef'
@@ -50,11 +51,12 @@ describe('verifyPluginSignature', () => {
 			repositoryUrl: 'https://github.com/rootbay/demo',
 			license: { spdxId: 'MIT' },
 			requirements: {},
-                distribution: {
-                        defaultMode: 'manual',
-                        autoUpdate: false,
-                        signature: 'sha256'
-                },
+			distribution: {
+				defaultMode: 'manual',
+				autoUpdate: false,
+				signature: 'sha256',
+				signatureHash: 'abcdef'
+			},
 			package: {
 				artifact: 'demo.dll',
 				hash: 'abcdef'
@@ -88,13 +90,11 @@ describe('verifyPluginSignature', () => {
 			distribution: {
 				defaultMode: 'manual',
 				autoUpdate: false,
-				signature: {
-					type: 'ed25519',
-					hash,
-					publicKey: 'key-1',
-					signature: toHex(signature),
-					certificateChain: ['leaf', 'intermediate']
-				}
+				signature: 'ed25519',
+				signatureHash: hash,
+				signatureSigner: 'key-1',
+				signatureValue: toHex(signature),
+				signatureCertificateChain: ['leaf', 'intermediate']
 			},
 			package: {
 				artifact: 'demo.dll',
@@ -114,15 +114,15 @@ describe('verifyPluginSignature', () => {
 
 		expect(result.trusted).toBe(true);
 		expect(result.signatureType).toBe('ed25519');
-		expect(result.publicKey).toBe('key-1');
+		expect(result.publicKey).toBe(toHex(keyPair.publicKey));
 		expect(validated).toBe(true);
 	});
 
-        it('rejects unknown ed25519 signers', async () => {
-                const manifest: PluginManifest = {
-                        id: 'demo',
-                        name: 'Demo',
-                        version: '1.0.0',
+	it('rejects unknown ed25519 signers', async () => {
+		const manifest: PluginManifest = {
+			id: 'demo',
+			name: 'Demo',
+			version: '1.0.0',
 			entry: 'demo.dll',
 			repositoryUrl: 'https://github.com/rootbay/demo',
 			license: { spdxId: 'MIT' },
@@ -130,12 +130,10 @@ describe('verifyPluginSignature', () => {
 			distribution: {
 				defaultMode: 'manual',
 				autoUpdate: false,
-				signature: {
-					type: 'ed25519',
-					hash: 'abcdef',
-					publicKey: 'missing',
-					signature: toHex(new Uint8Array(nacl.sign.signatureLength))
-				}
+				signature: 'ed25519',
+				signatureHash: 'abcdef',
+				signatureSigner: 'missing',
+				signatureValue: toHex(new Uint8Array(nacl.sign.signatureLength))
 			},
 			package: {
 				artifact: 'demo.dll',
@@ -143,33 +141,34 @@ describe('verifyPluginSignature', () => {
 			}
 		};
 
-                await expect(verifyPluginSignature(manifest)).rejects.toMatchObject({
-                        code: 'UNTRUSTED_SIGNER'
-                });
-        });
+		await expect(verifyPluginSignature(manifest)).rejects.toMatchObject({
+			code: 'UNTRUSTED_SIGNER'
+		});
+	});
 
-        it('rejects ed25519 manifests that omit legacy metadata', async () => {
-                const manifest: PluginManifest = {
-                        id: 'demo',
-                        name: 'Demo',
-                        version: '1.0.0',
-                        entry: 'demo.dll',
-                        repositoryUrl: 'https://github.com/rootbay/demo',
-                        license: { spdxId: 'MIT' },
-                        requirements: {},
-                        distribution: {
-                                defaultMode: 'manual',
-                                autoUpdate: false,
-                                signature: 'ed25519'
-                        },
-                        package: {
-                                artifact: 'demo.dll',
-                                hash: 'abcdef'
-                        }
-                };
+	it('rejects ed25519 manifests that omit legacy metadata', async () => {
+		const manifest: PluginManifest = {
+			id: 'demo',
+			name: 'Demo',
+			version: '1.0.0',
+			entry: 'demo.dll',
+			repositoryUrl: 'https://github.com/rootbay/demo',
+			license: { spdxId: 'MIT' },
+			requirements: {},
+			distribution: {
+				defaultMode: 'manual',
+				autoUpdate: false,
+				signature: 'ed25519',
+				signatureHash: 'abcdef'
+			},
+			package: {
+				artifact: 'demo.dll',
+				hash: 'abcdef'
+			}
+		};
 
-                await expect(verifyPluginSignature(manifest)).rejects.toMatchObject({
-                        code: 'UNTRUSTED_SIGNER'
-                });
-        });
+		await expect(verifyPluginSignature(manifest)).rejects.toMatchObject({
+			code: 'UNTRUSTED_SIGNER'
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- split plugin distribution signature metadata into explicit fields across Go and TypeScript schemas and update validation
- rework Go/TypeScript signature verification to resolve signer keys from policy data and emit signer/key details
- update server loaders, telemetry, manifests, and tests to consume the new structure

## Testing
- go test ./... (tenvy-client) (pass)
- go test ./... (shared/pluginmanifest) (pass)
- bun test tests/plugin-manifest-signature.test.ts (pass)


------
https://chatgpt.com/codex/tasks/task_e_68fca503a724832bb889aefef2767ffd