### PR TITLE
Support tar.gz plugin artifacts

### DIFF
--- a/tenvy-client/internal/plugins/archive.go
+++ b/tenvy-client/internal/plugins/archive.go
@@ -1,7 +1,9 @@
 package plugins
 
 import (
+	"archive/tar"
 	"archive/zip"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"os"
@@ -73,4 +75,84 @@ func extractZipEntry(entry *zip.File, dest string) error {
 		os.Chmod(target, mode)
 	}
 	return nil
+}
+
+func unpackTarGzArchive(path, dest string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open artifact archive: %w", err)
+	}
+	defer file.Close()
+
+	gz, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("open artifact archive: %w", err)
+	}
+	defer gz.Close()
+
+	reader := tar.NewReader(gz)
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read artifact archive: %w", err)
+		}
+		if err := extractTarEntry(header, reader, dest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func extractTarEntry(header *tar.Header, reader io.Reader, dest string) error {
+	cleaned := filepath.Clean(header.Name)
+	if cleaned == "." || cleaned == "" {
+		return nil
+	}
+	target := filepath.Join(dest, cleaned)
+	if !strings.HasPrefix(target, dest+string(os.PathSeparator)) && target != dest {
+		return fmt.Errorf("artifact entry escapes destination: %s", header.Name)
+	}
+
+	switch header.Typeflag {
+	case tar.TypeDir:
+		if err := os.MkdirAll(target, 0o755); err != nil {
+			return fmt.Errorf("create artifact directory: %w", err)
+		}
+		return nil
+	case tar.TypeReg, tar.TypeRegA:
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("prepare artifact path: %w", err)
+		}
+
+		temp, err := os.CreateTemp(filepath.Dir(target), "entry-*.tmp")
+		if err != nil {
+			return fmt.Errorf("create artifact temp file: %w", err)
+		}
+		tempPath := temp.Name()
+
+		if _, err := io.Copy(temp, reader); err != nil {
+			temp.Close()
+			os.Remove(tempPath)
+			return fmt.Errorf("write artifact entry: %w", err)
+		}
+		if err := temp.Close(); err != nil {
+			os.Remove(tempPath)
+			return fmt.Errorf("close artifact entry: %w", err)
+		}
+		if err := os.Rename(tempPath, target); err != nil {
+			os.Remove(tempPath)
+			return fmt.Errorf("finalize artifact entry: %w", err)
+		}
+		if mode := header.FileInfo().Mode(); mode != 0 {
+			os.Chmod(target, mode)
+		}
+		return nil
+	case tar.TypeXHeader, tar.TypeXGlobalHeader, tar.TypeGNUSparse, tar.TypeGNULongName, tar.TypeGNULongLink:
+		return nil
+	default:
+		return fmt.Errorf("artifact entry type not supported: %s", header.Name)
+	}
 }

--- a/tenvy-client/internal/plugins/remotedesktop_test.go
+++ b/tenvy-client/internal/plugins/remotedesktop_test.go
@@ -1,74 +1,76 @@
 package plugins_test
 
 import (
-        "archive/zip"
-        "bytes"
-        "context"
-        "crypto/ed25519"
-        "crypto/sha256"
-        "encoding/hex"
-        "fmt"
-        "io"
-        "log"
-        "net/http"
-        "net/http/httptest"
-        "os"
-        "path/filepath"
-        "strings"
-        "sync/atomic"
-        "testing"
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
 
 	plugins "github.com/rootbay/tenvy-client/internal/plugins"
 	manifest "github.com/rootbay/tenvy-client/shared/pluginmanifest"
 )
 
 const (
-        releaseSeedHex       = "11e4f334ae8f5dafc590d45ea6465ed65280579656f324cafe4d73109db06936"
-        releasePublicKeyHex  = "ea9ceca1c7c7176859b235e095cbca9b5755746b741865cab5458d6f0e754cc2"
-        releaseSigner        = "release"
-        releaseSignedAtStamp = "2024-01-01T00:00:00Z"
+	releaseSeedHex       = "11e4f334ae8f5dafc590d45ea6465ed65280579656f324cafe4d73109db06936"
+	releasePublicKeyHex  = "ea9ceca1c7c7176859b235e095cbca9b5755746b741865cab5458d6f0e754cc2"
+	releaseSigner        = "release"
+	releaseSignedAtStamp = "2024-01-01T00:00:00Z"
 )
 
 func decodeHex(t *testing.T, value string) []byte {
-        t.Helper()
-        decoded, err := hex.DecodeString(strings.TrimSpace(value))
-        if err != nil {
-                t.Fatalf("decode hex: %v", err)
-        }
-        return decoded
+	t.Helper()
+	decoded, err := hex.DecodeString(strings.TrimSpace(value))
+	if err != nil {
+		t.Fatalf("decode hex: %v", err)
+	}
+	return decoded
 }
 
 func releasePublicKey(t *testing.T) ed25519.PublicKey {
-        t.Helper()
-        return ed25519.PublicKey(decodeHex(t, releasePublicKeyHex))
+	t.Helper()
+	return ed25519.PublicKey(decodeHex(t, releasePublicKeyHex))
 }
 
 func releaseSignatureFor(t *testing.T, hash string) string {
-        t.Helper()
-        seed := decodeHex(t, releaseSeedHex)
-        privateKey := ed25519.NewKeyFromSeed(seed)
-        normalized := strings.ToLower(strings.TrimSpace(hash))
-        signature := ed25519.Sign(privateKey, []byte(normalized))
-        return hex.EncodeToString(signature)
+	t.Helper()
+	seed := decodeHex(t, releaseSeedHex)
+	privateKey := ed25519.NewKeyFromSeed(seed)
+	normalized := strings.ToLower(strings.TrimSpace(hash))
+	signature := ed25519.Sign(privateKey, []byte(normalized))
+	return hex.EncodeToString(signature)
 }
 
 func releaseVerifyOptions(t *testing.T, allowList ...string) manifest.VerifyOptions {
-        t.Helper()
-        opts := manifest.VerifyOptions{
-                Ed25519PublicKeys: map[string]ed25519.PublicKey{
-                        releaseSigner: releasePublicKey(t),
-                },
-        }
-        if len(allowList) > 0 {
-                opts.SHA256AllowList = append([]string(nil), allowList...)
-        }
-        return opts
+	t.Helper()
+	opts := manifest.VerifyOptions{
+		Ed25519PublicKeys: map[string]ed25519.PublicKey{
+			releaseSigner: releasePublicKey(t),
+		},
+	}
+	if len(allowList) > 0 {
+		opts.SHA256AllowList = append([]string(nil), allowList...)
+	}
+	return opts
 }
 
 func buildDescriptor(manifestJSON, version, artifactHash string, briefing manifest.ManifestBriefing) manifest.ManifestDescriptor {
-        digest := sha256.Sum256([]byte(manifestJSON))
-        descriptor := manifest.ManifestDescriptor{
-                PluginID:       plugins.RemoteDesktopEnginePluginID,
+	digest := sha256.Sum256([]byte(manifestJSON))
+	descriptor := manifest.ManifestDescriptor{
+		PluginID:       plugins.RemoteDesktopEnginePluginID,
 		Version:        version,
 		ManifestDigest: fmt.Sprintf("%x", digest[:]),
 		Distribution:   briefing,
@@ -82,14 +84,14 @@ func buildDescriptor(manifestJSON, version, artifactHash string, briefing manife
 func TestStageRemoteDesktopEngineSuccess(t *testing.T) {
 	t.Parallel()
 
-        artifactData := buildRemoteDesktopArtifact(t, map[string][]byte{
-                "remote-desktop-engine/remote-desktop-engine": []byte("engine payload"),
-        })
-        hash := sha256.Sum256(artifactData)
-        hashHex := fmt.Sprintf("%x", hash[:])
-        signatureValue := releaseSignatureFor(t, hashHex)
+	artifactData := buildRemoteDesktopArtifact(t, map[string][]byte{
+		"remote-desktop-engine/remote-desktop-engine": []byte("engine payload"),
+	})
+	hash := sha256.Sum256(artifactData)
+	hashHex := fmt.Sprintf("%x", hash[:])
+	signatureValue := releaseSignatureFor(t, hashHex)
 
-        manifestJSON := fmt.Sprintf(`{
+	manifestJSON := fmt.Sprintf(`{
                 "id": "remote-desktop-engine",
                 "name": "Remote Desktop Engine",
                 "version": "9.9.9",
@@ -117,7 +119,7 @@ func TestStageRemoteDesktopEngineSuccess(t *testing.T) {
 	defer server.Close()
 
 	root := t.TempDir()
-        opts := releaseVerifyOptions(t)
+	opts := releaseVerifyOptions(t)
 	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
@@ -170,6 +172,153 @@ func TestStageRemoteDesktopEngineSuccess(t *testing.T) {
 	}
 	if result2.Updated {
 		t.Fatalf("expected restage to be no-op")
+	}
+}
+
+func TestStageRemoteDesktopEngineSuccessTarGz(t *testing.T) {
+	t.Parallel()
+
+	artifactData := buildTarGzArchive(t, map[string][]byte{
+		"remote-desktop-engine/remote-desktop-engine": []byte("engine payload"),
+	})
+	hash := sha256.Sum256(artifactData)
+	hashHex := fmt.Sprintf("%x", hash[:])
+	signatureValue := releaseSignatureFor(t, hashHex)
+
+	manifestJSON := fmt.Sprintf(`{
+                "id": "remote-desktop-engine",
+                "name": "Remote Desktop Engine",
+                "version": "9.9.9",
+                "entry": "remote-desktop-engine/remote-desktop-engine",
+                "repositoryUrl": "https://github.com/rootbay/tenvy-client",
+                "license": {"spdxId": "MIT"},
+                "requirements": {},
+                "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "%[2]s", "signatureValue": "%[3]s", "signatureTimestamp": "%[4]s"},
+                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.tar.gz", "hash": "%[1]s"}
+        }`, hashHex, releaseSigner, signatureValue, releaseSignedAtStamp)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/artifact") {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			if _, err := w.Write(artifactData); err != nil {
+				t.Fatalf("write artifact: %v", err)
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := io.WriteString(w, manifestJSON); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	root := t.TempDir()
+	opts := releaseVerifyOptions(t)
+	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	descriptor := buildDescriptor(
+		manifestJSON,
+		"9.9.9",
+		hashHex,
+		manifest.ManifestBriefing{DefaultMode: manifest.DeliveryAutomatic, AutoUpdate: true},
+	)
+
+	ctx := context.Background()
+	result, err := plugins.StageRemoteDesktopEngine(ctx, manager, server.Client(), server.URL, "agent-1", "", "stage-test", manifest.RuntimeFacts{}, descriptor)
+	if err != nil {
+		t.Fatalf("stage engine: %v", err)
+	}
+	if !result.Updated {
+		t.Fatalf("expected install to be marked updated")
+	}
+	if strings.TrimSpace(result.EntryPath) == "" {
+		t.Fatalf("expected entry path, got empty string")
+	}
+
+	entryPayload, err := os.ReadFile(result.EntryPath)
+	if err != nil {
+		t.Fatalf("read entry payload: %v", err)
+	}
+	if string(entryPayload) != "engine payload" {
+		t.Fatalf("unexpected entry payload %q", string(entryPayload))
+	}
+
+	artifactPath := filepath.Join(manager.Root(), plugins.RemoteDesktopEnginePluginID, "remote-desktop-engine", "remote-desktop-engine.tar.gz")
+	if _, err := os.Stat(artifactPath); err != nil {
+		t.Fatalf("expected artifact persisted: %v", err)
+	}
+}
+
+func TestStageRemoteDesktopEngineFailsMalformedTarGz(t *testing.T) {
+	t.Parallel()
+
+	artifactData := []byte("not a tar.gz archive")
+	hash := sha256.Sum256(artifactData)
+	hashHex := fmt.Sprintf("%x", hash[:])
+	signatureValue := releaseSignatureFor(t, hashHex)
+
+	manifestJSON := fmt.Sprintf(`{
+                "id": "remote-desktop-engine",
+                "name": "Remote Desktop Engine",
+                "version": "2.2.2",
+                "entry": "remote-desktop-engine/remote-desktop-engine",
+                "repositoryUrl": "https://github.com/rootbay/tenvy-client",
+                "license": {"spdxId": "MIT"},
+                "requirements": {},
+                "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "%[2]s", "signatureValue": "%[3]s", "signatureTimestamp": "%[4]s"},
+                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.tar.gz", "hash": "%[1]s"}
+        }`, hashHex, releaseSigner, signatureValue, releaseSignedAtStamp)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/artifact") {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			if _, err := w.Write(artifactData); err != nil {
+				t.Fatalf("write artifact: %v", err)
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := io.WriteString(w, manifestJSON); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	root := t.TempDir()
+	opts := releaseVerifyOptions(t)
+	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	descriptor := buildDescriptor(
+		manifestJSON,
+		"2.2.2",
+		hashHex,
+		manifest.ManifestBriefing{DefaultMode: manifest.DeliveryAutomatic, AutoUpdate: true},
+	)
+
+	_, err = plugins.StageRemoteDesktopEngine(context.Background(), manager, server.Client(), server.URL, "agent-1", "", "stage-test", manifest.RuntimeFacts{}, descriptor)
+	if err == nil {
+		t.Fatal("expected staging to fail")
+	}
+	if !strings.Contains(err.Error(), "artifact") {
+		t.Fatalf("expected artifact failure, got %v", err)
+	}
+
+	snapshot := manager.Snapshot()
+	if snapshot == nil || len(snapshot.Installations) != 1 {
+		t.Fatalf("expected failure snapshot entry, got %#v", snapshot)
+	}
+	install := snapshot.Installations[0]
+	if install.Status != manifest.InstallError {
+		t.Fatalf("expected failure status, got %s", install.Status)
+	}
+	if install.Error == "" || !strings.Contains(install.Error, "artifact") {
+		t.Fatalf("expected artifact error message, got %q", install.Error)
 	}
 }
 
@@ -272,14 +421,14 @@ func TestStageRemoteDesktopEngineRespectsManualPolicyWithoutSignal(t *testing.T)
 func TestStageRemoteDesktopEngineAllowsManualWhenRequested(t *testing.T) {
 	t.Parallel()
 
-        artifactData := buildRemoteDesktopArtifact(t, map[string][]byte{
-                "remote-desktop-engine/remote-desktop-engine": []byte("engine payload"),
-        })
-        hash := sha256.Sum256(artifactData)
-        hashHex := fmt.Sprintf("%x", hash[:])
-        signatureValue := releaseSignatureFor(t, hashHex)
+	artifactData := buildRemoteDesktopArtifact(t, map[string][]byte{
+		"remote-desktop-engine/remote-desktop-engine": []byte("engine payload"),
+	})
+	hash := sha256.Sum256(artifactData)
+	hashHex := fmt.Sprintf("%x", hash[:])
+	signatureValue := releaseSignatureFor(t, hashHex)
 
-        manifestJSON := fmt.Sprintf(`{
+	manifestJSON := fmt.Sprintf(`{
                 "id": "remote-desktop-engine",
                 "name": "Remote Desktop Engine",
                 "version": "5.5.5",
@@ -308,8 +457,8 @@ func TestStageRemoteDesktopEngineAllowsManualWhenRequested(t *testing.T) {
 	}))
 	defer server.Close()
 
-        root := t.TempDir()
-        opts := releaseVerifyOptions(t)
+	root := t.TempDir()
+	opts := releaseVerifyOptions(t)
 	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
@@ -370,9 +519,9 @@ func TestStageRemoteDesktopEngineAllowsManualWhenRequested(t *testing.T) {
 func TestStageRemoteDesktopEngineBlocksIncompatiblePlatform(t *testing.T) {
 	t.Parallel()
 
-        hashHex := strings.Repeat("ab", 32)
-        signatureValue := releaseSignatureFor(t, hashHex)
-        manifestJSON := fmt.Sprintf(`{
+	hashHex := strings.Repeat("ab", 32)
+	signatureValue := releaseSignatureFor(t, hashHex)
+	manifestJSON := fmt.Sprintf(`{
                 "id": "remote-desktop-engine",
                 "name": "Remote Desktop Engine",
                 "version": "1.0.0",
@@ -397,8 +546,8 @@ func TestStageRemoteDesktopEngineBlocksIncompatiblePlatform(t *testing.T) {
 	}))
 	defer server.Close()
 
-        root := t.TempDir()
-        opts := releaseVerifyOptions(t)
+	root := t.TempDir()
+	opts := releaseVerifyOptions(t)
 	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
@@ -445,9 +594,9 @@ func TestStageRemoteDesktopEngineBlocksIncompatiblePlatform(t *testing.T) {
 func TestStageRemoteDesktopEngineBlocksIncompatibleArchitecture(t *testing.T) {
 	t.Parallel()
 
-        hashHex := strings.Repeat("cd", 32)
-        signatureValue := releaseSignatureFor(t, hashHex)
-        manifestJSON := fmt.Sprintf(`{
+	hashHex := strings.Repeat("cd", 32)
+	signatureValue := releaseSignatureFor(t, hashHex)
+	manifestJSON := fmt.Sprintf(`{
                 "id": "remote-desktop-engine",
                 "name": "Remote Desktop Engine",
                 "version": "1.0.0",
@@ -472,8 +621,8 @@ func TestStageRemoteDesktopEngineBlocksIncompatibleArchitecture(t *testing.T) {
 	}))
 	defer server.Close()
 
-        root := t.TempDir()
-        opts := releaseVerifyOptions(t)
+	root := t.TempDir()
+	opts := releaseVerifyOptions(t)
 	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
@@ -520,9 +669,9 @@ func TestStageRemoteDesktopEngineBlocksIncompatibleArchitecture(t *testing.T) {
 func TestStageRemoteDesktopEngineBlocksIncompatibleAgentVersion(t *testing.T) {
 	t.Parallel()
 
-        hashHex := strings.Repeat("ef", 32)
-        signatureValue := releaseSignatureFor(t, hashHex)
-        manifestJSON := fmt.Sprintf(`{
+	hashHex := strings.Repeat("ef", 32)
+	signatureValue := releaseSignatureFor(t, hashHex)
+	manifestJSON := fmt.Sprintf(`{
                 "id": "remote-desktop-engine",
                 "name": "Remote Desktop Engine",
                 "version": "1.0.0",
@@ -547,8 +696,8 @@ func TestStageRemoteDesktopEngineBlocksIncompatibleAgentVersion(t *testing.T) {
 	}))
 	defer server.Close()
 
-        root := t.TempDir()
-        opts := releaseVerifyOptions(t)
+	root := t.TempDir()
+	opts := releaseVerifyOptions(t)
 	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
@@ -607,6 +756,43 @@ func buildRemoteDesktopArtifact(t *testing.T, files map[string][]byte) []byte {
 	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close zip writer: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func buildTarGzArchive(t *testing.T, files map[string][]byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	writer := tar.NewWriter(gz)
+	for name, payload := range files {
+		header := &tar.Header{
+			Name:     name,
+			Mode:     0o644,
+			Size:     int64(len(payload)),
+			Typeflag: tar.TypeReg,
+		}
+		if strings.HasSuffix(name, "/") {
+			header.Typeflag = tar.TypeDir
+			header.Size = 0
+			header.Mode = 0o755
+		}
+		if err := writer.WriteHeader(header); err != nil {
+			t.Fatalf("write tar header: %v", err)
+		}
+		if header.Typeflag == tar.TypeDir {
+			continue
+		}
+		if _, err := writer.Write(payload); err != nil {
+			t.Fatalf("write tar payload: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
 	}
 	return buf.Bytes()
 }

--- a/tenvy-client/internal/plugins/stage.go
+++ b/tenvy-client/internal/plugins/stage.go
@@ -216,8 +216,14 @@ func StagePlugin(
 		}
 	}
 
-	if strings.EqualFold(filepath.Ext(artifactRel), ".zip") {
+	loweredArtifact := strings.ToLower(artifactRel)
+	switch {
+	case strings.EqualFold(filepath.Ext(artifactRel), ".zip"):
 		if err := unpackZipArchive(stagingArtifact, stagingDir); err != nil {
+			return result, newStageError(manifest.InstallError, mf.Version, err)
+		}
+	case strings.HasSuffix(loweredArtifact, ".tar.gz"), strings.HasSuffix(loweredArtifact, ".tgz"):
+		if err := unpackTarGzArchive(stagingArtifact, stagingDir); err != nil {
 			return result, newStageError(manifest.InstallError, mf.Version, err)
 		}
 	}

--- a/tenvy-client/internal/plugins/stage_tar_test.go
+++ b/tenvy-client/internal/plugins/stage_tar_test.go
@@ -1,0 +1,173 @@
+package plugins_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	plugins "github.com/rootbay/tenvy-client/internal/plugins"
+	manifest "github.com/rootbay/tenvy-client/shared/pluginmanifest"
+)
+
+func TestStagePluginStagesTarGzArtifact(t *testing.T) {
+	t.Parallel()
+
+	artifactData := buildTarGzArchive(t, map[string][]byte{
+		"awesome-plugin/plugin.bin": []byte("plugin payload"),
+	})
+	hash := sha256.Sum256(artifactData)
+	hashHex := fmt.Sprintf("%x", hash[:])
+	signatureValue := releaseSignatureFor(t, hashHex)
+
+	manifestJSON := fmt.Sprintf(`{
+                "id": "awesome-plugin",
+                "name": "Awesome Plugin",
+                "version": "1.2.3",
+                "entry": "awesome-plugin/plugin.bin",
+                "repositoryUrl": "https://github.com/rootbay/tenvy-client",
+                "license": {"spdxId": "MIT"},
+                "requirements": {},
+                "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "%[2]s", "signatureValue": "%[3]s", "signatureTimestamp": "%[4]s"},
+                "package": {"artifact": "awesome-plugin/awesome-plugin.tar.gz", "hash": "%[1]s"}
+        }`, hashHex, releaseSigner, signatureValue, releaseSignedAtStamp)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/artifact") {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			if _, err := w.Write(artifactData); err != nil {
+				t.Fatalf("write artifact: %v", err)
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := io.WriteString(w, manifestJSON); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	root := t.TempDir()
+	opts := releaseVerifyOptions(t)
+	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	digest := sha256.Sum256([]byte(manifestJSON))
+	descriptor := manifest.ManifestDescriptor{
+		PluginID:       "awesome-plugin",
+		Version:        "1.2.3",
+		ManifestDigest: fmt.Sprintf("%x", digest[:]),
+		Distribution:   manifest.ManifestBriefing{DefaultMode: manifest.DeliveryAutomatic, AutoUpdate: true},
+		ArtifactHash:   hashHex,
+	}
+
+	ctx := context.Background()
+	result, err := plugins.StagePlugin(ctx, manager, server.Client(), server.URL, "agent-1", "", "stage-test", manifest.RuntimeFacts{}, descriptor)
+	if err != nil {
+		t.Fatalf("stage plugin: %v", err)
+	}
+	if !result.Updated {
+		t.Fatalf("expected installation to be marked updated")
+	}
+	if strings.TrimSpace(result.EntryPath) == "" {
+		t.Fatalf("expected entry path to be set")
+	}
+
+	payload, err := os.ReadFile(result.EntryPath)
+	if err != nil {
+		t.Fatalf("read entry payload: %v", err)
+	}
+	if string(payload) != "plugin payload" {
+		t.Fatalf("unexpected entry payload %q", string(payload))
+	}
+
+	artifactPath := filepath.Join(manager.Root(), "awesome-plugin", "awesome-plugin", "awesome-plugin.tar.gz")
+	if _, err := os.Stat(artifactPath); err != nil {
+		t.Fatalf("expected artifact persisted: %v", err)
+	}
+
+	if !strings.EqualFold(result.Manifest.ID, "awesome-plugin") {
+		t.Fatalf("expected manifest id awesome-plugin, got %q", result.Manifest.ID)
+	}
+}
+
+func TestStagePluginFailsOnMalformedTarGz(t *testing.T) {
+	t.Parallel()
+
+	artifactData := []byte("broken tar.gz data")
+	hash := sha256.Sum256(artifactData)
+	hashHex := fmt.Sprintf("%x", hash[:])
+	signatureValue := releaseSignatureFor(t, hashHex)
+
+	manifestJSON := fmt.Sprintf(`{
+                "id": "broken-plugin",
+                "name": "Broken Plugin",
+                "version": "0.0.1",
+                "entry": "broken-plugin/plugin.bin",
+                "repositoryUrl": "https://github.com/rootbay/tenvy-client",
+                "license": {"spdxId": "MIT"},
+                "requirements": {},
+                "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "%[2]s", "signatureValue": "%[3]s", "signatureTimestamp": "%[4]s"},
+                "package": {"artifact": "broken-plugin/broken-plugin.tar.gz", "hash": "%[1]s"}
+        }`, hashHex, releaseSigner, signatureValue, releaseSignedAtStamp)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/artifact") {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			if _, err := w.Write(artifactData); err != nil {
+				t.Fatalf("write artifact: %v", err)
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := io.WriteString(w, manifestJSON); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	root := t.TempDir()
+	opts := releaseVerifyOptions(t)
+	manager, err := plugins.NewManager(root, log.New(io.Discard, "", 0), opts)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	digest := sha256.Sum256([]byte(manifestJSON))
+	descriptor := manifest.ManifestDescriptor{
+		PluginID:       "broken-plugin",
+		Version:        "0.0.1",
+		ManifestDigest: fmt.Sprintf("%x", digest[:]),
+		Distribution:   manifest.ManifestBriefing{DefaultMode: manifest.DeliveryAutomatic, AutoUpdate: true},
+		ArtifactHash:   hashHex,
+	}
+
+	_, err = plugins.StagePlugin(context.Background(), manager, server.Client(), server.URL, "agent-1", "", "stage-test", manifest.RuntimeFacts{}, descriptor)
+	if err == nil {
+		t.Fatal("expected staging to fail")
+	}
+
+	stageErr := &plugins.StageError{}
+	if !strings.Contains(err.Error(), "artifact") {
+		t.Fatalf("expected artifact failure, got %v", err)
+	}
+	if !errors.As(err, &stageErr) {
+		t.Fatalf("expected stage error type, got %T", err)
+	}
+	if stageErr.Status() != manifest.InstallError {
+		t.Fatalf("expected install error status, got %s", stageErr.Status())
+	}
+	if stageErr.Version() != "0.0.1" {
+		t.Fatalf("expected version propagated, got %q", stageErr.Version())
+	}
+}


### PR DESCRIPTION
## Summary
- add a safe tar.gz archive extractor alongside the existing zip helper
- allow StagePlugin and the remote desktop staging path to unpack tar.gz artifacts
- cover the new logic with unit tests for successful and malformed tar.gz packages

## Testing
- (cd tenvy-client && go test ./...)

------
https://chatgpt.com/codex/tasks/task_e_68fcfa24ebf4832bbfa3cbae47908ac2