### PR TITLE
Respect manual remote desktop policy

### DIFF
--- a/tenvy-client/internal/agent/plugins_sync.go
+++ b/tenvy-client/internal/agent/plugins_sync.go
@@ -130,6 +130,17 @@ func (a *Agent) stagePluginsFromList(ctx context.Context, snapshot *manifest.Man
 			continue
 		}
 
+		if !plugins.RemoteDesktopAutoSyncAllowed(entry) {
+			if a.logger != nil {
+				mode := strings.TrimSpace(string(entry.Distribution.DefaultMode))
+				if mode == "" {
+					mode = "unspecified"
+				}
+				a.logger.Printf("plugin sync: skipping remote desktop plugin %s (delivery mode: %s, auto-update: %t)", strings.TrimSpace(entry.PluginID), mode, entry.Distribution.AutoUpdate)
+			}
+			continue
+		}
+
 		stageCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		facts := a.remoteDesktopRuntimeFacts()
 		if _, err := plugins.StageRemoteDesktopEngine(

--- a/tenvy-client/internal/agent/remote_desktop_integration_test.go
+++ b/tenvy-client/internal/agent/remote_desktop_integration_test.go
@@ -133,6 +133,10 @@ func TestRemoteDesktopModuleNegotiationWithManagedEngine(t *testing.T) {
 			plugins.RemoteDesktopEnginePluginID: {
 				PluginID: plugins.RemoteDesktopEnginePluginID,
 				Version:  pluginVersion,
+				Distribution: manifest.ManifestBriefing{
+					DefaultMode: manifest.DeliveryAutomatic,
+					AutoUpdate:  true,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- add a policy helper that refuses automatic staging when the remote desktop manifest is manual
- teach the agent sync loop to skip staging manual remote desktop manifests
- extend and update unit/integration tests to cover the manual policy behaviour

## Testing
- (cd tenvy-client && go test ./internal/plugins)
- (cd tenvy-client && go test ./internal/agent)

------
https://chatgpt.com/codex/tasks/task_e_68fcad9a1044832bb2d81806d39f5629