### PR TITLE
Enforce plugin API role checks

### DIFF
--- a/tenvy-server/src/routes/api/plugins/+server.ts
+++ b/tenvy-server/src/routes/api/plugins/+server.ts
@@ -6,6 +6,7 @@ import type { RequestHandler } from './$types';
 import { createPluginRepository } from '$lib/data/plugins.js';
 import { loadPluginManifests } from '$lib/data/plugin-manifests.js';
 import { getVerificationOptions } from '$lib/server/plugins/signature-policy.js';
+import { requireDeveloper } from '$lib/server/authorization.js';
 import {
         ArchiveExtractionError,
         extractPluginArchive,
@@ -92,7 +93,9 @@ export const GET: RequestHandler = async () => {
         return json({ plugins });
 };
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ locals, request }) => {
+        requireDeveloper(locals.user);
+
         const contentType = request.headers.get('content-type') ?? '';
         if (!contentType.toLowerCase().includes('multipart/form-data')) {
                 throw error(415, { message: 'Expected multipart form data upload' });

--- a/tenvy-server/src/routes/api/plugins/[id]/+server.ts
+++ b/tenvy-server/src/routes/api/plugins/[id]/+server.ts
@@ -1,14 +1,15 @@
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import {
-	createPluginRepository,
-	type PluginRepositoryUpdate,
-	type Plugin
+        createPluginRepository,
+        type PluginRepositoryUpdate,
+        type Plugin
 } from '$lib/data/plugins.js';
 import {
-	pluginUpdateSchema,
-	type PluginUpdatePayloadInput
+        pluginUpdateSchema,
+        type PluginUpdatePayloadInput
 } from '$lib/validation/plugin-update-schema.js';
+import { requireAdmin } from '$lib/server/authorization.js';
 
 const repository = createPluginRepository();
 
@@ -97,9 +98,11 @@ export const GET: RequestHandler = async ({ params }) => {
 	}
 };
 
-export const PATCH: RequestHandler = async ({ params, request }) => {
-	const { id } = params;
-	const rawBody = await request.text();
+export const PATCH: RequestHandler = async ({ locals, params, request }) => {
+        requireAdmin(locals.user);
+
+        const { id } = params;
+        const rawBody = await request.text();
 	let parsedBody: unknown;
 
 	if (rawBody.trim().length === 0) {

--- a/tenvy-server/tests/plugins-api-auth.test.ts
+++ b/tenvy-server/tests/plugins-api-auth.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { POST as uploadPlugin } from '../src/routes/api/plugins/+server.js';
+import { PATCH as updatePlugin } from '../src/routes/api/plugins/[id]/+server.js';
+import type { AuthenticatedUser, UserRole } from '../src/lib/server/auth.js';
+
+const createUser = (role: UserRole): AuthenticatedUser => ({
+        id: `user-${role}`,
+        role,
+        passkeyRegistered: true,
+        voucherId: 'voucher-123',
+        voucherActive: true,
+        voucherExpiresAt: null
+});
+
+const createUploadEvent = (user: AuthenticatedUser | null) => ({
+        locals: { user },
+        request: new Request('http://tenvy.test/api/plugins', { method: 'POST' })
+}) as unknown as Parameters<typeof uploadPlugin>[0];
+
+const createPatchEvent = (user: AuthenticatedUser | null) => ({
+        locals: { user },
+        params: { id: 'clipboard-sync' },
+        request: new Request('http://tenvy.test/api/plugins/clipboard-sync', {
+                method: 'PATCH',
+                headers: { 'content-type': 'application/json' },
+                body: '{}'
+        })
+}) as unknown as Parameters<typeof updatePlugin>[0];
+
+describe('plugin API authorization', () => {
+        it('rejects plugin uploads from unauthenticated users', async () => {
+                await expect(uploadPlugin(createUploadEvent(null))).rejects.toMatchObject({ status: 401 });
+        });
+
+        it('rejects plugin uploads from non-developer users', async () => {
+                const operator = createUser('operator');
+                await expect(uploadPlugin(createUploadEvent(operator))).rejects.toMatchObject({ status: 403 });
+        });
+
+        it('rejects plugin approvals from unauthenticated users', async () => {
+                await expect(updatePlugin(createPatchEvent(null))).rejects.toMatchObject({ status: 401 });
+        });
+
+        it('rejects plugin approvals from non-admin users', async () => {
+                const developer = createUser('developer');
+                await expect(updatePlugin(createPatchEvent(developer))).rejects.toMatchObject({ status: 403 });
+        });
+});


### PR DESCRIPTION
## Summary
- require developer privileges before accepting plugin uploads
- gate plugin update/approval endpoint behind the admin role
- cover unauthorized plugin upload/approval attempts in unit tests

## Testing
- bun run test:unit -- --run tests/plugins-api-auth.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fd007f6590832b9513ce483bf92fbf