### PR TITLE
Add notes module integration

### DIFF
--- a/shared/modules/index.ts
+++ b/shared/modules/index.ts
@@ -172,7 +172,7 @@ export const agentModules: AgentModuleDefinition[] = [
     title: "Incident Notes",
     description:
       "Secure local note taking synchronized with the controller vault.",
-    commands: [],
+    commands: ["notes.sync"],
     capabilities: [
       {
         id: "notes.sync",

--- a/tenvy-client/internal/agent/runtime.go
+++ b/tenvy-client/internal/agent/runtime.go
@@ -174,19 +174,6 @@ func runAgentOnce(ctx context.Context, opts RuntimeOptions) error {
 		}
 	}
 
-	modules := newDefaultModuleManager()
-	modules.SetEnabledModules(opts.EnabledModules)
-	agent.modules = modules
-	if err := modules.Init(ctx, agent.moduleRuntime()); err != nil {
-		return fmt.Errorf("initialize modules: %w", err)
-	}
-
-	router, err := newDefaultCommandRouter()
-	if err != nil {
-		return fmt.Errorf("initialize commands: %w", err)
-	}
-	agent.commands = router
-
 	if notesPath, err := notes.DefaultPath(dataDirectory(opts.Preferences)); err != nil {
 		opts.Logger.Printf("notes disabled (path error): %v", err)
 	} else {
@@ -204,6 +191,19 @@ func runAgentOnce(ctx context.Context, opts RuntimeOptions) error {
 			agent.notes = notesManager
 		}
 	}
+
+	modules := newDefaultModuleManager()
+	modules.SetEnabledModules(opts.EnabledModules)
+	agent.modules = modules
+	if err := modules.Init(ctx, agent.moduleRuntime()); err != nil {
+		return fmt.Errorf("initialize modules: %w", err)
+	}
+
+	router, err := newDefaultCommandRouter()
+	if err != nil {
+		return fmt.Errorf("initialize commands: %w", err)
+	}
+	agent.commands = router
 
 	agent.applyPreferences()
 


### PR DESCRIPTION
## Summary
- initialize the notes manager before module startup and include it in the agent module runtime config
- add a notes module backed by the notes manager, register it with the default module set, and publish the matching metadata to shared modules
- cover the new module with unit tests to confirm registration, metadata, and sync command handling

## Testing
- cd tenvy-client && go test ./internal/agent -run TestNotesModuleRegistrationAndSync -count=1 -timeout=120s

------
https://chatgpt.com/codex/tasks/task_e_68fcded16634832bab66bd9d01c564e9