### PR TITLE
Add plugin dependency support across schema, server, and agent

### DIFF
--- a/shared/pluginmanifest/manifest_test.go
+++ b/shared/pluginmanifest/manifest_test.go
@@ -89,3 +89,22 @@ func TestManifestValidateRuntime(t *testing.T) {
 		t.Fatal("expected runtime validation to fail for empty interface")
 	}
 }
+
+func TestManifestValidateDependencies(t *testing.T) {
+	manifest := buildTestManifest()
+	manifest.Dependencies = []string{"helper-plugin"}
+
+	if err := manifest.Validate(); err != nil {
+		t.Fatalf("expected dependency validation success, got %v", err)
+	}
+
+	manifest.Dependencies = []string{"helper-plugin", "HELPER-plugin"}
+	if err := manifest.Validate(); err == nil {
+		t.Fatal("expected duplicate dependency validation failure")
+	}
+
+	manifest.Dependencies = []string{"test-plugin"}
+	if err := manifest.Validate(); err == nil {
+		t.Fatal("expected self dependency validation failure")
+	}
+}

--- a/shared/types/plugin-manifest.test.ts
+++ b/shared/types/plugin-manifest.test.ts
@@ -1,37 +1,37 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 import {
   type PluginManifest,
   validatePluginManifest,
-} from './plugin-manifest.js';
+} from "./plugin-manifest.js";
 
 const baseManifest: PluginManifest = {
-  id: 'test-plugin',
-  name: 'Test Plugin',
-  version: '1.2.3',
-  entry: 'plugin.exe',
-  repositoryUrl: 'https://example.com/test-plugin',
+  id: "test-plugin",
+  name: "Test Plugin",
+  version: "1.2.3",
+  entry: "plugin.exe",
+  repositoryUrl: "https://example.com/test-plugin",
   requirements: {
-    platforms: ['windows'],
-    architectures: ['x86_64'],
+    platforms: ["windows"],
+    architectures: ["x86_64"],
     requiredModules: [],
   },
   distribution: {
-    defaultMode: 'automatic',
+    defaultMode: "automatic",
     autoUpdate: true,
-    signature: 'sha256',
-    signatureHash: 'a'.repeat(64),
+    signature: "sha256",
+    signatureHash: "a".repeat(64),
   },
   package: {
-    artifact: 'plugin.zip',
-    hash: 'a'.repeat(64),
+    artifact: "plugin.zip",
+    hash: "a".repeat(64),
   },
 };
 
 const cloneManifest = (): PluginManifest =>
   JSON.parse(JSON.stringify(baseManifest)) as PluginManifest;
 
-describe('validatePluginManifest', () => {
-  it('accepts artifact file names without path separators', () => {
+describe("validatePluginManifest", () => {
+  it("accepts artifact file names without path separators", () => {
     const manifest = cloneManifest();
 
     const problems = validatePluginManifest(manifest);
@@ -39,36 +39,36 @@ describe('validatePluginManifest', () => {
     expect(problems).toHaveLength(0);
   });
 
-  it('rejects artifact paths containing directory separators', () => {
+  it("rejects artifact paths containing directory separators", () => {
     const manifest = cloneManifest();
-    manifest.package.artifact = 'nested/plugin.zip';
+    manifest.package.artifact = "nested/plugin.zip";
 
     const problems = validatePluginManifest(manifest);
 
-    expect(problems).toContain('package artifact must be a file name');
+    expect(problems).toContain("package artifact must be a file name");
   });
 
-  it('validates telemetry descriptors', () => {
+  it("validates telemetry descriptors", () => {
     const manifest = cloneManifest();
-    manifest.telemetry = ['remote-desktop.metrics'];
+    manifest.telemetry = ["remote-desktop.metrics"];
 
     let problems = validatePluginManifest(manifest);
     expect(problems).not.toContain(
-      'telemetry remote-desktop.metrics is not registered',
+      "telemetry remote-desktop.metrics is not registered",
     );
 
-    manifest.telemetry = ['unknown.telemetry'];
+    manifest.telemetry = ["unknown.telemetry"];
     problems = validatePluginManifest(manifest);
 
-    expect(problems).toContain('telemetry unknown.telemetry is not registered');
+    expect(problems).toContain("telemetry unknown.telemetry is not registered");
   });
 
-  it('accepts wasm runtime descriptors', () => {
+  it("accepts wasm runtime descriptors", () => {
     const manifest = cloneManifest();
     manifest.runtime = {
-      type: 'wasm',
+      type: "wasm",
       sandboxed: true,
-      host: { interfaces: ['tenvy.core/1'], apiVersion: '1.0' },
+      host: { interfaces: ["tenvy.core/1"], apiVersion: "1.0" },
     };
 
     const problems = validatePluginManifest(manifest);
@@ -76,17 +76,35 @@ describe('validatePluginManifest', () => {
     expect(problems).toHaveLength(0);
   });
 
-  it('rejects unsupported runtime metadata', () => {
+  it("rejects unsupported runtime metadata", () => {
     const manifest = cloneManifest();
     manifest.runtime = {
-      type: 'invalid-type' as never,
-      host: { interfaces: ['', 'tenvy.core/1'], apiVersion: '' },
+      type: "invalid-type" as never,
+      host: { interfaces: ["", "tenvy.core/1"], apiVersion: "" },
     };
 
     const problems = validatePluginManifest(manifest);
 
-    expect(problems).toContain('unsupported runtime type: invalid-type');
-    expect(problems).toContain('runtime host interface 0 is empty');
-    expect(problems).toContain('runtime host apiVersion cannot be empty');
+    expect(problems).toContain("unsupported runtime type: invalid-type");
+    expect(problems).toContain("runtime host interface 0 is empty");
+    expect(problems).toContain("runtime host apiVersion cannot be empty");
+  });
+
+  it("validates plugin dependency lists", () => {
+    const manifest = cloneManifest();
+    manifest.dependencies = ["helper-plugin"];
+
+    let problems = validatePluginManifest(manifest);
+    expect(problems).not.toContain("dependency helper-plugin is duplicated");
+
+    manifest.dependencies = ["helper-plugin", "HELPER-plugin"];
+    problems = validatePluginManifest(manifest);
+    expect(problems).toContain("dependency HELPER-plugin is duplicated");
+
+    manifest.dependencies = ["test-plugin"];
+    problems = validatePluginManifest(manifest);
+    expect(problems).toContain(
+      "dependency test-plugin cannot reference the plugin itself",
+    );
   });
 });

--- a/tenvy-client/internal/agent/modules.go
+++ b/tenvy-client/internal/agent/modules.go
@@ -494,6 +494,23 @@ func (r *moduleManager) PluginHandle(pluginID string) PluginActivationHandle {
 	return activation.handle
 }
 
+func (r *moduleManager) ActivePluginIDs() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(r.pluginActivations) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(r.pluginActivations))
+	for id := range r.pluginActivations {
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	sort.Strings(ids)
+	return ids
+}
+
 func (r *moduleManager) RegisterModuleExtension(moduleID string, extension ModuleExtension) error {
 	moduleID = strings.TrimSpace(moduleID)
 	if moduleID == "" {

--- a/tenvy-server/src/lib/components/plugins/PluginCard.svelte
+++ b/tenvy-server/src/lib/components/plugins/PluginCard.svelte
@@ -19,15 +19,15 @@
 		type Plugin,
 		type PluginUpdatePayload
 	} from '$lib/data/plugin-view.js';
-        import {
-                Download,
-                Info,
-                PackageSearch,
-                RefreshCcw,
-                ShieldAlert,
-                ShieldCheck,
-                Wifi
-        } from '@lucide/svelte';
+	import {
+		Download,
+		Info,
+		PackageSearch,
+		RefreshCcw,
+		ShieldAlert,
+		ShieldCheck,
+		Wifi
+	} from '@lucide/svelte';
 
 	import {
 		distributionModes,
@@ -106,6 +106,19 @@
 						</Badge>
 					{/each}
 				{/if}
+				{#if plugin.dependencies.length > 0}
+					<span class="text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
+						Depends on
+					</span>
+					{#each plugin.dependencies as dependency (dependency)}
+						<Badge
+							variant="secondary"
+							class="border border-border/60 bg-background/60 text-foreground"
+						>
+							{dependency}
+						</Badge>
+					{/each}
+				{/if}
 			</div>
 		</div>
 		<div class="flex flex-col gap-4 text-sm text-muted-foreground">
@@ -146,28 +159,26 @@
 				<span class="text-xs tracking-wide uppercase">Package size</span>
 				<p class="text-lg font-semibold text-foreground">{plugin.size}</p>
 			</div>
-                        <div class="space-y-1 rounded-md border border-border/60 px-3 py-2">
-                                <span class="text-xs tracking-wide uppercase">Status</span>
-                                <p class="text-lg font-semibold text-foreground">{pluginStatusLabels[plugin.status]}</p>
-                        </div>
-                        <div class="space-y-1 rounded-md border border-border/60 px-3 py-2">
-                                <div class="flex items-center justify-between">
-                                        <span class="text-xs tracking-wide uppercase">Runtime</span>
-                                        {#if plugin.runtime.type === 'wasm'}
-                                                <ShieldCheck class="h-4 w-4 text-emerald-500" />
-                                        {:else}
-                                                <ShieldAlert class="h-4 w-4 text-muted-foreground" />
-                                        {/if}
-                                </div>
-                                <p class="text-lg font-semibold text-foreground">
-                                        {plugin.runtime.type === 'wasm' ? 'WebAssembly' : 'Native'}
-                                </p>
-                                <p class="text-xs text-muted-foreground">
-                                        {plugin.runtime.sandboxed
-                                                ? 'Sandboxed execution enforced'
-                                                : 'Runs with host privileges'}
-                                </p>
-                        </div>
+			<div class="space-y-1 rounded-md border border-border/60 px-3 py-2">
+				<span class="text-xs tracking-wide uppercase">Status</span>
+				<p class="text-lg font-semibold text-foreground">{pluginStatusLabels[plugin.status]}</p>
+			</div>
+			<div class="space-y-1 rounded-md border border-border/60 px-3 py-2">
+				<div class="flex items-center justify-between">
+					<span class="text-xs tracking-wide uppercase">Runtime</span>
+					{#if plugin.runtime.type === 'wasm'}
+						<ShieldCheck class="h-4 w-4 text-emerald-500" />
+					{:else}
+						<ShieldAlert class="h-4 w-4 text-muted-foreground" />
+					{/if}
+				</div>
+				<p class="text-lg font-semibold text-foreground">
+					{plugin.runtime.type === 'wasm' ? 'WebAssembly' : 'Native'}
+				</p>
+				<p class="text-xs text-muted-foreground">
+					{plugin.runtime.sandboxed ? 'Sandboxed execution enforced' : 'Runs with host privileges'}
+				</p>
+			</div>
 			<div class="space-y-1 rounded-md border border-border/60 px-3 py-2">
 				<div class="flex items-center justify-between">
 					<span class="text-xs tracking-wide uppercase">Manual deployments</span>

--- a/tenvy-server/src/lib/components/plugins/PluginCard.svelte.test.ts
+++ b/tenvy-server/src/lib/components/plugins/PluginCard.svelte.test.ts
@@ -29,6 +29,7 @@ const basePlugin: Plugin = {
 		lastManualPush: '2024-01-03',
 		lastAutoSync: '2024-01-04'
 	},
+	dependencies: [],
 	requiredModules: [],
 	approvalStatus: 'approved',
 	signature: {

--- a/tenvy-server/src/lib/data/plugin-view.ts
+++ b/tenvy-server/src/lib/data/plugin-view.ts
@@ -66,32 +66,33 @@ export type PluginDistributionView = {
 };
 
 export type PluginRuntimeSummary = {
-        type: PluginRuntimeType;
-        sandboxed: boolean;
+	type: PluginRuntimeType;
+	sandboxed: boolean;
 };
 
 export type Plugin = {
-        id: string;
-        name: string;
-        description: string;
-        version: string;
-        author: string;
-        category: PluginCategory;
-        status: PluginStatus;
-        enabled: boolean;
-        autoUpdate: boolean;
-        installations: number;
-        lastDeployed: string;
-        lastChecked: string;
-        size: string;
-        capabilities: string[];
-        artifact: string;
-        runtime: PluginRuntimeSummary;
-        distribution: PluginDistributionView;
-        requiredModules: { id: string; title: string }[];
-        approvalStatus: PluginApprovalStatus;
-        approvedAt?: string;
-        signature: PluginSignatureState;
+	id: string;
+	name: string;
+	description: string;
+	version: string;
+	author: string;
+	category: PluginCategory;
+	status: PluginStatus;
+	enabled: boolean;
+	autoUpdate: boolean;
+	installations: number;
+	lastDeployed: string;
+	lastChecked: string;
+	size: string;
+	capabilities: string[];
+	artifact: string;
+	runtime: PluginRuntimeSummary;
+	distribution: PluginDistributionView;
+	dependencies: string[];
+	requiredModules: { id: string; title: string }[];
+	approvalStatus: PluginApprovalStatus;
+	approvedAt?: string;
+	signature: PluginSignatureState;
 };
 
 export type PluginSignatureState = {
@@ -186,7 +187,7 @@ export function formatRelativeTime(input?: Date | null): string {
 	return input.toISOString();
 }
 import type {
-        PluginSignatureStatus,
-        PluginSignatureType,
-        PluginRuntimeType
+	PluginSignatureStatus,
+	PluginSignatureType,
+	PluginRuntimeType
 } from '../../../../shared/types/plugin-manifest.js';

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/plugins/+page.svelte
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/plugins/+page.svelte
@@ -273,6 +273,10 @@
 							<Separator orientation="vertical" />
 							<span>Requires modules: {plugin.requirements.requiredModules.join(', ')}</span>
 						{/if}
+						{#if plugin.requirements.dependencies.length > 0}
+							<Separator orientation="vertical" />
+							<span>Depends on plugins: {plugin.requirements.dependencies.join(', ')}</span>
+						{/if}
 					</div>
 				</CardFooter>
 			</Card>

--- a/tenvy-server/src/routes/(app)/plugins/+page.svelte
+++ b/tenvy-server/src/routes/(app)/plugins/+page.svelte
@@ -69,7 +69,8 @@
 			plugin.author ?? '',
 			plugin.version ?? '',
 			...plugin.capabilities,
-			...plugin.requiredModules.map((module) => module.title)
+			...plugin.requiredModules.map((module) => module.title),
+			...plugin.dependencies
 		]
 			.join(' ')
 			.toLowerCase();

--- a/tenvy-server/tests/plugins-repository.test.ts
+++ b/tenvy-server/tests/plugins-repository.test.ts
@@ -16,31 +16,32 @@ const manifestFixture = {
 	entry: 'clipboard-sync.dll',
 	author: 'Tenvy Labs',
 	repositoryUrl: 'https://github.com/rootbay/tenvy-clipboard-sync',
+	dependencies: ['core-utils'],
 	license: {
 		spdxId: 'MIT',
 		name: 'MIT License',
 		url: 'https://opensource.org/license/mit'
 	},
 	categories: ['collection'],
-        capabilities: ['clipboard.capture', 'clipboard.push'],
-        requirements: {
-                minAgentVersion: '1.2.0',
-                platforms: ['windows', 'macos'],
-                architectures: ['x86_64'],
-                requiredModules: ['clipboard']
-        },
-        distribution: {
-                defaultMode: 'automatic',
-                autoUpdate: true,
-                signature: 'sha256',
-                signatureHash: 'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd',
-                signatureValue: '0123456789abcdef0123456789abcdef'
-        },
-        package: {
-                artifact: 'clipboard-sync-1.4.2.dll',
-                sizeBytes: 18_743_296,
-                hash: 'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd'
-        }
+	capabilities: ['clipboard.capture', 'clipboard.push'],
+	requirements: {
+		minAgentVersion: '1.2.0',
+		platforms: ['windows', 'macos'],
+		architectures: ['x86_64'],
+		requiredModules: ['clipboard']
+	},
+	distribution: {
+		defaultMode: 'automatic',
+		autoUpdate: true,
+		signature: 'sha256',
+		signatureHash: 'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+		signatureValue: '0123456789abcdef0123456789abcdef'
+	},
+	package: {
+		artifact: 'clipboard-sync-1.4.2.dll',
+		sizeBytes: 18_743_296,
+		hash: 'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+	}
 };
 
 const PLUGIN_TABLE_DDL = `
@@ -118,8 +119,9 @@ describe('plugin repository', () => {
 			expect(clipboard?.artifact).toContain('clipboard');
 			expect(clipboard?.distribution.defaultMode).toBe('automatic');
 			expect(clipboard?.distribution.allowAutoSync).toBe(true);
+			expect(clipboard?.dependencies).toContain('core-utils');
 			expect(clipboard?.requiredModules.map((module) => module.id)).toContain('clipboard');
-                        expect(clipboard?.signature.status).toBe('untrusted');
+			expect(clipboard?.signature.status).toBe('untrusted');
 			expect(clipboard?.signature.trusted).toBe(false);
 		} finally {
 			sqlite.close();


### PR DESCRIPTION
## Summary
- add dependency list support to the shared plugin manifest schema in both TypeScript and Go, including validation and tests for invalid dependency lists
- propagate dependency metadata through the controller stack so repository snapshots, telemetry, and UI components surface required plugins
- teach the agent plugin staging pipeline to respect dependency ordering, block activation when prerequisites are missing, and cover cycles/missing cases with tests

## Testing
- go test ./...
- go test ./...
- go test ./...
- bunx vitest run


------
https://chatgpt.com/codex/tasks/task_e_68fd260b0970832bbfeec005764f9646