### PR TITLE
Expose manifest snapshots via client plugin endpoint

### DIFF
--- a/tenvy-client/internal/agent/plugins_sync.go
+++ b/tenvy-client/internal/agent/plugins_sync.go
@@ -141,13 +141,13 @@ func (a *Agent) fetchApprovedPluginList(ctx context.Context) (*manifest.Manifest
 		return nil, errors.New("agent identity not established")
 	}
 
-	endpoint := fmt.Sprintf("%s/api/agents/%s/plugins", strings.TrimRight(base, "/"), url.PathEscape(agentID))
+	endpoint := fmt.Sprintf("%s/api/clients/%s/plugins", strings.TrimRight(base, "/"), url.PathEscape(agentID))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", "application/vnd.tenvy.plugin-manifest+json")
 	req.Header.Set("User-Agent", a.userAgent())
 	if key := strings.TrimSpace(a.key); key != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))

--- a/tenvy-server/src/lib/server/http/bearer.ts
+++ b/tenvy-server/src/lib/server/http/bearer.ts
@@ -1,0 +1,8 @@
+export function getBearerToken(header: string | null): string | undefined {
+        if (!header) {
+                return undefined;
+        }
+
+        const match = header.match(/^Bearer\s+(.+)$/i);
+        return match?.[1]?.trim();
+}

--- a/tenvy-server/src/routes/api/agents/[id]/plugins/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/plugins/+server.ts
@@ -1,28 +1,6 @@
-import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { registry, RegistryError } from '$lib/server/rat/store.js';
-import { telemetryStore, getBearerToken } from './_shared.js';
+import { resolveClientPluginRequest } from '../../clients/[id]/plugins/+server.js';
 
-export const GET: RequestHandler = async ({ params, request }) => {
-        const id = params.id;
-        if (!id) {
-                throw error(400, 'Missing agent identifier');
-        }
-
-        const token = getBearerToken(request.headers.get('authorization'));
-        if (!token) {
-                throw error(401, 'Missing agent key');
-        }
-
-        try {
-            registry.authorizeAgent(id, token);
-        } catch (err) {
-                if (err instanceof RegistryError) {
-                        throw error(err.status, err.message);
-                }
-                throw error(500, 'Failed to authorize agent');
-        }
-
-        const snapshot = await telemetryStore.getManifestSnapshot();
-        return json(snapshot);
+export const GET: RequestHandler = async ({ params, request, url }) => {
+        return resolveClientPluginRequest({ id: params.id }, request, url, { forceSnapshot: true });
 };

--- a/tenvy-server/src/routes/api/agents/[id]/plugins/_shared.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/plugins/_shared.ts
@@ -1,11 +1,6 @@
 import { PluginTelemetryStore } from '$lib/server/plugins/telemetry-store.js';
+import { getBearerToken } from '$lib/server/http/bearer.js';
 
 export const telemetryStore = new PluginTelemetryStore();
 
-export function getBearerToken(header: string | null): string | undefined {
-        if (!header) {
-                return undefined;
-        }
-        const match = header.match(/^Bearer\s+(.+)$/i);
-        return match?.[1]?.trim();
-}
+export { getBearerToken };

--- a/tenvy-server/src/routes/api/clients/[id]/plugins/+server.ts
+++ b/tenvy-server/src/routes/api/clients/[id]/plugins/+server.ts
@@ -1,52 +1,107 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { registry } from '$lib/server/rat/store.js';
+import { registry, RegistryError } from '$lib/server/rat/store.js';
 import { createPluginRepository } from '$lib/data/plugins.js';
 import { loadPluginManifests } from '$lib/data/plugin-manifests.js';
 import { buildClientPlugin, type ClientPlugin } from '$lib/data/client-plugin-view.js';
-import { PluginTelemetryStore } from '$lib/server/plugins/telemetry-store.js';
+import { getBearerToken } from '$lib/server/http/bearer.js';
+import { telemetryStore } from '../../../agents/[id]/plugins/_shared.js';
 
 const repository = createPluginRepository();
-const telemetryStore = new PluginTelemetryStore();
 
-export const GET: RequestHandler = async ({ params }) => {
-	const { id } = params;
-	if (!id) {
-		throw error(400, 'Missing client identifier');
-	}
+const SNAPSHOT_MEDIA_TYPE = 'application/vnd.tenvy.plugin-manifest+json';
 
-	try {
-		registry.getAgent(id);
-	} catch {
-		throw error(404, 'Client not found');
-	}
+type ClientPluginRequestOptions = {
+        forceSnapshot?: boolean;
+};
 
-	const [manifestRecords, pluginViews, telemetryRecords] = await Promise.all([
-		loadManifests(),
-		repository.list(),
-		telemetryStore.listAgentPlugins(id)
-	]);
+export async function resolveClientPluginRequest(
+        params: { id?: string },
+        request: Request,
+        url: URL,
+        options: ClientPluginRequestOptions = {}
+): Promise<Response> {
+        const { id } = params;
+        if (!id) {
+                throw error(400, 'Missing client identifier');
+        }
 
-	const manifestIndex = new Map(
-		manifestRecords.map((record) => [record.manifest.id, record.manifest])
-	);
-	const telemetryIndex = new Map(telemetryRecords.map((record) => [record.pluginId, record]));
+        const wantsSnapshot =
+                options.forceSnapshot === true ||
+                url.searchParams.get('format') === 'snapshot' ||
+                acceptsSnapshot(request.headers.get('accept'));
 
-	const plugins: ClientPlugin[] = [];
+        if (wantsSnapshot) {
+                const token = getBearerToken(request.headers.get('authorization'));
+                if (!token) {
+                        throw error(401, 'Missing agent key');
+                }
 
-	for (const view of pluginViews) {
-		const manifest = manifestIndex.get(view.id);
+                try {
+                        registry.authorizeAgent(id, token);
+                } catch (err) {
+                        if (err instanceof RegistryError) {
+                                throw error(err.status, err.message);
+                        }
+                        throw error(500, 'Failed to authorize agent');
+                }
+
+                const snapshot = await telemetryStore.getManifestSnapshot();
+                return json(snapshot, {
+                        headers: {
+                                'content-type': SNAPSHOT_MEDIA_TYPE,
+                                'cache-control': 'no-store'
+                        }
+                });
+        }
+
+        try {
+                registry.getAgent(id);
+        } catch {
+                throw error(404, 'Client not found');
+        }
+
+        const [manifestRecords, pluginViews, telemetryRecords] = await Promise.all([
+                loadManifests(),
+                repository.list(),
+                telemetryStore.listAgentPlugins(id)
+        ]);
+
+        const manifestIndex = new Map(
+                manifestRecords.map((record) => [record.manifest.id, record.manifest])
+        );
+        const telemetryIndex = new Map(telemetryRecords.map((record) => [record.pluginId, record]));
+
+        const plugins: ClientPlugin[] = [];
+
+        for (const view of pluginViews) {
+                const manifest = manifestIndex.get(view.id);
 		if (!manifest) {
 			continue;
 		}
 
 		const telemetry = telemetryIndex.get(view.id);
 		plugins.push(buildClientPlugin(manifest, view, telemetry));
-	}
+        }
 
-	return json({ plugins });
+        return json({ plugins });
+};
+
+export const GET: RequestHandler = async ({ params, request, url }) => {
+        return resolveClientPluginRequest(params, request, url);
 };
 
 async function loadManifests() {
-	return loadPluginManifests();
+        return loadPluginManifests();
+}
+
+function acceptsSnapshot(accept: string | null): boolean {
+        if (!accept) {
+                return false;
+        }
+
+        return accept
+                .split(',')
+                .map((part) => part.split(';')[0]?.trim().toLowerCase())
+                .some((mime) => mime === SNAPSHOT_MEDIA_TYPE);
 }


### PR DESCRIPTION
## Summary
- allow `/api/clients/:id/plugins` to return agent manifest snapshots when negotiated via the Accept header or query parameter and gate the snapshot behind bearer auth
- reuse the client plugins handler for the legacy agent endpoint and move bearer parsing into a shared helper
- point the Go agent sync code at the new endpoint, adding unit coverage and updating Vitest tests for both operator and agent flows

## Testing
- bun run test:unit tests/agent-plugin-api.test.ts
- go test ./internal/agent -run TestFetchApprovedPluginListUsesClientPluginEndpoint -count=1 -v


------
https://chatgpt.com/codex/tasks/task_e_68fcce20f14c832ba78c2f7590c673e9