### PR TITLE
Enforce file-name plugin artifacts across manifests

### DIFF
--- a/shared/pluginmanifest/manifest.go
+++ b/shared/pluginmanifest/manifest.go
@@ -296,9 +296,12 @@ func (m Manifest) Validate() error {
 	if err := m.validateLicense(); err != nil {
 		problems = append(problems, err)
 	}
-	if strings.TrimSpace(m.Package.Artifact) == "" {
-		problems = append(problems, errors.New("missing package artifact"))
-	}
+        artifact := strings.TrimSpace(m.Package.Artifact)
+        if artifact == "" {
+                problems = append(problems, errors.New("missing package artifact"))
+        } else if strings.ContainsAny(artifact, "/\\") {
+                problems = append(problems, errors.New("package artifact must be a file name"))
+        }
 
 	if err := m.validateDistribution(); err != nil {
 		problems = append(problems, err)

--- a/shared/pluginmanifest/manifest_test.go
+++ b/shared/pluginmanifest/manifest_test.go
@@ -1,0 +1,52 @@
+package pluginmanifest
+
+import (
+	"strings"
+	"testing"
+)
+
+func buildTestManifest() Manifest {
+	hash := strings.Repeat("a", 64)
+	return Manifest{
+		ID:            "test-plugin",
+		Name:          "Test Plugin",
+		Version:       "1.2.3",
+		Entry:         "plugin.exe",
+		RepositoryURL: "https://example.com/test-plugin",
+		Distribution: Distribution{
+			DefaultMode:   DeliveryAutomatic,
+			AutoUpdate:    true,
+			Signature:     SignatureSHA256,
+			SignatureHash: hash,
+		},
+		Package: PackageDescriptor{
+			Artifact: "plugin.zip",
+			Hash:     hash,
+		},
+		Requirements: Requirements{
+			Platforms:     []PluginPlatform{PlatformWindows},
+			Architectures: []PluginArchitecture{ArchitectureX8664},
+		},
+	}
+}
+
+func TestManifestValidateAllowsArtifactFileName(t *testing.T) {
+	manifest := buildTestManifest()
+
+	if err := manifest.Validate(); err != nil {
+		t.Fatalf("expected validation success, got %v", err)
+	}
+}
+
+func TestManifestValidateRejectsPathQualifiedArtifact(t *testing.T) {
+	manifest := buildTestManifest()
+	manifest.Package.Artifact = "nested/plugin.zip"
+
+	err := manifest.Validate()
+	if err == nil {
+		t.Fatal("expected validation to fail for path-qualified artifact")
+	}
+	if !strings.Contains(err.Error(), "package artifact must be a file name") {
+		t.Fatalf("expected artifact file name error, got %v", err)
+	}
+}

--- a/shared/pluginmanifest/remote-desktop-engine.json
+++ b/shared/pluginmanifest/remote-desktop-engine.json
@@ -41,7 +41,7 @@
     "signatureTimestamp": "2024-01-01T00:00:00Z"
   },
   "package": {
-    "artifact": "remote-desktop-engine/remote-desktop-engine.zip",
+    "artifact": "remote-desktop-engine.zip",
     "sizeBytes": 216,
     "hash": "e385e7caab88ce61adb864e33a068785645a21afb4693b81cfa9dfc9338c58ee"
   }

--- a/shared/types/plugin-manifest.test.ts
+++ b/shared/types/plugin-manifest.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type PluginManifest,
+  validatePluginManifest,
+} from './plugin-manifest.js';
+
+const baseManifest: PluginManifest = {
+  id: 'test-plugin',
+  name: 'Test Plugin',
+  version: '1.2.3',
+  entry: 'plugin.exe',
+  repositoryUrl: 'https://example.com/test-plugin',
+  requirements: {
+    platforms: ['windows'],
+    architectures: ['x86_64'],
+    requiredModules: [],
+  },
+  distribution: {
+    defaultMode: 'automatic',
+    autoUpdate: true,
+    signature: 'sha256',
+    signatureHash: 'a'.repeat(64),
+  },
+  package: {
+    artifact: 'plugin.zip',
+    hash: 'a'.repeat(64),
+  },
+};
+
+const cloneManifest = (): PluginManifest =>
+  JSON.parse(JSON.stringify(baseManifest)) as PluginManifest;
+
+describe('validatePluginManifest', () => {
+  it('accepts artifact file names without path separators', () => {
+    const manifest = cloneManifest();
+
+    const problems = validatePluginManifest(manifest);
+
+    expect(problems).toHaveLength(0);
+  });
+
+  it('rejects artifact paths containing directory separators', () => {
+    const manifest = cloneManifest();
+    manifest.package.artifact = 'nested/plugin.zip';
+
+    const problems = validatePluginManifest(manifest);
+
+    expect(problems).toContain('package artifact must be a file name');
+  });
+});

--- a/shared/types/plugin-manifest.ts
+++ b/shared/types/plugin-manifest.ts
@@ -307,8 +307,11 @@ export function validatePluginManifest(manifest: PluginManifest): string[] {
     }
   }
 
-  if (!manifest.package || isEmpty(manifest.package.artifact)) {
+  const artifact = manifest.package?.artifact ?? "";
+  if (isEmpty(artifact)) {
     problems.push("missing package artifact");
+  } else if (artifact.includes("/") || artifact.includes("\\")) {
+    problems.push("package artifact must be a file name");
   }
 
   const mode = manifest.distribution?.defaultMode;

--- a/tenvy-client/internal/agent/remote_desktop_integration_test.go
+++ b/tenvy-client/internal/agent/remote_desktop_integration_test.go
@@ -57,7 +57,7 @@ func TestRemoteDesktopModuleNegotiationWithManagedEngine(t *testing.T) {
 			SignatureHash: hashHex,
 		},
 		Package: manifest.PackageDescriptor{
-			Artifact: "remote-desktop-engine/engine.zip",
+			Artifact: "remote-desktop-engine.zip",
 			Hash:     hashHex,
 		},
 	})

--- a/tenvy-client/internal/plugins/remotedesktop.go
+++ b/tenvy-client/internal/plugins/remotedesktop.go
@@ -144,8 +144,15 @@ func StageRemoteDesktopEngine(
 		return result, errors.New(message)
 	}
 
-	artifactRel := filepath.Clean(filepath.FromSlash(mf.Package.Artifact))
-	if artifactRel == "" || strings.HasPrefix(artifactRel, "..") {
+	artifactRef := strings.TrimSpace(mf.Package.Artifact)
+	if artifactRef == "" || strings.ContainsAny(artifactRef, "/\\") {
+		message := "manifest artifact path is invalid"
+		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallError, message)
+		return result, errors.New(message)
+	}
+
+	artifactRel := filepath.Clean(artifactRef)
+	if artifactRel == "" || artifactRel == "." || strings.HasPrefix(artifactRel, "..") {
 		message := "manifest artifact path is invalid"
 		manager.recordInstallStatusLocked(RemoteDesktopEnginePluginID, mf.Version, manifest.InstallError, message)
 		return result, errors.New(message)

--- a/tenvy-client/internal/plugins/remotedesktop_test.go
+++ b/tenvy-client/internal/plugins/remotedesktop_test.go
@@ -100,7 +100,7 @@ func TestStageRemoteDesktopEngineSuccess(t *testing.T) {
                 "license": { "spdxId": "MIT" },
                 "requirements": {},
                 "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "%[2]s", "signatureValue": "%[3]s", "signatureTimestamp": "%[4]s"},
-                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip", "hash": "%[1]s"}
+                "package": {"artifact": "remote-desktop-engine.zip", "hash": "%[1]s"}
         }`, hashHex, releaseSigner, signatureValue, releaseSignedAtStamp)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -152,7 +152,7 @@ func TestStageRemoteDesktopEngineSuccess(t *testing.T) {
 		t.Fatalf("unexpected entry payload %q", string(entryPayload))
 	}
 
-	artifactPath := filepath.Join(manager.Root(), plugins.RemoteDesktopEnginePluginID, "remote-desktop-engine", "remote-desktop-engine.zip")
+	artifactPath := filepath.Join(manager.Root(), plugins.RemoteDesktopEnginePluginID, "remote-desktop-engine.zip")
 	if _, err := os.Stat(artifactPath); err != nil {
 		t.Fatalf("expected artifact persisted: %v", err)
 	}
@@ -194,7 +194,7 @@ func TestStageRemoteDesktopEngineSuccessTarGz(t *testing.T) {
                 "license": {"spdxId": "MIT"},
                 "requirements": {},
                 "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "%[2]s", "signatureValue": "%[3]s", "signatureTimestamp": "%[4]s"},
-                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.tar.gz", "hash": "%[1]s"}
+                "package": {"artifact": "remote-desktop-engine.tar.gz", "hash": "%[1]s"}
         }`, hashHex, releaseSigner, signatureValue, releaseSignedAtStamp)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -246,7 +246,7 @@ func TestStageRemoteDesktopEngineSuccessTarGz(t *testing.T) {
 		t.Fatalf("unexpected entry payload %q", string(entryPayload))
 	}
 
-	artifactPath := filepath.Join(manager.Root(), plugins.RemoteDesktopEnginePluginID, "remote-desktop-engine", "remote-desktop-engine.tar.gz")
+	artifactPath := filepath.Join(manager.Root(), plugins.RemoteDesktopEnginePluginID, "remote-desktop-engine.tar.gz")
 	if _, err := os.Stat(artifactPath); err != nil {
 		t.Fatalf("expected artifact persisted: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestStageRemoteDesktopEngineFailsMalformedTarGz(t *testing.T) {
                 "license": {"spdxId": "MIT"},
                 "requirements": {},
                 "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "%[2]s", "signatureValue": "%[3]s", "signatureTimestamp": "%[4]s"},
-                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.tar.gz", "hash": "%[1]s"}
+                "package": {"artifact": "remote-desktop-engine.tar.gz", "hash": "%[1]s"}
         }`, hashHex, releaseSigner, signatureValue, releaseSignedAtStamp)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -437,7 +437,7 @@ func TestStageRemoteDesktopEngineAllowsManualWhenRequested(t *testing.T) {
                 "license": {"spdxId": "MIT"},
                 "requirements": {"platforms": ["windows"], "architectures": ["x86_64"]},
                 "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "%[2]s", "signatureValue": "%[3]s", "signatureTimestamp": "%[4]s"},
-                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip", "hash": "%[1]s"}
+                "package": {"artifact": "remote-desktop-engine.zip", "hash": "%[1]s"}
         }`, hashHex, releaseSigner, signatureValue, releaseSignedAtStamp)
 
 	var artifactServed atomic.Bool
@@ -530,7 +530,7 @@ func TestStageRemoteDesktopEngineBlocksIncompatiblePlatform(t *testing.T) {
                 "license": {"spdxId": "MIT"},
                 "requirements": {"platforms": ["windows"]},
                 "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "%[2]s", "signatureValue": "%[3]s", "signatureTimestamp": "%[4]s"},
-                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip", "hash": "%[1]s"}
+                "package": {"artifact": "remote-desktop-engine.zip", "hash": "%[1]s"}
         }`, hashHex, releaseSigner, signatureValue, releaseSignedAtStamp)
 
 	var artifactRequested atomic.Bool
@@ -605,7 +605,7 @@ func TestStageRemoteDesktopEngineBlocksIncompatibleArchitecture(t *testing.T) {
                 "license": {"spdxId": "MIT"},
                 "requirements": {"architectures": ["arm64"]},
                 "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "%[2]s", "signatureValue": "%[3]s", "signatureTimestamp": "%[4]s"},
-                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip", "hash": "%[1]s"}
+                "package": {"artifact": "remote-desktop-engine.zip", "hash": "%[1]s"}
         }`, hashHex, releaseSigner, signatureValue, releaseSignedAtStamp)
 
 	var artifactRequested atomic.Bool
@@ -680,7 +680,7 @@ func TestStageRemoteDesktopEngineBlocksIncompatibleAgentVersion(t *testing.T) {
                 "license": {"spdxId": "MIT"},
                 "requirements": {"minAgentVersion": "5.0.0"},
                 "distribution": {"defaultMode": "manual", "autoUpdate": false, "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "%[2]s", "signatureValue": "%[3]s", "signatureTimestamp": "%[4]s"},
-                "package": {"artifact": "remote-desktop-engine/remote-desktop-engine.zip", "hash": "%[1]s"}
+                "package": {"artifact": "remote-desktop-engine.zip", "hash": "%[1]s"}
         }`, hashHex, releaseSigner, signatureValue, releaseSignedAtStamp)
 
 	var artifactRequested atomic.Bool

--- a/tenvy-client/internal/plugins/stage.go
+++ b/tenvy-client/internal/plugins/stage.go
@@ -160,8 +160,13 @@ func StagePlugin(
 		return result, newStageError(manifest.InstallBlocked, mf.Version, errors.New(message))
 	}
 
-	artifactRel := filepath.Clean(filepath.FromSlash(mf.Package.Artifact))
-	if artifactRel == "" || strings.HasPrefix(artifactRel, "..") {
+	artifactRef := strings.TrimSpace(mf.Package.Artifact)
+	if artifactRef == "" || strings.ContainsAny(artifactRef, "/\\") {
+		return result, newStageError(manifest.InstallError, mf.Version, errors.New("manifest artifact path is invalid"))
+	}
+
+	artifactRel := filepath.Clean(artifactRef)
+	if artifactRel == "" || artifactRel == "." || strings.HasPrefix(artifactRel, "..") {
 		return result, newStageError(manifest.InstallError, mf.Version, errors.New("manifest artifact path is invalid"))
 	}
 

--- a/tenvy-client/internal/plugins/stage_tar_test.go
+++ b/tenvy-client/internal/plugins/stage_tar_test.go
@@ -37,7 +37,7 @@ func TestStagePluginStagesTarGzArtifact(t *testing.T) {
                 "license": {"spdxId": "MIT"},
                 "requirements": {},
                 "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "%[2]s", "signatureValue": "%[3]s", "signatureTimestamp": "%[4]s"},
-                "package": {"artifact": "awesome-plugin/awesome-plugin.tar.gz", "hash": "%[1]s"}
+                "package": {"artifact": "awesome-plugin.tar.gz", "hash": "%[1]s"}
         }`, hashHex, releaseSigner, signatureValue, releaseSignedAtStamp)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -91,7 +91,7 @@ func TestStagePluginStagesTarGzArtifact(t *testing.T) {
 		t.Fatalf("unexpected entry payload %q", string(payload))
 	}
 
-	artifactPath := filepath.Join(manager.Root(), "awesome-plugin", "awesome-plugin", "awesome-plugin.tar.gz")
+	artifactPath := filepath.Join(manager.Root(), "awesome-plugin", "awesome-plugin.tar.gz")
 	if _, err := os.Stat(artifactPath); err != nil {
 		t.Fatalf("expected artifact persisted: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestStagePluginFailsOnMalformedTarGz(t *testing.T) {
                 "license": {"spdxId": "MIT"},
                 "requirements": {},
                 "distribution": {"defaultMode": "automatic", "autoUpdate": true, "signature": "ed25519", "signatureHash": "%[1]s", "signatureSigner": "%[2]s", "signatureValue": "%[3]s", "signatureTimestamp": "%[4]s"},
-                "package": {"artifact": "broken-plugin/broken-plugin.tar.gz", "hash": "%[1]s"}
+                "package": {"artifact": "broken-plugin.tar.gz", "hash": "%[1]s"}
         }`, hashHex, releaseSigner, signatureValue, releaseSignedAtStamp)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tenvy-server/resources/plugin-manifests/remote-desktop-engine.json
+++ b/tenvy-server/resources/plugin-manifests/remote-desktop-engine.json
@@ -28,7 +28,7 @@
                 "signatureTimestamp": "2024-01-01T00:00:00Z"
         },
         "package": {
-                "artifact": "remote-desktop-engine/remote-desktop-engine.zip",
+                "artifact": "remote-desktop-engine.zip",
                 "sizeBytes": 216,
                 "hash": "e385e7caab88ce61adb864e33a068785645a21afb4693b81cfa9dfc9338c58ee"
         }

--- a/tenvy-server/src/routes/api/agents/[id]/plugins/[pluginId]/artifact/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/plugins/[pluginId]/artifact/+server.ts
@@ -1,6 +1,6 @@
 import { createReadStream } from 'node:fs';
 import { stat } from 'node:fs/promises';
-import { dirname, resolve, normalize, isAbsolute, sep } from 'node:path';
+import { dirname, resolve, sep } from 'node:path';
 import { error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { registry, RegistryError } from '$lib/server/rat/store.js';
@@ -38,13 +38,12 @@ export const GET: RequestHandler = async ({ params, request }) => {
                 throw error(404, 'Plugin artifact not found');
         }
 
-        const normalized = normalize(trimmed);
-        if (normalized === '' || normalized.startsWith('..') || isAbsolute(normalized)) {
+        if (trimmed.includes('/') || trimmed.includes('\\')) {
                 throw error(404, 'Plugin artifact not found');
         }
 
         const baseDir = dirname(approved.record.source);
-        const artifactPath = resolve(baseDir, normalized);
+        const artifactPath = resolve(baseDir, trimmed);
         const safeBase = baseDir.endsWith(sep) ? baseDir : `${baseDir}${sep}`;
         if (!artifactPath.startsWith(safeBase)) {
                 throw error(404, 'Plugin artifact not found');

--- a/tenvy-server/tests/agent-plugin-api.test.ts
+++ b/tenvy-server/tests/agent-plugin-api.test.ts
@@ -87,6 +87,14 @@ describe('agent plugin API', () => {
         let trustPath: string;
         const manifestId = 'test-plugin';
         const artifactContent = 'artifact payload';
+        const developerUser = {
+                id: 'developer-1',
+                role: 'developer',
+                passkeyRegistered: true,
+                voucherId: 'voucher-1',
+                voucherActive: true,
+                voucherExpiresAt: null
+        } as const;
 
         beforeEach(async () => {
                 manifestDir = mkdtempSync(join(tmpdir(), 'tenvy-agent-manifests-'));
@@ -284,6 +292,7 @@ describe('agent plugin API', () => {
                 );
 
                 const response = await POST({
+                        locals: { user: developerUser },
                         request: new Request('https://controller.test/api/plugins', {
                                 method: 'POST',
                                 body: form
@@ -349,6 +358,7 @@ describe('agent plugin API', () => {
                 form.set('artifact', new File([archiveBuffer], 'tar-plugin.tar.gz'));
 
                 const response = await POST({
+                        locals: { user: developerUser },
                         request: new Request('https://controller.test/api/plugins', {
                                 method: 'POST',
                                 body: form
@@ -379,6 +389,7 @@ describe('agent plugin API', () => {
 
                 await expect(
                         POST({
+                                locals: { user: developerUser },
                                 request: new Request('https://controller.test/api/plugins', {
                                         method: 'POST',
                                         body: form
@@ -397,6 +408,7 @@ describe('agent plugin API', () => {
 
                 await expect(
                         POST({
+                                locals: { user: developerUser },
                                 request: new Request('https://controller.test/api/plugins', {
                                         method: 'POST',
                                         body: form
@@ -437,6 +449,7 @@ describe('agent plugin API', () => {
 
                 await expect(
                         POST({
+                                locals: { user: developerUser },
                                 request: new Request('https://controller.test/api/plugins', {
                                         method: 'POST',
                                         body: form
@@ -477,6 +490,7 @@ describe('agent plugin API', () => {
 
                 await expect(
                         POST({
+                                locals: { user: developerUser },
                                 request: new Request('https://controller.test/api/plugins', {
                                         method: 'POST',
                                         body: form
@@ -520,6 +534,7 @@ describe('agent plugin API', () => {
 
                 await expect(
                         POST({
+                                locals: { user: developerUser },
                                 request: new Request('https://controller.test/api/plugins', {
                                         method: 'POST',
                                         body: form


### PR DESCRIPTION
## Summary
- require plugin manifests to use artifact file names only and update bundled remote desktop manifest references
- harden agent-side staging logic to reject path-qualified artifact values and refresh associated tests
- adapt server artifact lookups to the flattened layout and add cross-language unit tests covering artifact validation

## Testing
- `cd shared/pluginmanifest && go test ./...`
- `cd tenvy-client && go test ./...`
- `cd tenvy-server && npm run test:unit -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68fd0474cbb0832ba3273349ec4878f5