### PR TITLE
Handle plugin package archives in upload API

### DIFF
--- a/tenvy-server/bun.lock
+++ b/tenvy-server/bun.lock
@@ -22,6 +22,7 @@
         "rate-limiter-flexible": "^8.1.0",
         "shell-quote": "^1.8.3",
         "systeminformation": "^5.27.11",
+        "tar-stream": "^3.1.7",
         "topojson-client": "^3.1.0",
         "tweetnacl": "^1.0.3",
         "world-atlas": "^2.0.2",
@@ -530,7 +531,11 @@
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
+    "b4a": ["b4a@1.7.3", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q=="],
+
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "bare-events": ["bare-events@2.8.1", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-oxSAxTS1hRfnyit2CL5QpAOS5ixfBjj6ex3yTNvXyY/kE719jQ/IjuESJBK2w5v4wwQRAHGseVJXx9QBYOtFGQ=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -750,11 +755,15 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
     "expect-type": ["expect-type@1.2.2", "", {}, "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -1190,6 +1199,8 @@
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
+    "streamx": ["streamx@2.23.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg=="],
+
     "string-width": ["string-width@1.0.2", "", { "dependencies": { "code-point-at": "^1.0.0", "is-fullwidth-code-point": "^1.0.0", "strip-ansi": "^3.0.0" } }, "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw=="],
 
     "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
@@ -1232,7 +1243,9 @@
 
     "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
-    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+    "tar-stream": ["tar-stream@3.1.7", "", { "dependencies": { "b4a": "^1.6.4", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ=="],
+
+    "text-decoder": ["text-decoder@1.2.3", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA=="],
 
     "thirty-two": ["thirty-two@1.0.2", "", {}, "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA=="],
 
@@ -1406,7 +1419,7 @@
 
     "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
-    "tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+    "tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "topojson-client/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
@@ -1481,6 +1494,8 @@
     "read-pkg-up/find-up/path-exists": ["path-exists@2.1.0", "", { "dependencies": { "pinkie-promise": "^2.0.0" } }, "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@2.1.1", "", {}, "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="],
+
+    "tar-fs/tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "wide-align/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 

--- a/tenvy-server/package.json
+++ b/tenvy-server/package.json
@@ -89,11 +89,12 @@
 		"otplib": "^12.0.1",
 		"ps-list": "^9.0.0",
 		"rate-limiter-flexible": "^8.1.0",
-		"shell-quote": "^1.8.3",
-		"systeminformation": "^5.27.11",
-		"topojson-client": "^3.1.0",
-		"tweetnacl": "^1.0.3",
-		"world-atlas": "^2.0.2",
-		"zod": "^4.1.12"
-	}
+                "shell-quote": "^1.8.3",
+                "systeminformation": "^5.27.11",
+                "tar-stream": "^3.1.7",
+                "topojson-client": "^3.1.0",
+                "tweetnacl": "^1.0.3",
+                "world-atlas": "^2.0.2",
+                "zod": "^4.1.12"
+        }
 }

--- a/tenvy-server/src/lib/server/plugins/archive.ts
+++ b/tenvy-server/src/lib/server/plugins/archive.ts
@@ -1,0 +1,227 @@
+import { mkdtemp, mkdir, writeFile, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve, sep } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import JSZip from 'jszip';
+import { extract as createTarExtract } from 'tar-stream';
+import { createGunzip } from 'node:zlib';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+export class ArchiveExtractionError extends Error {
+        constructor(message: string, options?: ErrorOptions) {
+                super(message, options);
+                this.name = 'ArchiveExtractionError';
+        }
+}
+
+export interface ExtractedArchiveEntry {
+        relativePath: string;
+        absolutePath: string;
+}
+
+export interface ExtractPluginArchiveResult {
+        directory: string;
+        manifestPath: string | null;
+        entries: Map<string, ExtractedArchiveEntry>;
+        entriesByBasename: Map<string, ExtractedArchiveEntry>;
+        cleanup: () => Promise<void>;
+}
+
+interface ExtractArchiveOptions {
+        fileName?: string;
+}
+
+const normalizeEntryPath = (entryName: string): string => {
+        let normalized = entryName.replace(/\\/g, '/');
+        normalized = normalized.replace(/^\.\/+/, '');
+        normalized = normalized.replace(/\/+/g, '/');
+        while (normalized.startsWith('../')) {
+                normalized = normalized.substring(3);
+        }
+        return normalized;
+};
+
+const ensureExtractionDirectory = async (): Promise<string> => {
+        const prefix = join(tmpdir(), 'tenvy-plugin-');
+        return mkdtemp(`${prefix}${randomUUID()}-`);
+};
+
+const ensureWithinDirectory = (baseDir: string, targetPath: string): void => {
+        const normalizedBase = baseDir.endsWith(sep) ? baseDir : `${baseDir}${sep}`;
+        const resolved = resolve(targetPath);
+        if (!resolved.startsWith(normalizedBase)) {
+                throw new ArchiveExtractionError('Archive entry resolves outside of extraction directory');
+        }
+};
+
+const recordEntry = (
+        result: ExtractPluginArchiveResult,
+        relativePath: string,
+        absolutePath: string
+) => {
+        const entry: ExtractedArchiveEntry = { relativePath, absolutePath };
+        result.entries.set(relativePath, entry);
+        const base = basename(relativePath);
+        if (!result.entriesByBasename.has(base)) {
+                result.entriesByBasename.set(base, entry);
+        }
+};
+
+const writeArchiveEntry = async (
+        result: ExtractPluginArchiveResult,
+        entryName: string,
+        data: Uint8Array
+) => {
+        const relativePath = normalizeEntryPath(entryName);
+        if (!relativePath || relativePath.includes('..')) {
+                throw new ArchiveExtractionError('Archive entry has an invalid name');
+        }
+
+        const absolutePath = resolve(result.directory, relativePath);
+        ensureWithinDirectory(result.directory, absolutePath);
+        await mkdir(dirname(absolutePath), { recursive: true });
+        await writeFile(absolutePath, data);
+        recordEntry(result, relativePath, absolutePath);
+};
+
+const writeDirectoryEntry = async (result: ExtractPluginArchiveResult, entryName: string) => {
+        const relativePath = normalizeEntryPath(entryName);
+        if (!relativePath || relativePath.includes('..')) {
+                throw new ArchiveExtractionError('Archive entry has an invalid name');
+        }
+        const absolutePath = resolve(result.directory, relativePath);
+        ensureWithinDirectory(result.directory, absolutePath);
+        await mkdir(absolutePath, { recursive: true });
+};
+
+const extractZipArchive = async (result: ExtractPluginArchiveResult, payload: Uint8Array) => {
+        const zip = await JSZip.loadAsync(payload);
+        const entries = Object.values(zip.files);
+        for (const entry of entries) {
+                const relativePath = normalizeEntryPath(entry.name);
+                if (!relativePath) {
+                        continue;
+                }
+                if (entry.dir) {
+                        await writeDirectoryEntry(result, relativePath);
+                        continue;
+                }
+                const content = await entry.async('nodebuffer');
+                await writeArchiveEntry(result, relativePath, content);
+        }
+};
+
+const streamToBuffer = async (stream: Readable): Promise<Buffer> => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of stream) {
+                chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : Buffer.from(chunk));
+        }
+        return Buffer.concat(chunks);
+};
+
+const extractTarGzArchive = async (result: ExtractPluginArchiveResult, payload: Uint8Array) => {
+        const extractStream = createTarExtract();
+        const completion = new Promise<void>((resolveExtract, rejectExtract) => {
+                let rejected = false;
+                const fail = (err: unknown) => {
+                        if (!rejected) {
+                                rejected = true;
+                                extractStream.destroy(err instanceof Error ? err : new Error(String(err)));
+                                rejectExtract(err);
+                        }
+                };
+
+                extractStream.on('entry', (header, stream, next) => {
+                        const entryName = header.name ?? '';
+                        const processEntry = async () => {
+                                try {
+                                        if (header.type === 'directory') {
+                                                await writeDirectoryEntry(result, entryName);
+                                        } else if (header.type === 'file' || header.type === 'contiguous-file') {
+                                                const data = await streamToBuffer(stream as unknown as Readable);
+                                                await writeArchiveEntry(result, entryName, data);
+                                        }
+                                        next();
+                                } catch (err) {
+                                        fail(err);
+                                }
+                        };
+
+                        stream.on('error', fail);
+                        void processEntry();
+                });
+                extractStream.on('finish', () => {
+                        if (!rejected) {
+                                resolveExtract();
+                        }
+                });
+                extractStream.on('error', fail);
+        });
+
+        await pipeline(Readable.from(payload), createGunzip(), extractStream);
+        await completion;
+};
+
+const detectArchiveFormat = (fileName: string | undefined, payload: Uint8Array): 'zip' | 'tar.gz' => {
+        const lower = fileName?.toLowerCase() ?? '';
+        if (lower.endsWith('.zip')) {
+                return 'zip';
+        }
+        if (lower.endsWith('.tar.gz') || lower.endsWith('.tgz')) {
+                return 'tar.gz';
+        }
+        if (payload.byteLength >= 2 && payload[0] === 0x50 && payload[1] === 0x4b) {
+                return 'zip';
+        }
+        if (payload.byteLength >= 2 && payload[0] === 0x1f && payload[1] === 0x8b) {
+                return 'tar.gz';
+        }
+        throw new ArchiveExtractionError('Unsupported archive format');
+};
+
+export const extractPluginArchive = async (
+        payload: Uint8Array,
+        options: ExtractArchiveOptions = {}
+): Promise<ExtractPluginArchiveResult> => {
+        if (payload.byteLength === 0) {
+                throw new ArchiveExtractionError('Archive payload is empty');
+        }
+
+        const directory = await ensureExtractionDirectory();
+        const result: ExtractPluginArchiveResult = {
+                directory,
+                manifestPath: null,
+                entries: new Map(),
+                entriesByBasename: new Map(),
+                cleanup: async () => {
+                        await rm(directory, { recursive: true, force: true });
+                }
+        };
+
+        try {
+                const format = detectArchiveFormat(options.fileName, payload);
+                if (format === 'zip') {
+                        await extractZipArchive(result, payload);
+                } else {
+                        await extractTarGzArchive(result, payload);
+                }
+        } catch (err) {
+                await result.cleanup();
+                throw err;
+        }
+
+        const manifestEntry = result.entriesByBasename.get('manifest.json');
+        result.manifestPath = manifestEntry?.absolutePath ?? null;
+
+        return result;
+};
+
+export const readExtractedManifest = async (
+        archive: ExtractPluginArchiveResult
+): Promise<string> => {
+        if (!archive.manifestPath) {
+                throw new ArchiveExtractionError('Archive is missing manifest.json');
+        }
+        return readFile(archive.manifestPath, 'utf8');
+};

--- a/tenvy-server/src/routes/api/plugins/+server.ts
+++ b/tenvy-server/src/routes/api/plugins/+server.ts
@@ -1,11 +1,16 @@
 import { createHash } from 'node:crypto';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { createPluginRepository } from '$lib/data/plugins.js';
 import { loadPluginManifests } from '$lib/data/plugin-manifests.js';
 import { getVerificationOptions } from '$lib/server/plugins/signature-policy.js';
+import {
+        ArchiveExtractionError,
+        extractPluginArchive,
+        readExtractedManifest
+} from '$lib/server/plugins/archive.js';
 import {
         validatePluginManifest,
         verifyPluginSignature,
@@ -94,90 +99,128 @@ export const POST: RequestHandler = async ({ request }) => {
         }
 
         const formData = await request.formData();
-        const manifestUpload = requireFile(formData.get('manifest'), 'manifest');
         const artifactUpload = requireFile(formData.get('artifact'), 'artifact');
+        const packageBuffer = Buffer.from(await artifactUpload.arrayBuffer());
 
-        let manifest: PluginManifest;
+        let archive: Awaited<ReturnType<typeof extractPluginArchive>> | null = null;
         try {
-                manifest = JSON.parse(await manifestUpload.text()) as PluginManifest;
+                archive = await extractPluginArchive(packageBuffer, { fileName: artifactUpload.name });
         } catch (err) {
-                console.warn('Rejected plugin upload: manifest is not valid JSON', err);
-                throw error(400, { message: 'Manifest must be valid JSON' });
+                if (err instanceof ArchiveExtractionError) {
+                        console.warn('Rejected plugin upload: invalid archive', err);
+                        throw error(400, { message: err.message });
+                }
+                throw err;
         }
 
-        const validationErrors = validatePluginManifest(manifest);
-        if (validationErrors.length > 0) {
-                console.warn('Rejected plugin upload: manifest failed validation', {
-                        errors: validationErrors
-                });
-                throw error(400, {
-                        message: 'Invalid plugin manifest',
-                        details: validationErrors
-                });
+        if (!archive) {
+                throw error(500, { message: 'Archive extraction failed' });
         }
 
-        const pluginId = ensurePluginId(manifest);
-        const manifestDirectory = resolveManifestDirectory();
-        const existingRecords = await loadPluginManifests({ directory: manifestDirectory });
-        const existingRecord = existingRecords.find((record) => record.manifest.id === pluginId);
-        if (existingRecord && existingRecord.manifest.version === manifest.version) {
-                console.warn('Rejected plugin upload: duplicate version', {
-                        pluginId,
-                        version: manifest.version
-                });
-                throw error(409, {
-                        message: `Plugin ${pluginId} version ${manifest.version} already exists`
-                });
-        }
+        try {
+                let manifestContent: string;
+                try {
+                        manifestContent = await readExtractedManifest(archive);
+                } catch (err) {
+                        if (err instanceof ArchiveExtractionError) {
+                                console.warn('Rejected plugin upload: manifest missing from archive', err);
+                                throw error(400, { message: err.message });
+                        }
+                        throw err;
+                }
+                let manifest: PluginManifest;
+                try {
+                        manifest = JSON.parse(manifestContent) as PluginManifest;
+                } catch (err) {
+                        console.warn('Rejected plugin upload: manifest is not valid JSON', err);
+                        throw error(400, { message: 'Manifest must be valid JSON' });
+                }
 
-        const artifactName = ensureArtifactReference(manifest);
-        const artifactBuffer = Buffer.from(await artifactUpload.arrayBuffer());
-        const artifactHash = createHash('sha256').update(artifactBuffer).digest('hex');
-        const manifestHash = manifest.package?.hash?.trim().toLowerCase();
-        if (!manifestHash) {
+                const validationErrors = validatePluginManifest(manifest);
+                if (validationErrors.length > 0) {
+                        console.warn('Rejected plugin upload: manifest failed validation', {
+                                errors: validationErrors
+                        });
+                        throw error(400, {
+                                message: 'Invalid plugin manifest',
+                                details: validationErrors
+                        });
+                }
+
+                const pluginId = ensurePluginId(manifest);
+                const manifestDirectory = resolveManifestDirectory();
+                const existingRecords = await loadPluginManifests({ directory: manifestDirectory });
+                const existingRecord = existingRecords.find((record) => record.manifest.id === pluginId);
+                if (existingRecord && existingRecord.manifest.version === manifest.version) {
+                        console.warn('Rejected plugin upload: duplicate version', {
+                                pluginId,
+                                version: manifest.version
+                        });
+                        throw error(409, {
+                                message: `Plugin ${pluginId} version ${manifest.version} already exists`
+                        });
+                }
+
+                const artifactName = ensureArtifactReference(manifest);
+                const extractedArtifact = archive.entriesByBasename.get(artifactName);
+                if (!extractedArtifact) {
+                        console.warn('Rejected plugin upload: artifact missing from archive', {
+                                pluginId,
+                                artifactName
+                        });
+                        throw error(400, { message: `Plugin artifact ${artifactName} is missing from archive` });
+                }
+
+                const artifactBuffer = await readFile(extractedArtifact.absolutePath);
+                const artifactHash = createHash('sha256').update(artifactBuffer).digest('hex');
+                const manifestHash = manifest.package?.hash?.trim().toLowerCase();
+                if (!manifestHash) {
                         throw error(400, { message: 'Plugin manifest is missing package hash' });
-        }
+                }
 
-        if (artifactHash !== manifestHash) {
-                console.warn('Rejected plugin upload: artifact hash mismatch', {
+                if (artifactHash !== manifestHash) {
+                        console.warn('Rejected plugin upload: artifact hash mismatch', {
+                                pluginId,
+                                expected: manifestHash,
+                                actual: artifactHash
+                        });
+                        throw error(400, {
+                                message: 'Artifact hash does not match manifest package hash'
+                        });
+                }
+
+                if (manifest.package) {
+                        manifest.package.sizeBytes = artifactBuffer.byteLength;
+                }
+
+                try {
+                        await verifyPluginSignature(manifest, getVerificationOptions());
+                } catch (err) {
+                        console.warn('Rejected plugin upload: signature verification failed', err);
+                        throw error(400, {
+                                message: err instanceof Error ? err.message : 'Signature verification failed'
+                        });
+                }
+
+                await writeArtifact(manifestDirectory, artifactName, artifactBuffer);
+                await writeManifest(manifestDirectory, pluginId, manifest);
+
+                const plugin = await repository.get(pluginId);
+
+                console.info('Accepted plugin upload', {
                         pluginId,
-                        expected: manifestHash,
-                        actual: artifactHash
+                        version: manifest.version,
+                        replacedVersion: existingRecord?.manifest.version ?? null
                 });
-                throw error(400, {
-                        message: 'Artifact hash does not match manifest package hash'
-                });
+
+                return json(
+                        {
+                                plugin,
+                                approvalStatus: plugin.approvalStatus ?? 'pending'
+                        },
+                        { status: existingRecord ? 200 : 201 }
+                );
+        } finally {
+                await archive.cleanup();
         }
-
-        if (manifest.package) {
-                manifest.package.sizeBytes = artifactBuffer.byteLength;
-        }
-
-        try {
-                await verifyPluginSignature(manifest, getVerificationOptions());
-        } catch (err) {
-                console.warn('Rejected plugin upload: signature verification failed', err);
-                throw error(400, {
-                        message: err instanceof Error ? err.message : 'Signature verification failed'
-                });
-        }
-
-        await writeArtifact(manifestDirectory, artifactName, artifactBuffer);
-        await writeManifest(manifestDirectory, pluginId, manifest);
-
-        const plugin = await repository.get(pluginId);
-
-        console.info('Accepted plugin upload', {
-                pluginId,
-                version: manifest.version,
-                replacedVersion: existingRecord?.manifest.version ?? null
-        });
-
-        return json(
-                {
-                        plugin,
-                        approvalStatus: plugin.approvalStatus ?? 'pending'
-                },
-                { status: existingRecord ? 200 : 201 }
-        );
 };

--- a/tenvy-server/tests/agent-plugin-api.test.ts
+++ b/tenvy-server/tests/agent-plugin-api.test.ts
@@ -3,17 +3,58 @@ import { createHash } from 'node:crypto';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { gzipSync } from 'node:zlib';
 import { db } from '$lib/server/db/index.js';
 import { plugin as pluginTable } from '$lib/server/db/schema.js';
 import { eq } from 'drizzle-orm';
 import { refreshSignaturePolicy } from '$lib/server/plugins/signature-policy.js';
 import { PluginTelemetryStore } from '$lib/server/plugins/telemetry-store.js';
+import JSZip from 'jszip';
+import { pack as createTarPack } from 'tar-stream';
 
 const RELEASE_SIGNER = 'release';
 const RELEASE_PUBLIC_KEY = 'ea9ceca1c7c7176859b235e095cbca9b5755746b741865cab5458d6f0e754cc2';
 const RELEASE_SIGNATURE_TIMESTAMP = '2024-01-01T00:00:00Z';
 const RELEASE_ARTIFACT_SIGNATURE =
         '2b4a75ee35bc4f9f9b15b84e8c993886f1ae98ce73e289df36c03835fc2920a71e9df3018650e99b0e48df6483d1adb112efec64edcd883725ef1e9dcc7c040b';
+
+const toBuffer = (value: string | Uint8Array | Buffer): Buffer =>
+        typeof value === 'string' ? Buffer.from(value, 'utf8') : Buffer.from(value);
+
+const createZipPluginPackage = async (files: Record<string, string | Uint8Array | Buffer>) => {
+        const zip = new JSZip();
+        for (const [name, content] of Object.entries(files)) {
+                zip.file(name, toBuffer(content));
+        }
+        return zip.generateAsync({ type: 'nodebuffer' });
+};
+
+const createTarGzPluginPackage = async (files: Record<string, string | Uint8Array | Buffer>) => {
+        const pack = createTarPack();
+        const chunks: Buffer[] = [];
+        pack.on('data', (chunk) => {
+                chunks.push(Buffer.from(chunk));
+        });
+        const completion = new Promise<void>((resolve, reject) => {
+                pack.on('end', () => resolve());
+                pack.on('error', (err) => reject(err));
+        });
+        for (const [name, content] of Object.entries(files)) {
+                await new Promise<void>((resolveEntry, rejectEntry) => {
+                        pack.entry({ name }, toBuffer(content), (err) => {
+                                if (err) {
+                                        rejectEntry(err);
+                                } else {
+                                        resolveEntry();
+                                }
+                        });
+                });
+        }
+        pack.finalize();
+        await completion;
+        const tarBuffer = Buffer.concat(chunks);
+        return gzipSync(tarBuffer);
+};
 
 const mockEnv = vi.hoisted(() => {
         process.env.DATABASE_URL = ':memory:';
@@ -50,46 +91,46 @@ describe('agent plugin API', () => {
         beforeEach(async () => {
                 manifestDir = mkdtempSync(join(tmpdir(), 'tenvy-agent-manifests-'));
                 const manifestPath = join(manifestDir, `${manifestId}.json`);
-        const artifactPath = join(manifestDir, 'pkg.zip');
-        const artifactBuffer = Buffer.from(artifactContent, 'utf8');
-        const artifactHash = createHash('sha256').update(artifactBuffer).digest('hex');
-        writeFileSync(artifactPath, artifactBuffer);
-        writeFileSync(
-                manifestPath,
-                JSON.stringify({
-                        id: manifestId,
+                const artifactPath = join(manifestDir, 'pkg.zip');
+                const artifactBuffer = Buffer.from(artifactContent, 'utf8');
+                const artifactHash = createHash('sha256').update(artifactBuffer).digest('hex');
+                writeFileSync(artifactPath, artifactBuffer);
+                writeFileSync(
+                        manifestPath,
+                        JSON.stringify({
+                                id: manifestId,
                                 name: 'Test Plugin',
                                 version: '1.0.0',
                                 entry: 'plugin.exe',
                                 repositoryUrl: 'https://github.com/rootbay/test-plugin',
                                 license: { spdxId: 'MIT' },
                                 requirements: {},
-                        distribution: {
-                                defaultMode: 'automatic',
-                                autoUpdate: true,
-                                signature: 'ed25519',
-                                signatureHash: artifactHash,
-                                signatureSigner: RELEASE_SIGNER,
-                                signatureValue: RELEASE_ARTIFACT_SIGNATURE,
-                                signatureTimestamp: RELEASE_SIGNATURE_TIMESTAMP
-                        },
-                        package: {
-                                artifact: 'pkg.zip',
-                                hash: artifactHash,
-                                sizeBytes: artifactBuffer.byteLength
-                        }
+                                distribution: {
+                                        defaultMode: 'automatic',
+                                        autoUpdate: true,
+                                        signature: 'ed25519',
+                                        signatureHash: artifactHash,
+                                        signatureSigner: RELEASE_SIGNER,
+                                        signatureValue: RELEASE_ARTIFACT_SIGNATURE,
+                                        signatureTimestamp: RELEASE_SIGNATURE_TIMESTAMP
+                                },
+                                package: {
+                                        artifact: 'pkg.zip',
+                                        hash: artifactHash,
+                                        sizeBytes: artifactBuffer.byteLength
+                                }
                         })
                 );
 
                 trustDir = mkdtempSync(join(tmpdir(), 'tenvy-plugin-trust-'));
                 trustPath = join(trustDir, 'trust.json');
-        writeFileSync(
-                trustPath,
-                JSON.stringify({
-                        sha256AllowList: [artifactHash],
-                        ed25519PublicKeys: { [RELEASE_SIGNER]: RELEASE_PUBLIC_KEY }
-                })
-        );
+                writeFileSync(
+                        trustPath,
+                        JSON.stringify({
+                                sha256AllowList: [artifactHash],
+                                ed25519PublicKeys: { [RELEASE_SIGNER]: RELEASE_PUBLIC_KEY }
+                        })
+                );
 
                 process.env.TENVY_PLUGIN_MANIFEST_DIR = manifestDir;
                 process.env.TENVY_PLUGIN_TRUST_CONFIG = trustPath;
@@ -193,20 +234,18 @@ describe('agent plugin API', () => {
                 expect(Buffer.from(artifactBuffer).toString()).toBe(artifactContent);
         });
 
-        it('accepts plugin uploads and persists runtime metadata', async () => {
+        it('accepts plugin uploads from zip archives and persists runtime metadata', async () => {
                 const { POST } = await import('../src/routes/api/plugins/+server.ts');
 
                 const artifactPayload = 'uploaded artifact payload';
                 const artifactBuffer = Buffer.from(artifactPayload, 'utf8');
                 const artifactHash = createHash('sha256').update(artifactBuffer).digest('hex');
+                const existingHash = createHash('sha256').update(artifactContent, 'utf8').digest('hex');
 
                 writeFileSync(
                         trustPath,
                         JSON.stringify({
-                                sha256AllowList: [
-                                        createHash('sha256').update(artifactContent, 'utf8').digest('hex'),
-                                        artifactHash
-                                ],
+                                sha256AllowList: [existingHash, artifactHash],
                                 ed25519PublicKeys: { [RELEASE_SIGNER]: RELEASE_PUBLIC_KEY }
                         })
                 );
@@ -227,20 +266,21 @@ describe('agent plugin API', () => {
                                 signatureHash: artifactHash
                         },
                         package: {
-                                artifact: 'uploaded.zip',
+                                artifact: 'uploaded.bin',
                                 hash: artifactHash,
                                 sizeBytes: artifactBuffer.byteLength
                         }
                 } satisfies Record<string, unknown>;
 
+                const archiveBuffer = await createZipPluginPackage({
+                        'manifest.json': JSON.stringify(manifest),
+                        'uploaded.bin': artifactBuffer
+                });
+
                 const form = new FormData();
                 form.set(
-                        'manifest',
-                        new File([JSON.stringify(manifest)], 'manifest.json', { type: 'application/json' })
-                );
-                form.set(
                         'artifact',
-                        new File([artifactBuffer], 'uploaded.zip', { type: 'application/octet-stream' })
+                        new File([archiveBuffer], 'uploaded.zip', { type: 'application/octet-stream' })
                 );
 
                 const response = await POST({
@@ -266,27 +306,174 @@ describe('agent plugin API', () => {
                 expect(row?.approvalStatus).toBe('pending');
         });
 
+        it('accepts plugin uploads from tar.gz archives', async () => {
+                const { POST } = await import('../src/routes/api/plugins/+server.ts');
+
+                const artifactBuffer = Buffer.from('tar payload', 'utf8');
+                const artifactHash = createHash('sha256').update(artifactBuffer).digest('hex');
+                const existingHash = createHash('sha256').update(artifactContent, 'utf8').digest('hex');
+
+                writeFileSync(
+                        trustPath,
+                        JSON.stringify({
+                                sha256AllowList: [existingHash, artifactHash],
+                                ed25519PublicKeys: { [RELEASE_SIGNER]: RELEASE_PUBLIC_KEY }
+                        })
+                );
+                refreshSignaturePolicy();
+
+                const manifest = {
+                        id: 'tar-plugin',
+                        name: 'Tar Plugin',
+                        version: '1.0.0',
+                        entry: 'tar.exe',
+                        requirements: {},
+                        distribution: {
+                                defaultMode: 'manual',
+                                autoUpdate: false,
+                                signature: 'sha256',
+                                signatureHash: artifactHash
+                        },
+                        package: {
+                                artifact: 'tar.bin',
+                                hash: artifactHash
+                        }
+                } satisfies Record<string, unknown>;
+
+                const archiveBuffer = await createTarGzPluginPackage({
+                        'manifest.json': JSON.stringify(manifest),
+                        'tar.bin': artifactBuffer
+                });
+
+                const form = new FormData();
+                form.set('artifact', new File([archiveBuffer], 'tar-plugin.tar.gz'));
+
+                const response = await POST({
+                        request: new Request('https://controller.test/api/plugins', {
+                                method: 'POST',
+                                body: form
+                        })
+                } as Parameters<typeof POST>[0]);
+
+                expect(response.status).toBe(201);
+        });
+
         it('rejects uploads with invalid manifests', async () => {
                 const { POST } = await import('../src/routes/api/plugins/+server.ts');
 
-                const artifactBuffer = Buffer.from('broken', 'utf8');
-
-                const manifest = {
-                        id: '',
-                        name: '',
-                        version: 'not-a-version',
-                        entry: '',
-                        requirements: {},
-                        distribution: { defaultMode: 'invalid', autoUpdate: false, signature: 'sha256' },
-                        package: { artifact: '', hash: '' }
-                } satisfies Record<string, unknown>;
+                const archiveBuffer = await createZipPluginPackage({
+                        'manifest.json': JSON.stringify({
+                                id: '',
+                                name: '',
+                                version: 'not-a-version',
+                                entry: '',
+                                requirements: {},
+                                distribution: { defaultMode: 'invalid', autoUpdate: false, signature: 'sha256' },
+                                package: { artifact: '', hash: '' }
+                        }),
+                        'artifact.bin': 'broken'
+                });
 
                 const form = new FormData();
-                form.set(
-                        'manifest',
-                        new File([JSON.stringify(manifest)], 'manifest.json', { type: 'application/json' })
-                );
-                form.set('artifact', new File([artifactBuffer], 'broken.zip', { type: 'application/octet-stream' }));
+                form.set('artifact', new File([archiveBuffer], 'invalid.zip'));
+
+                await expect(
+                        POST({
+                                request: new Request('https://controller.test/api/plugins', {
+                                        method: 'POST',
+                                        body: form
+                                })
+                        } as Parameters<typeof POST>[0])
+                ).rejects.toMatchObject({ status: 400 });
+        });
+
+        it('rejects uploads when manifest is missing from archive', async () => {
+                const { POST } = await import('../src/routes/api/plugins/+server.ts');
+
+                const archiveBuffer = await createZipPluginPackage({ 'plugin.bin': 'content' });
+
+                const form = new FormData();
+                form.set('artifact', new File([archiveBuffer], 'no-manifest.zip'));
+
+                await expect(
+                        POST({
+                                request: new Request('https://controller.test/api/plugins', {
+                                        method: 'POST',
+                                        body: form
+                                })
+                        } as Parameters<typeof POST>[0])
+                ).rejects.toMatchObject({ status: 400 });
+        });
+
+        it('rejects uploads when artifact hash mismatches manifest', async () => {
+                const { POST } = await import('../src/routes/api/plugins/+server.ts');
+
+                const artifactBuffer = Buffer.from('actual artifact', 'utf8');
+                const manifestHash = '0'.repeat(64);
+
+                const archiveBuffer = await createZipPluginPackage({
+                        'manifest.json': JSON.stringify({
+                                id: 'hash-mismatch',
+                                name: 'Hash Mismatch',
+                                version: '1.0.0',
+                                entry: 'mismatch.exe',
+                                requirements: {},
+                                distribution: {
+                                        defaultMode: 'manual',
+                                        autoUpdate: false,
+                                        signature: 'sha256',
+                                        signatureHash: manifestHash
+                                },
+                                package: {
+                                        artifact: 'mismatch.bin',
+                                        hash: manifestHash
+                                }
+                        }),
+                        'mismatch.bin': artifactBuffer
+                });
+
+                const form = new FormData();
+                form.set('artifact', new File([archiveBuffer], 'hash-mismatch.zip'));
+
+                await expect(
+                        POST({
+                                request: new Request('https://controller.test/api/plugins', {
+                                        method: 'POST',
+                                        body: form
+                                })
+                        } as Parameters<typeof POST>[0])
+                ).rejects.toMatchObject({ status: 400 });
+        });
+
+        it('rejects uploads when signature verification fails', async () => {
+                const { POST } = await import('../src/routes/api/plugins/+server.ts');
+
+                const artifactBuffer = Buffer.from('unsigned artifact', 'utf8');
+                const artifactHash = createHash('sha256').update(artifactBuffer).digest('hex');
+
+                const archiveBuffer = await createZipPluginPackage({
+                        'manifest.json': JSON.stringify({
+                                id: 'signature-failure',
+                                name: 'Signature Failure',
+                                version: '1.0.0',
+                                entry: 'signature.exe',
+                                requirements: {},
+                                distribution: {
+                                        defaultMode: 'manual',
+                                        autoUpdate: false,
+                                        signature: 'sha256',
+                                        signatureHash: artifactHash
+                                },
+                                package: {
+                                        artifact: 'signature.bin',
+                                        hash: artifactHash
+                                }
+                        }),
+                        'signature.bin': artifactBuffer
+                });
+
+                const form = new FormData();
+                form.set('artifact', new File([archiveBuffer], 'signature-failure.zip'));
 
                 await expect(
                         POST({
@@ -304,36 +491,32 @@ describe('agent plugin API', () => {
                 const artifactBuffer = Buffer.from(artifactContent, 'utf8');
                 const manifestHash = createHash('sha256').update(artifactBuffer).digest('hex');
 
-                const manifest = {
-                        id: manifestId,
-                        name: 'Test Plugin',
-                        version: '1.0.0',
-                        entry: 'plugin.exe',
-                        repositoryUrl: 'https://github.com/rootbay/test-plugin',
-                        license: { spdxId: 'MIT' },
-                        requirements: {},
-                        distribution: {
-                                defaultMode: 'automatic',
-                                autoUpdate: true,
-                                signature: 'sha256',
-                                signatureHash: manifestHash
-                        },
-                        package: {
-                                artifact: 'pkg.zip',
-                                hash: manifestHash,
-                                sizeBytes: artifactBuffer.byteLength
-                        }
-                } satisfies Record<string, unknown>;
+                const archiveBuffer = await createZipPluginPackage({
+                        'manifest.json': JSON.stringify({
+                                id: manifestId,
+                                name: 'Test Plugin',
+                                version: '1.0.0',
+                                entry: 'plugin.exe',
+                                repositoryUrl: 'https://github.com/rootbay/test-plugin',
+                                license: { spdxId: 'MIT' },
+                                requirements: {},
+                                distribution: {
+                                        defaultMode: 'automatic',
+                                        autoUpdate: true,
+                                        signature: 'sha256',
+                                        signatureHash: manifestHash
+                                },
+                                package: {
+                                        artifact: 'pkg.zip',
+                                        hash: manifestHash,
+                                        sizeBytes: artifactBuffer.byteLength
+                                }
+                        }),
+                        'pkg.zip': artifactBuffer
+                });
 
                 const form = new FormData();
-                form.set(
-                        'manifest',
-                        new File([JSON.stringify(manifest)], 'manifest.json', { type: 'application/json' })
-                );
-                form.set(
-                        'artifact',
-                        new File([artifactBuffer], 'pkg.zip', { type: 'application/octet-stream' })
-                );
+                form.set('artifact', new File([archiveBuffer], 'pkg.zip'));
 
                 await expect(
                         POST({

--- a/tenvy-server/tests/plugin-manifests.test.ts
+++ b/tenvy-server/tests/plugin-manifests.test.ts
@@ -37,7 +37,9 @@ describe('loadPluginManifests', () => {
                         distribution: {
                                 defaultMode: 'manual',
                                 autoUpdate: false,
-                                signature: 'sha256'
+                                signature: 'sha256',
+                                signatureHash:
+                                        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
                         },
                         requirements: {
                                 platforms: ['windows'],

--- a/tenvy-server/tests/plugins-repository.test.ts
+++ b/tenvy-server/tests/plugins-repository.test.ts
@@ -32,11 +32,9 @@ const manifestFixture = {
         distribution: {
                 defaultMode: 'automatic',
                 autoUpdate: true,
-                signature: {
-                        type: 'sha256',
-                        hash: 'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd',
-                        signature: '0123456789abcdef0123456789abcdef'
-                }
+                signature: 'sha256',
+                signatureHash: 'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+                signatureValue: '0123456789abcdef0123456789abcdef'
         },
         package: {
                 artifact: 'clipboard-sync-1.4.2.dll',


### PR DESCRIPTION
## Summary
- add archive extraction utilities to safely unpack zip and tar.gz plugin packages
- update the plugin upload endpoint to validate manifests and artifacts extracted from a single package upload
- extend plugin API tests for archive uploads and adjust manifest fixtures to the new schema
- add the tar-stream dependency for handling tar.gz archives

## Testing
- bun test:unit --run tests/plugin-manifests.test.ts tests/plugins-repository.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fcf601287c832b9d2aec0edc5a4a7c