### PR TITLE
Add manual plugin staging support and stage API

### DIFF
--- a/shared/pluginmanifest/manifest.go
+++ b/shared/pluginmanifest/manifest.go
@@ -248,6 +248,7 @@ type ManifestDescriptor struct {
 	ArtifactHash   string           `json:"artifactHash,omitempty"`
 	ArtifactSize   int64            `json:"artifactSizeBytes,omitempty"`
 	ApprovedAt     string           `json:"approvedAt,omitempty"`
+	ManualPushAt   string           `json:"manualPushAt,omitempty"`
 	Distribution   ManifestBriefing `json:"distribution"`
 }
 

--- a/shared/types/plugin-manifest.ts
+++ b/shared/types/plugin-manifest.ts
@@ -123,6 +123,7 @@ export interface PluginManifestDescriptor {
   artifactHash?: string | null;
   artifactSizeBytes?: number | null;
   approvedAt?: string | null;
+  manualPushAt?: string | null;
   distribution: {
     defaultMode: PluginDeliveryMode;
     autoUpdate: boolean;

--- a/tenvy-client/internal/agent/agent.go
+++ b/tenvy-client/internal/agent/agent.go
@@ -133,7 +133,7 @@ func (a *Agent) setPluginManifestList(list *manifest.ManifestList) {
 		if id == "" {
 			continue
 		}
-		digests[id] = entry.ManifestDigest
+		digests[id] = manifestDescriptorFingerprint(entry)
 		descriptors[id] = entry
 	}
 	a.pluginManifestDigests = digests

--- a/tenvy-client/internal/agent/plugins_sync_test.go
+++ b/tenvy-client/internal/agent/plugins_sync_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	remotedesktop "github.com/rootbay/tenvy-client/internal/modules/control/remotedesktop"
@@ -155,7 +156,7 @@ func TestApplyPluginManifestDeltaRemovesRemoteDesktopPlugin(t *testing.T) {
 	}
 }
 
-func TestStagePluginsFromListSkipsManualRemoteDesktop(t *testing.T) {
+func TestStagePluginsFromListSkipsManualRemoteDesktopWithoutSignal(t *testing.T) {
 	t.Parallel()
 
 	pluginRoot := t.TempDir()
@@ -199,6 +200,95 @@ func TestStagePluginsFromListSkipsManualRemoteDesktop(t *testing.T) {
 
 	if snapshot := agent.plugins.Snapshot(); snapshot != nil && len(snapshot.Installations) > 0 {
 		t.Fatalf("expected no plugin installations recorded, got %#v", snapshot.Installations)
+	}
+}
+
+func TestStagePluginsFromListStagesManualRemoteDesktopWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	pluginID := plugins.RemoteDesktopEnginePluginID
+	original := pluginStages.Lookup(pluginID)
+	handler := &testPluginStageHandler{
+		outcome: pluginStageOutcome{
+			Manifest: &manifest.Manifest{
+				ID:           pluginID,
+				Version:      "2.0.0",
+				Capabilities: []string{"remote-desktop.metrics"},
+			},
+			Staged: true,
+		},
+	}
+	pluginStages.Register(pluginID, handler)
+	t.Cleanup(func() {
+		if original != nil {
+			pluginStages.Register(pluginID, original)
+		} else {
+			pluginStages.Unregister(pluginID)
+		}
+	})
+
+	pluginRoot := t.TempDir()
+	manager, err := plugins.NewManager(pluginRoot, log.New(io.Discard, "", 0), manifest.VerifyOptions{})
+	if err != nil {
+		t.Fatalf("new plugin manager: %v", err)
+	}
+
+	agent := &Agent{
+		id:       "agent-1",
+		baseURL:  "https://controller.test",
+		client:   &http.Client{},
+		plugins:  manager,
+		modules:  newDefaultModuleManager(),
+		logger:   log.New(io.Discard, "", 0),
+		metadata: protocol.AgentMetadata{OS: "windows", Architecture: "amd64", Version: "1.0.0"},
+	}
+
+	snapshot := &manifest.ManifestList{
+		Version: "1",
+		Manifests: []manifest.ManifestDescriptor{
+			{
+				PluginID:       pluginID,
+				ManifestDigest: "digest-1",
+				ManualPushAt:   "2024-01-02T03:04:05Z",
+				Distribution: manifest.ManifestBriefing{
+					DefaultMode: manifest.DeliveryManual,
+					AutoUpdate:  false,
+				},
+			},
+		},
+	}
+
+	if err := agent.stagePluginsFromList(context.Background(), snapshot); err != nil {
+		t.Fatalf("stage plugins: %v", err)
+	}
+	if handler.calls != 1 {
+		t.Fatalf("expected handler invoked once, got %d", handler.calls)
+	}
+
+	metadata := agent.modules.Metadata()
+	var remoteMetadata *ModuleMetadata
+	for index := range metadata {
+		if strings.EqualFold(metadata[index].ID, "remote-desktop") {
+			remoteMetadata = &metadata[index]
+			break
+		}
+	}
+	if remoteMetadata == nil {
+		t.Fatal("remote desktop metadata missing")
+	}
+
+	var extensionFound bool
+	for _, ext := range remoteMetadata.Extensions {
+		if ext.Source != pluginID {
+			continue
+		}
+		extensionFound = true
+		if ext.Version != "2.0.0" {
+			t.Fatalf("unexpected extension version %q", ext.Version)
+		}
+	}
+	if !extensionFound {
+		t.Fatalf("expected extension registered for %s", pluginID)
 	}
 }
 

--- a/tenvy-client/internal/plugins/remotedesktop.go
+++ b/tenvy-client/internal/plugins/remotedesktop.go
@@ -107,7 +107,9 @@ func StageRemoteDesktopEngine(
 		return result, nil
 	}
 
-	if !RemoteDesktopAutoSyncAllowed(descriptor) {
+	manualRequested := strings.TrimSpace(descriptor.ManualPushAt) != ""
+
+	if !RemoteDesktopAutoSyncAllowed(descriptor) && !manualRequested {
 		version := strings.TrimSpace(descriptor.Version)
 		message := "remote desktop plugin automatic staging disabled by policy"
 		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, version, manifest.InstallDisabled, message)

--- a/tenvy-server/src/routes/api/clients/[id]/plugins/[pluginId]/stage/+server.ts
+++ b/tenvy-server/src/routes/api/clients/[id]/plugins/[pluginId]/stage/+server.ts
@@ -1,0 +1,49 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { registry } from '$lib/server/rat/store.js';
+import { PluginTelemetryStore } from '$lib/server/plugins/telemetry-store.js';
+import { createPluginRepository } from '$lib/data/plugins.js';
+import { buildClientPlugin } from '$lib/data/client-plugin-view.js';
+
+const telemetryStore = new PluginTelemetryStore();
+const repository = createPluginRepository();
+
+export const POST: RequestHandler = async ({ params }) => {
+        const { id, pluginId } = params;
+        if (!id || !pluginId) {
+                throw error(400, 'Missing identifiers');
+        }
+
+        try {
+                registry.getAgent(id);
+        } catch {
+                throw error(404, 'Client not found');
+        }
+
+        const approved = await telemetryStore.getApprovedManifest(pluginId);
+        if (!approved) {
+                throw error(404, 'Plugin not found or not approved');
+        }
+
+        await telemetryStore.recordManualPush(id, pluginId);
+
+        const [plugins, telemetry] = await Promise.all([
+                repository.list(),
+                telemetryStore.listAgentPlugins(id)
+        ]);
+
+        const pluginIndex = new Map(plugins.map((plugin) => [plugin.id, plugin]));
+        const telemetryIndex = new Map(telemetry.map((record) => [record.pluginId, record]));
+
+        const manifest = approved.record.manifest;
+        const plugin = pluginIndex.get(pluginId);
+
+        if (!manifest || !plugin) {
+                throw error(404, 'Plugin not found for client');
+        }
+
+        const telemetryRecord = telemetryIndex.get(pluginId);
+        const response = buildClientPlugin(manifest, plugin, telemetryRecord);
+
+        return json({ plugin: response });
+};


### PR DESCRIPTION
## Summary
- include manual push timestamps in shared plugin manifest descriptors
- allow the Go agent to detect manual install requests, stage remote desktop plugins on demand, and fingerprint manifest digests
- expose a client plugin stage API on the server that records manual pushes, updates telemetry snapshots, and cover the flow with tests

## Testing
- `go test -json ./internal/agent -run TestStagePluginsFromListStagesManualRemoteDesktopWhenRequested -count=1 -timeout 30s`
- `go test -json ./internal/plugins -run TestStageRemoteDesktopEngineAllowsManualWhenRequested -count=1 -timeout 30s`
- `bun test` *(fails: vitest browser/env mocks unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fcbc229ccc832b84ab9035e9b4c910