### PR TITLE
Add registry management module and API

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "tweetnacl": "^1.0.3"
+    "tweetnacl": "^1.0.3",
+    "zod": "^4.1.12"
   }
 }

--- a/shared/types/registry.ts
+++ b/shared/types/registry.ts
@@ -1,0 +1,198 @@
+import { z } from 'zod';
+
+export const registryHiveNameSchema = z.enum([
+  'HKEY_LOCAL_MACHINE',
+  'HKEY_CURRENT_USER',
+  'HKEY_USERS'
+]);
+export type RegistryHiveName = z.infer<typeof registryHiveNameSchema>;
+
+export const registryValueTypeSchema = z.enum([
+  'REG_SZ',
+  'REG_EXPAND_SZ',
+  'REG_MULTI_SZ',
+  'REG_DWORD',
+  'REG_QWORD',
+  'REG_BINARY'
+]);
+export type RegistryValueType = z.infer<typeof registryValueTypeSchema>;
+
+export const registryValueSchema = z.object({
+  name: z.string().min(1),
+  type: registryValueTypeSchema,
+  data: z.string(),
+  size: z.number().int().nonnegative(),
+  lastModified: z.string(),
+  description: z.string().optional(),
+});
+export type RegistryValue = z.infer<typeof registryValueSchema>;
+
+export const registryValueInputSchema = z.object({
+  name: z.string().min(1),
+  type: registryValueTypeSchema,
+  data: z.string(),
+  description: z.string().optional(),
+});
+export type RegistryValueInput = z.infer<typeof registryValueInputSchema>;
+
+export const registryKeySchema = z.object({
+  hive: registryHiveNameSchema,
+  name: z.string(),
+  path: z.string(),
+  parentPath: z.string().nullable(),
+  values: z.array(registryValueSchema),
+  subKeys: z.array(z.string()),
+  lastModified: z.string(),
+  wow64Mirrored: z.boolean(),
+  owner: z.string(),
+  description: z.string().optional(),
+});
+export type RegistryKey = z.infer<typeof registryKeySchema>;
+
+export const registryHiveSchema = z.record(z.string(), registryKeySchema);
+export type RegistryHive = z.infer<typeof registryHiveSchema>;
+
+export const registrySnapshotSchema = z.record(
+  registryHiveNameSchema,
+  registryHiveSchema
+);
+export type RegistrySnapshot = z.infer<typeof registrySnapshotSchema>;
+
+export const registryListRequestSchema = z.object({
+  operation: z.literal('list'),
+  hive: registryHiveNameSchema.optional(),
+  path: z.string().optional(),
+  depth: z.number().int().min(0).max(64).optional(),
+});
+export type RegistryListRequest = z.infer<typeof registryListRequestSchema>;
+
+export const registryCreateKeyRequestSchema = z.object({
+  operation: z.literal('create'),
+  target: z.literal('key'),
+  hive: registryHiveNameSchema,
+  parentPath: z.string().optional(),
+  name: z.string().min(1),
+});
+export type RegistryCreateKeyRequest = z.infer<typeof registryCreateKeyRequestSchema>;
+
+export const registryCreateValueRequestSchema = z.object({
+  operation: z.literal('create'),
+  target: z.literal('value'),
+  hive: registryHiveNameSchema,
+  keyPath: z.string().min(1),
+  value: registryValueInputSchema,
+});
+export type RegistryCreateValueRequest = z.infer<typeof registryCreateValueRequestSchema>;
+
+export const registryUpdateKeyRequestSchema = z.object({
+  operation: z.literal('update'),
+  target: z.literal('key'),
+  hive: registryHiveNameSchema,
+  path: z.string().min(1),
+  name: z.string().min(1),
+});
+export type RegistryUpdateKeyRequest = z.infer<typeof registryUpdateKeyRequestSchema>;
+
+export const registryUpdateValueRequestSchema = z.object({
+  operation: z.literal('update'),
+  target: z.literal('value'),
+  hive: registryHiveNameSchema,
+  keyPath: z.string().min(1),
+  value: registryValueInputSchema,
+  originalName: z.string().min(1).optional(),
+});
+export type RegistryUpdateValueRequest = z.infer<typeof registryUpdateValueRequestSchema>;
+
+export const registryDeleteKeyRequestSchema = z.object({
+  operation: z.literal('delete'),
+  target: z.literal('key'),
+  hive: registryHiveNameSchema,
+  path: z.string().min(1),
+});
+export type RegistryDeleteKeyRequest = z.infer<typeof registryDeleteKeyRequestSchema>;
+
+export const registryDeleteValueRequestSchema = z.object({
+  operation: z.literal('delete'),
+  target: z.literal('value'),
+  hive: registryHiveNameSchema,
+  keyPath: z.string().min(1),
+  name: z.string().min(1),
+});
+export type RegistryDeleteValueRequest = z.infer<typeof registryDeleteValueRequestSchema>;
+
+export const registryCommandRequestSchema = z.union([
+  registryListRequestSchema,
+  registryCreateKeyRequestSchema,
+  registryCreateValueRequestSchema,
+  registryUpdateKeyRequestSchema,
+  registryUpdateValueRequestSchema,
+  registryDeleteKeyRequestSchema,
+  registryDeleteValueRequestSchema,
+]);
+export type RegistryCommandRequest = z.infer<typeof registryCommandRequestSchema>;
+
+export const registryCommandPayloadSchema = z.object({
+  request: registryCommandRequestSchema,
+});
+export type RegistryCommandPayload = z.infer<typeof registryCommandPayloadSchema>;
+
+export const registryListResultSchema = z.object({
+  snapshot: registrySnapshotSchema,
+  generatedAt: z.string(),
+});
+export type RegistryListResult = z.infer<typeof registryListResultSchema>;
+
+export const registryMutationResultSchema = z.object({
+  hive: registryHiveSchema,
+  keyPath: z.string(),
+  valueName: z.string().nullable().optional(),
+  mutatedAt: z.string(),
+});
+export type RegistryMutationResult = z.infer<typeof registryMutationResultSchema>;
+
+const registrySuccessResponseSchema = z.discriminatedUnion('operation', [
+  z.object({
+    operation: z.literal('list'),
+    status: z.literal('ok'),
+    result: registryListResultSchema,
+  }),
+  z.object({
+    operation: z.literal('create'),
+    status: z.literal('ok'),
+    result: registryMutationResultSchema,
+  }),
+  z.object({
+    operation: z.literal('update'),
+    status: z.literal('ok'),
+    result: registryMutationResultSchema,
+  }),
+  z.object({
+    operation: z.literal('delete'),
+    status: z.literal('ok'),
+    result: registryMutationResultSchema,
+  }),
+]);
+
+const registryErrorResponseSchema = z.object({
+  operation: z.enum(['list', 'create', 'update', 'delete']),
+  status: z.literal('error'),
+  error: z.string().default(''),
+  code: z.string().optional(),
+  details: z.unknown().optional(),
+});
+
+export const registryCommandResponseSchema = z.union([
+  registrySuccessResponseSchema,
+  registryErrorResponseSchema,
+]);
+export type RegistryCommandResponse = z.infer<typeof registryCommandResponseSchema>;
+
+export type RegistryMutationOperationResponse = Extract<
+  RegistryCommandResponse,
+  { status: 'ok'; operation: 'create' | 'update' | 'delete' }
+>;
+
+export type RegistryListOperationResponse = Extract<
+  RegistryCommandResponse,
+  { status: 'ok'; operation: 'list' }
+>;

--- a/tenvy-client/internal/modules/management/registry/manager.go
+++ b/tenvy-client/internal/modules/management/registry/manager.go
@@ -1,0 +1,409 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rootbay/tenvy-client/internal/protocol"
+)
+
+type (
+	Command       = protocol.Command
+	CommandResult = protocol.CommandResult
+)
+
+type Logger interface {
+	Printf(format string, args ...interface{})
+}
+
+type Manager struct {
+	provider Provider
+	logger   Logger
+}
+
+func NewManager(logger Logger) *Manager {
+	return &Manager{
+		provider: newNativeProvider(),
+		logger:   logger,
+	}
+}
+
+func (m *Manager) UpdateLogger(logger Logger) {
+	m.logger = logger
+}
+
+func (m *Manager) SetProvider(provider Provider) {
+	if provider == nil {
+		m.provider = newNativeProvider()
+		return
+	}
+	m.provider = provider
+}
+
+func (m *Manager) logf(format string, args ...interface{}) {
+	if m.logger == nil {
+		return
+	}
+	m.logger.Printf(format, args...)
+}
+
+func (m *Manager) HandleCommand(ctx context.Context, cmd Command) CommandResult {
+	completedAt := time.Now().UTC().Format(time.RFC3339Nano)
+	result := CommandResult{CommandID: cmd.ID, CompletedAt: completedAt}
+
+	if len(cmd.Payload) == 0 {
+		result.Success = false
+		result.Error = "registry payload required"
+		return result
+	}
+
+	var payload RegistryCommandPayload
+	if err := json.Unmarshal(cmd.Payload, &payload); err != nil {
+		result.Success = false
+		result.Error = fmt.Sprintf("invalid registry payload: %v", err)
+		return result
+	}
+
+	request := payload.Request
+	switch request.Operation {
+	case "list":
+		response, err := m.provider.List(ctx, ListRequest{
+			Hive:  strings.TrimSpace(request.Hive),
+			Path:  strings.TrimSpace(request.Path),
+			Depth: request.Depth,
+		})
+		if err != nil {
+			result.Success = false
+			result.Error = err.Error()
+			return result
+		}
+		if err := m.setSuccessResult(&result, "list", response); err != nil {
+			result.Success = false
+			result.Error = fmt.Sprintf("encode response: %v", err)
+			return result
+		}
+		return result
+	case "create":
+		switch strings.ToLower(request.Target) {
+		case "key":
+			if strings.TrimSpace(request.Name) == "" {
+				result.Success = false
+				result.Error = "registry key name required"
+				return result
+			}
+			response, err := m.provider.CreateKey(ctx, CreateKeyRequest{
+				Hive:       strings.TrimSpace(request.Hive),
+				ParentPath: strings.TrimSpace(request.ParentPath),
+				Name:       strings.TrimSpace(request.Name),
+			})
+			if err != nil {
+				result.Success = false
+				result.Error = err.Error()
+				return result
+			}
+			if err := m.setSuccessResult(&result, "create", response); err != nil {
+				result.Success = false
+				result.Error = fmt.Sprintf("encode response: %v", err)
+				return result
+			}
+			return result
+		case "value":
+			if request.Value == nil {
+				result.Success = false
+				result.Error = "registry value payload required"
+				return result
+			}
+			if strings.TrimSpace(request.KeyPath) == "" {
+				result.Success = false
+				result.Error = "registry key path required"
+				return result
+			}
+			response, err := m.provider.CreateValue(ctx, CreateValueRequest{
+				Hive:    strings.TrimSpace(request.Hive),
+				KeyPath: strings.TrimSpace(request.KeyPath),
+				Value:   *request.Value,
+			})
+			if err != nil {
+				result.Success = false
+				result.Error = err.Error()
+				return result
+			}
+			if err := m.setSuccessResult(&result, "create", response); err != nil {
+				result.Success = false
+				result.Error = fmt.Sprintf("encode response: %v", err)
+				return result
+			}
+			return result
+		default:
+			result.Success = false
+			result.Error = fmt.Sprintf("unsupported registry create target %q", request.Target)
+			return result
+		}
+	case "update":
+		switch strings.ToLower(request.Target) {
+		case "key":
+			if strings.TrimSpace(request.Path) == "" {
+				result.Success = false
+				result.Error = "registry key path required"
+				return result
+			}
+			if strings.TrimSpace(request.Name) == "" {
+				result.Success = false
+				result.Error = "registry key name required"
+				return result
+			}
+			response, err := m.provider.UpdateKey(ctx, UpdateKeyRequest{
+				Hive: strings.TrimSpace(request.Hive),
+				Path: strings.TrimSpace(request.Path),
+				Name: strings.TrimSpace(request.Name),
+			})
+			if err != nil {
+				result.Success = false
+				result.Error = err.Error()
+				return result
+			}
+			if err := m.setSuccessResult(&result, "update", response); err != nil {
+				result.Success = false
+				result.Error = fmt.Sprintf("encode response: %v", err)
+				return result
+			}
+			return result
+		case "value":
+			if request.Value == nil {
+				result.Success = false
+				result.Error = "registry value payload required"
+				return result
+			}
+			if strings.TrimSpace(request.KeyPath) == "" {
+				result.Success = false
+				result.Error = "registry key path required"
+				return result
+			}
+			response, err := m.provider.UpdateValue(ctx, UpdateValueRequest{
+				Hive:         strings.TrimSpace(request.Hive),
+				KeyPath:      strings.TrimSpace(request.KeyPath),
+				Value:        *request.Value,
+				OriginalName: strings.TrimSpace(request.OriginalName),
+			})
+			if err != nil {
+				result.Success = false
+				result.Error = err.Error()
+				return result
+			}
+			if err := m.setSuccessResult(&result, "update", response); err != nil {
+				result.Success = false
+				result.Error = fmt.Sprintf("encode response: %v", err)
+				return result
+			}
+			return result
+		default:
+			result.Success = false
+			result.Error = fmt.Sprintf("unsupported registry update target %q", request.Target)
+			return result
+		}
+	case "delete":
+		switch strings.ToLower(request.Target) {
+		case "key":
+			if strings.TrimSpace(request.Path) == "" {
+				result.Success = false
+				result.Error = "registry key path required"
+				return result
+			}
+			response, err := m.provider.DeleteKey(ctx, DeleteKeyRequest{
+				Hive: strings.TrimSpace(request.Hive),
+				Path: strings.TrimSpace(request.Path),
+			})
+			if err != nil {
+				result.Success = false
+				result.Error = err.Error()
+				return result
+			}
+			if err := m.setSuccessResult(&result, "delete", response); err != nil {
+				result.Success = false
+				result.Error = fmt.Sprintf("encode response: %v", err)
+				return result
+			}
+			return result
+		case "value":
+			if strings.TrimSpace(request.KeyPath) == "" {
+				result.Success = false
+				result.Error = "registry key path required"
+				return result
+			}
+			if strings.TrimSpace(request.Name) == "" {
+				result.Success = false
+				result.Error = "registry value name required"
+				return result
+			}
+			response, err := m.provider.DeleteValue(ctx, DeleteValueRequest{
+				Hive:    strings.TrimSpace(request.Hive),
+				KeyPath: strings.TrimSpace(request.KeyPath),
+				Name:    strings.TrimSpace(request.Name),
+			})
+			if err != nil {
+				result.Success = false
+				result.Error = err.Error()
+				return result
+			}
+			if err := m.setSuccessResult(&result, "delete", response); err != nil {
+				result.Success = false
+				result.Error = fmt.Sprintf("encode response: %v", err)
+				return result
+			}
+			return result
+		default:
+			result.Success = false
+			result.Error = fmt.Sprintf("unsupported registry delete target %q", request.Target)
+			return result
+		}
+	default:
+		result.Success = false
+		result.Error = fmt.Sprintf("unsupported registry operation %q", request.Operation)
+		return result
+	}
+}
+
+func (m *Manager) setSuccessResult(result *CommandResult, operation string, payload interface{}) error {
+	encoded, err := json.Marshal(RegistryCommandResponse{
+		Operation: operation,
+		Status:    "ok",
+		Result:    payload,
+	})
+	if err != nil {
+		return err
+	}
+	result.Success = true
+	result.Output = string(encoded)
+	return nil
+}
+
+// Provider defines the native registry operations implemented per platform.
+type Provider interface {
+	List(ctx context.Context, req ListRequest) (RegistryListResult, error)
+	CreateKey(ctx context.Context, req CreateKeyRequest) (RegistryMutationResult, error)
+	CreateValue(ctx context.Context, req CreateValueRequest) (RegistryMutationResult, error)
+	UpdateKey(ctx context.Context, req UpdateKeyRequest) (RegistryMutationResult, error)
+	UpdateValue(ctx context.Context, req UpdateValueRequest) (RegistryMutationResult, error)
+	DeleteKey(ctx context.Context, req DeleteKeyRequest) (RegistryMutationResult, error)
+	DeleteValue(ctx context.Context, req DeleteValueRequest) (RegistryMutationResult, error)
+}
+
+var ErrNotSupported = errors.New("registry operations not supported on this platform")
+
+// Request/response structures align with the shared contracts used by the server UI.
+type RegistryCommandPayload struct {
+	Request RegistryCommandRequest `json:"request"`
+}
+
+type RegistryCommandRequest struct {
+	Operation    string              `json:"operation"`
+	Target       string              `json:"target,omitempty"`
+	Hive         string              `json:"hive,omitempty"`
+	Path         string              `json:"path,omitempty"`
+	ParentPath   string              `json:"parentPath,omitempty"`
+	Name         string              `json:"name,omitempty"`
+	KeyPath      string              `json:"keyPath,omitempty"`
+	Value        *RegistryValueInput `json:"value,omitempty"`
+	OriginalName string              `json:"originalName,omitempty"`
+	Depth        int                 `json:"depth,omitempty"`
+}
+
+type RegistryListResult struct {
+	Snapshot    RegistrySnapshot `json:"snapshot"`
+	GeneratedAt string           `json:"generatedAt"`
+}
+
+type RegistryMutationResult struct {
+	Hive      RegistryHive `json:"hive"`
+	KeyPath   string       `json:"keyPath"`
+	ValueName *string      `json:"valueName,omitempty"`
+	MutatedAt string       `json:"mutatedAt"`
+}
+
+type RegistryCommandResponse struct {
+	Operation string      `json:"operation"`
+	Status    string      `json:"status"`
+	Result    interface{} `json:"result,omitempty"`
+	Error     string      `json:"error,omitempty"`
+	Code      string      `json:"code,omitempty"`
+	Details   interface{} `json:"details,omitempty"`
+}
+
+type RegistryValueInput struct {
+	Name        string  `json:"name"`
+	Type        string  `json:"type"`
+	Data        string  `json:"data"`
+	Description *string `json:"description,omitempty"`
+}
+
+type RegistryValue struct {
+	Name         string  `json:"name"`
+	Type         string  `json:"type"`
+	Data         string  `json:"data"`
+	Size         int     `json:"size"`
+	LastModified string  `json:"lastModified"`
+	Description  *string `json:"description,omitempty"`
+}
+
+type RegistryKey struct {
+	Hive          string          `json:"hive"`
+	Name          string          `json:"name"`
+	Path          string          `json:"path"`
+	ParentPath    *string         `json:"parentPath"`
+	Values        []RegistryValue `json:"values"`
+	SubKeys       []string        `json:"subKeys"`
+	LastModified  string          `json:"lastModified"`
+	Wow64Mirrored bool            `json:"wow64Mirrored"`
+	Owner         string          `json:"owner"`
+	Description   *string         `json:"description,omitempty"`
+}
+
+type RegistryHive map[string]RegistryKey
+
+type RegistrySnapshot map[string]RegistryHive
+
+type ListRequest struct {
+	Hive  string
+	Path  string
+	Depth int
+}
+
+type CreateKeyRequest struct {
+	Hive       string
+	ParentPath string
+	Name       string
+}
+
+type CreateValueRequest struct {
+	Hive    string
+	KeyPath string
+	Value   RegistryValueInput
+}
+
+type UpdateKeyRequest struct {
+	Hive string
+	Path string
+	Name string
+}
+
+type UpdateValueRequest struct {
+	Hive         string
+	KeyPath      string
+	Value        RegistryValueInput
+	OriginalName string
+}
+
+type DeleteKeyRequest struct {
+	Hive string
+	Path string
+}
+
+type DeleteValueRequest struct {
+	Hive    string
+	KeyPath string
+	Name    string
+}

--- a/tenvy-client/internal/modules/management/registry/manager_test.go
+++ b/tenvy-client/internal/modules/management/registry/manager_test.go
@@ -1,0 +1,183 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeProvider struct {
+	listReq         *ListRequest
+	listResp        RegistryListResult
+	createKeyReq    *CreateKeyRequest
+	createKeyResp   RegistryMutationResult
+	createValueReq  *CreateValueRequest
+	createValueResp RegistryMutationResult
+	updateKeyReq    *UpdateKeyRequest
+	updateKeyResp   RegistryMutationResult
+	updateValueReq  *UpdateValueRequest
+	updateValueResp RegistryMutationResult
+	deleteKeyReq    *DeleteKeyRequest
+	deleteKeyResp   RegistryMutationResult
+	deleteValueReq  *DeleteValueRequest
+	deleteValueResp RegistryMutationResult
+	err             error
+}
+
+func (f *fakeProvider) List(ctx context.Context, req ListRequest) (RegistryListResult, error) {
+	f.listReq = &req
+	return f.listResp, f.err
+}
+
+func (f *fakeProvider) CreateKey(ctx context.Context, req CreateKeyRequest) (RegistryMutationResult, error) {
+	f.createKeyReq = &req
+	return f.createKeyResp, f.err
+}
+
+func (f *fakeProvider) CreateValue(ctx context.Context, req CreateValueRequest) (RegistryMutationResult, error) {
+	f.createValueReq = &req
+	return f.createValueResp, f.err
+}
+
+func (f *fakeProvider) UpdateKey(ctx context.Context, req UpdateKeyRequest) (RegistryMutationResult, error) {
+	f.updateKeyReq = &req
+	return f.updateKeyResp, f.err
+}
+
+func (f *fakeProvider) UpdateValue(ctx context.Context, req UpdateValueRequest) (RegistryMutationResult, error) {
+	f.updateValueReq = &req
+	return f.updateValueResp, f.err
+}
+
+func (f *fakeProvider) DeleteKey(ctx context.Context, req DeleteKeyRequest) (RegistryMutationResult, error) {
+	f.deleteKeyReq = &req
+	return f.deleteKeyResp, f.err
+}
+
+func (f *fakeProvider) DeleteValue(ctx context.Context, req DeleteValueRequest) (RegistryMutationResult, error) {
+	f.deleteValueReq = &req
+	return f.deleteValueResp, f.err
+}
+
+func marshalPayload(t *testing.T, payload RegistryCommandPayload) []byte {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return data
+}
+
+func parseResponse(t *testing.T, result CommandResult) RegistryCommandResponse {
+	t.Helper()
+	if !result.Success {
+		t.Fatalf("expected successful command result, got error %q", result.Error)
+	}
+	var decoded RegistryCommandResponse
+	if err := json.Unmarshal([]byte(result.Output), &decoded); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return decoded
+}
+
+func TestManagerDispatchesListRequests(t *testing.T) {
+	provider := &fakeProvider{
+		listResp: RegistryListResult{
+			Snapshot: RegistrySnapshot{
+				"HKEY_CURRENT_USER": RegistryHive{
+					"Software": {
+						Hive:         "HKEY_CURRENT_USER",
+						Name:         "Software",
+						Path:         "Software",
+						ParentPath:   nil,
+						Values:       nil,
+						SubKeys:      nil,
+						LastModified: time.Now().UTC().Format(time.RFC3339Nano),
+						Owner:        "TEN\\Analyst",
+					},
+				},
+			},
+			GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		},
+	}
+	manager := NewManager(nil)
+	manager.SetProvider(provider)
+
+	payload := RegistryCommandPayload{
+		Request: RegistryCommandRequest{Operation: "list", Hive: "HKEY_CURRENT_USER"},
+	}
+	result := manager.HandleCommand(context.Background(), Command{ID: "cmd-1", Payload: marshalPayload(t, payload)})
+	response := parseResponse(t, result)
+	if response.Operation != "list" || response.Status != "ok" {
+		t.Fatalf("unexpected response metadata: %+v", response)
+	}
+	if provider.listReq == nil || provider.listReq.Hive != "HKEY_CURRENT_USER" {
+		t.Fatalf("provider did not receive list request: %+v", provider.listReq)
+	}
+}
+
+func TestManagerHandlesCreateKeyRequests(t *testing.T) {
+	provider := &fakeProvider{
+		createKeyResp: RegistryMutationResult{
+			Hive:      RegistryHive{"Root": {Path: "Root"}},
+			KeyPath:   "Root\\New",
+			MutatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		},
+	}
+	manager := NewManager(nil)
+	manager.SetProvider(provider)
+
+	payload := RegistryCommandPayload{
+		Request: RegistryCommandRequest{
+			Operation:  "create",
+			Target:     "key",
+			Hive:       "HKEY_LOCAL_MACHINE",
+			ParentPath: "Root",
+			Name:       "New",
+		},
+	}
+
+	result := manager.HandleCommand(context.Background(), Command{ID: "cmd-2", Payload: marshalPayload(t, payload)})
+	response := parseResponse(t, result)
+	if response.Operation != "create" {
+		t.Fatalf("expected create operation, got %s", response.Operation)
+	}
+	if provider.createKeyReq == nil || provider.createKeyReq.Name != "New" {
+		t.Fatalf("provider did not receive key creation request: %+v", provider.createKeyReq)
+	}
+}
+
+func TestManagerPropagatesProviderErrors(t *testing.T) {
+	provider := &fakeProvider{err: errors.New("denied")}
+	manager := NewManager(nil)
+	manager.SetProvider(provider)
+
+	payload := RegistryCommandPayload{
+		Request: RegistryCommandRequest{
+			Operation: "delete",
+			Target:    "key",
+			Hive:      "HKEY_USERS",
+			Path:      "Sample",
+		},
+	}
+	result := manager.HandleCommand(context.Background(), Command{ID: "cmd-err", Payload: marshalPayload(t, payload)})
+	if result.Success {
+		t.Fatalf("expected failure result")
+	}
+	if result.Error != "denied" {
+		t.Fatalf("unexpected error message: %s", result.Error)
+	}
+}
+
+func TestManagerRejectsUnsupportedOperations(t *testing.T) {
+	manager := NewManager(nil)
+	payload := RegistryCommandPayload{
+		Request: RegistryCommandRequest{Operation: "unknown"},
+	}
+	result := manager.HandleCommand(context.Background(), Command{ID: "cmd-3", Payload: marshalPayload(t, payload)})
+	if result.Success {
+		t.Fatalf("expected unsupported operation to fail")
+	}
+}

--- a/tenvy-client/internal/modules/management/registry/provider_stub.go
+++ b/tenvy-client/internal/modules/management/registry/provider_stub.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package registry
+
+import "context"
+
+type nativeProvider struct{}
+
+func newNativeProvider() Provider {
+	return &nativeProvider{}
+}
+
+func (p *nativeProvider) List(ctx context.Context, req ListRequest) (RegistryListResult, error) {
+	return RegistryListResult{}, ErrNotSupported
+}
+
+func (p *nativeProvider) CreateKey(ctx context.Context, req CreateKeyRequest) (RegistryMutationResult, error) {
+	return RegistryMutationResult{}, ErrNotSupported
+}
+
+func (p *nativeProvider) CreateValue(ctx context.Context, req CreateValueRequest) (RegistryMutationResult, error) {
+	return RegistryMutationResult{}, ErrNotSupported
+}
+
+func (p *nativeProvider) UpdateKey(ctx context.Context, req UpdateKeyRequest) (RegistryMutationResult, error) {
+	return RegistryMutationResult{}, ErrNotSupported
+}
+
+func (p *nativeProvider) UpdateValue(ctx context.Context, req UpdateValueRequest) (RegistryMutationResult, error) {
+	return RegistryMutationResult{}, ErrNotSupported
+}
+
+func (p *nativeProvider) DeleteKey(ctx context.Context, req DeleteKeyRequest) (RegistryMutationResult, error) {
+	return RegistryMutationResult{}, ErrNotSupported
+}
+
+func (p *nativeProvider) DeleteValue(ctx context.Context, req DeleteValueRequest) (RegistryMutationResult, error) {
+	return RegistryMutationResult{}, ErrNotSupported
+}

--- a/tenvy-client/internal/modules/management/registry/provider_windows.go
+++ b/tenvy-client/internal/modules/management/registry/provider_windows.go
@@ -1,0 +1,692 @@
+//go:build windows
+
+package registry
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+	"unicode/utf16"
+
+	"golang.org/x/sys/windows"
+	winregistry "golang.org/x/sys/windows/registry"
+)
+
+const registryAccess = winregistry.ENUMERATE_SUB_KEYS | winregistry.QUERY_VALUE | winregistry.SET_VALUE
+
+type nativeProvider struct{}
+
+func newNativeProvider() Provider {
+	return &nativeProvider{}
+}
+
+func (p *nativeProvider) List(ctx context.Context, req ListRequest) (RegistryListResult, error) {
+	hiveNames := []string{"HKEY_LOCAL_MACHINE", "HKEY_CURRENT_USER", "HKEY_USERS"}
+	if strings.TrimSpace(req.Hive) != "" {
+		hiveNames = []string{req.Hive}
+	}
+	snapshot := make(RegistrySnapshot)
+	for _, hiveName := range hiveNames {
+		hiveData, err := p.enumerateHive(ctx, hiveName, strings.TrimSpace(req.Path), req.Depth)
+		if err != nil {
+			return RegistryListResult{}, err
+		}
+		snapshot[hiveName] = hiveData
+	}
+	return RegistryListResult{
+		Snapshot:    snapshot,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}, nil
+}
+
+func (p *nativeProvider) CreateKey(ctx context.Context, req CreateKeyRequest) (RegistryMutationResult, error) {
+	hive := strings.TrimSpace(req.Hive)
+	name := strings.TrimSpace(req.Name)
+	if hive == "" || name == "" {
+		return RegistryMutationResult{}, fmt.Errorf("registry hive and name required")
+	}
+	root, err := mapHiveName(hive)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	parentPath := normalizeRegistryPath(req.ParentPath)
+	parentKey, closeParent, err := openWritableKey(root, parentPath)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	if closeParent {
+		defer parentKey.Close()
+	}
+
+	newKey, _, err := winregistry.CreateKey(parentKey, name, winregistry.CREATE_SUB_KEY|registryAccess)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	newKey.Close()
+
+	keyPath := joinRegistryPath(parentPath, name)
+	hiveData, err := p.enumerateHive(ctx, hive, "", -1)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	return RegistryMutationResult{
+		Hive:      hiveData,
+		KeyPath:   keyPath,
+		MutatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}, nil
+}
+
+func (p *nativeProvider) CreateValue(ctx context.Context, req CreateValueRequest) (RegistryMutationResult, error) {
+	hive := strings.TrimSpace(req.Hive)
+	keyPath := normalizeRegistryPath(req.KeyPath)
+	if hive == "" || keyPath == "" {
+		return RegistryMutationResult{}, fmt.Errorf("registry hive and key path required")
+	}
+	root, err := mapHiveName(hive)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	key, err := winregistry.OpenKey(root, keyPath, registryAccess)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	defer key.Close()
+
+	value := req.Value
+	if err := writeRegistryValue(key, value); err != nil {
+		return RegistryMutationResult{}, err
+	}
+
+	hiveData, err := p.enumerateHive(ctx, hive, "", -1)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	valueName := value.Name
+	if valueName == "" {
+		valueName = defaultValueName()
+	}
+	return RegistryMutationResult{
+		Hive:      hiveData,
+		KeyPath:   keyPath,
+		ValueName: stringPointer(valueName),
+		MutatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}, nil
+}
+
+func (p *nativeProvider) UpdateKey(ctx context.Context, req UpdateKeyRequest) (RegistryMutationResult, error) {
+	hive := strings.TrimSpace(req.Hive)
+	path := normalizeRegistryPath(req.Path)
+	name := strings.TrimSpace(req.Name)
+	if hive == "" || path == "" || name == "" {
+		return RegistryMutationResult{}, fmt.Errorf("registry hive, path, and name required")
+	}
+	root, err := mapHiveName(hive)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	parentPath, currentName := splitRegistryPath(path)
+	parentKey, closeParent, err := openWritableKey(root, parentPath)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	if closeParent {
+		defer parentKey.Close()
+	}
+
+	if strings.EqualFold(currentName, name) {
+		hiveData, err := p.enumerateHive(ctx, hive, "", -1)
+		if err != nil {
+			return RegistryMutationResult{}, err
+		}
+		return RegistryMutationResult{
+			Hive:      hiveData,
+			KeyPath:   path,
+			MutatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		}, nil
+	}
+
+	oldPtr, err := windows.UTF16PtrFromString(currentName)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	newPtr, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	if err := windows.RegRenameKey(windows.Handle(parentKey), oldPtr, newPtr); err != nil {
+		return RegistryMutationResult{}, fmt.Errorf("rename registry key: %w", err)
+	}
+
+	newPath := joinRegistryPath(parentPath, name)
+	hiveData, err := p.enumerateHive(ctx, hive, "", -1)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	return RegistryMutationResult{
+		Hive:      hiveData,
+		KeyPath:   newPath,
+		MutatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}, nil
+}
+
+func (p *nativeProvider) UpdateValue(ctx context.Context, req UpdateValueRequest) (RegistryMutationResult, error) {
+	hive := strings.TrimSpace(req.Hive)
+	keyPath := normalizeRegistryPath(req.KeyPath)
+	if hive == "" || keyPath == "" {
+		return RegistryMutationResult{}, fmt.Errorf("registry hive and key path required")
+	}
+	root, err := mapHiveName(hive)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	key, err := winregistry.OpenKey(root, keyPath, registryAccess)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	defer key.Close()
+
+	value := req.Value
+	if err := writeRegistryValue(key, value); err != nil {
+		return RegistryMutationResult{}, err
+	}
+
+	originalName := sanitizeValueName(req.OriginalName)
+	newName := sanitizeValueName(value.Name)
+	if originalName != "" && !strings.EqualFold(originalName, newName) {
+		_ = key.DeleteValue(originalName)
+	}
+
+	hiveData, err := p.enumerateHive(ctx, hive, "", -1)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	displayName := value.Name
+	if displayName == "" {
+		displayName = defaultValueName()
+	}
+	return RegistryMutationResult{
+		Hive:      hiveData,
+		KeyPath:   keyPath,
+		ValueName: stringPointer(displayName),
+		MutatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}, nil
+}
+
+func (p *nativeProvider) DeleteKey(ctx context.Context, req DeleteKeyRequest) (RegistryMutationResult, error) {
+	hive := strings.TrimSpace(req.Hive)
+	path := normalizeRegistryPath(req.Path)
+	if hive == "" || path == "" {
+		return RegistryMutationResult{}, fmt.Errorf("registry hive and key path required")
+	}
+	root, err := mapHiveName(hive)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	parentPath, name := splitRegistryPath(path)
+	parentKey, closeParent, err := openWritableKey(root, parentPath)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	if closeParent {
+		defer parentKey.Close()
+	}
+
+	if err := winregistry.DeleteKey(parentKey, name); err != nil {
+		return RegistryMutationResult{}, err
+	}
+
+	hiveData, err := p.enumerateHive(ctx, hive, "", -1)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	fallback := parentPath
+	hivePaths := hiveData
+	if fallback != "" {
+		if _, exists := hivePaths[fallback]; !exists {
+			fallback = ""
+		}
+	}
+	return RegistryMutationResult{
+		Hive:      hiveData,
+		KeyPath:   fallback,
+		MutatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}, nil
+}
+
+func (p *nativeProvider) DeleteValue(ctx context.Context, req DeleteValueRequest) (RegistryMutationResult, error) {
+	hive := strings.TrimSpace(req.Hive)
+	keyPath := normalizeRegistryPath(req.KeyPath)
+	if hive == "" || keyPath == "" {
+		return RegistryMutationResult{}, fmt.Errorf("registry hive and key path required")
+	}
+	root, err := mapHiveName(hive)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	key, err := winregistry.OpenKey(root, keyPath, registryAccess)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	defer key.Close()
+
+	name := sanitizeValueName(req.Name)
+	if err := key.DeleteValue(name); err != nil {
+		return RegistryMutationResult{}, err
+	}
+
+	hiveData, err := p.enumerateHive(ctx, hive, "", -1)
+	if err != nil {
+		return RegistryMutationResult{}, err
+	}
+	return RegistryMutationResult{
+		Hive:      hiveData,
+		KeyPath:   keyPath,
+		MutatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}, nil
+}
+
+func (p *nativeProvider) enumerateHive(ctx context.Context, hiveName, basePath string, depth int) (RegistryHive, error) {
+	root, err := mapHiveName(hiveName)
+	if err != nil {
+		return nil, err
+	}
+	basePath = normalizeRegistryPath(basePath)
+	hive := make(RegistryHive)
+	if basePath != "" {
+		key, err := winregistry.OpenKey(root, basePath, registryAccess)
+		if err != nil {
+			if errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
+				return hive, nil
+			}
+			return nil, err
+		}
+		defer key.Close()
+		if err := p.collectKey(ctx, key, hiveName, basePath, depth, hive); err != nil {
+			return nil, err
+		}
+		return hive, nil
+	}
+
+	rootKey := winregistry.Key(root)
+	subKeys, err := rootKey.ReadSubKeyNames(-1)
+	if err != nil {
+		if errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
+			return hive, nil
+		}
+		return nil, err
+	}
+	nextDepth := depth
+	if nextDepth == 0 {
+		nextDepth = -1
+	}
+	for _, sub := range subKeys {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		subKey, err := winregistry.OpenKey(rootKey, sub, registryAccess)
+		if err != nil {
+			continue
+		}
+		if err := p.collectKey(ctx, subKey, hiveName, sub, nextDepth-1, hive); err != nil {
+			subKey.Close()
+			return nil, err
+		}
+		subKey.Close()
+	}
+	return hive, nil
+}
+
+func (p *nativeProvider) collectKey(ctx context.Context, key winregistry.Key, hiveName, path string, depth int, hive RegistryHive) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	info, err := key.Stat()
+	if err != nil {
+		return err
+	}
+	parent := parentPath(path)
+	parentPtr := (*string)(nil)
+	if parent != "" {
+		parentPtr = stringPointer(parent)
+	}
+	entry := RegistryKey{
+		Hive:          hiveName,
+		Name:          lastSegment(path),
+		Path:          path,
+		ParentPath:    parentPtr,
+		Values:        []RegistryValue{},
+		SubKeys:       []string{},
+		LastModified:  info.ModTime.UTC().Format(time.RFC3339Nano),
+		Wow64Mirrored: false,
+		Owner:         "SYSTEM",
+	}
+	if values, err := readRegistryValues(key, entry.LastModified); err == nil {
+		entry.Values = values
+	}
+	if depth != 0 {
+		subNames, err := key.ReadSubKeyNames(-1)
+		if err != nil && !errors.Is(err, syscall.ERROR_NO_MORE_ITEMS) {
+			return err
+		}
+		nextDepth := depth - 1
+		if depth < 0 {
+			nextDepth = -1
+		}
+		for _, sub := range subNames {
+			subPath := joinRegistryPath(path, sub)
+			entry.SubKeys = append(entry.SubKeys, subPath)
+			child, err := winregistry.OpenKey(key, sub, registryAccess)
+			if err != nil {
+				continue
+			}
+			if err := p.collectKey(ctx, child, hiveName, subPath, nextDepth, hive); err != nil {
+				child.Close()
+				return err
+			}
+			child.Close()
+		}
+	}
+	hive[path] = entry
+	return nil
+}
+
+func readRegistryValues(key winregistry.Key, lastModified string) ([]RegistryValue, error) {
+	names, err := key.ReadValueNames(-1)
+	if err != nil {
+		if errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
+			return []RegistryValue{}, nil
+		}
+		return nil, err
+	}
+	values := make([]RegistryValue, 0, len(names))
+	for _, name := range names {
+		value, err := readRegistryValue(key, name, lastModified)
+		if err != nil {
+			continue
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func readRegistryValue(key winregistry.Key, name string, lastModified string) (RegistryValue, error) {
+	valueType, _, err := key.GetValue(name, nil)
+	if err != nil {
+		return RegistryValue{}, err
+	}
+	displayName := name
+	if displayName == "" {
+		displayName = defaultValueName()
+	}
+
+	switch winregistry.ValueType(valueType) {
+	case winregistry.SZ:
+		data, _, err := key.GetStringValue(name)
+		if err != nil {
+			return RegistryValue{}, err
+		}
+		return RegistryValue{
+			Name:         displayName,
+			Type:         "REG_SZ",
+			Data:         data,
+			Size:         utf16Length(data) * 2,
+			LastModified: lastModified,
+		}, nil
+	case winregistry.EXPAND_SZ:
+		data, _, err := key.GetStringValue(name)
+		if err != nil {
+			return RegistryValue{}, err
+		}
+		return RegistryValue{
+			Name:         displayName,
+			Type:         "REG_EXPAND_SZ",
+			Data:         data,
+			Size:         utf16Length(data) * 2,
+			LastModified: lastModified,
+		}, nil
+	case winregistry.MULTI_SZ:
+		data, _, err := key.GetStringsValue(name)
+		if err != nil {
+			return RegistryValue{}, err
+		}
+		joined := strings.Join(data, "\n")
+		size := 0
+		for _, segment := range data {
+			size += utf16Length(segment) + 1
+		}
+		if size == 0 {
+			size = 1
+		}
+		return RegistryValue{
+			Name:         displayName,
+			Type:         "REG_MULTI_SZ",
+			Data:         joined,
+			Size:         size * 2,
+			LastModified: lastModified,
+		}, nil
+	case winregistry.DWORD:
+		value, _, err := key.GetIntegerValue(name)
+		if err != nil {
+			return RegistryValue{}, err
+		}
+		return RegistryValue{
+			Name:         displayName,
+			Type:         "REG_DWORD",
+			Data:         fmt.Sprintf("0x%08X", uint32(value)),
+			Size:         4,
+			LastModified: lastModified,
+		}, nil
+	case winregistry.QWORD:
+		value, _, err := key.GetIntegerValue(name)
+		if err != nil {
+			return RegistryValue{}, err
+		}
+		return RegistryValue{
+			Name:         displayName,
+			Type:         "REG_QWORD",
+			Data:         fmt.Sprintf("0x%016X", value),
+			Size:         8,
+			LastModified: lastModified,
+		}, nil
+	case winregistry.BINARY:
+		data, _, err := key.GetBinaryValue(name)
+		if err != nil {
+			return RegistryValue{}, err
+		}
+		return RegistryValue{
+			Name:         displayName,
+			Type:         "REG_BINARY",
+			Data:         hexWithSpaces(data),
+			Size:         len(data),
+			LastModified: lastModified,
+		}, nil
+	default:
+		data, _, err := key.GetBinaryValue(name)
+		if err != nil {
+			return RegistryValue{}, err
+		}
+		return RegistryValue{
+			Name:         displayName,
+			Type:         fmt.Sprintf("REG_%d", valueType),
+			Data:         hexWithSpaces(data),
+			Size:         len(data),
+			LastModified: lastModified,
+		}, nil
+	}
+}
+
+func writeRegistryValue(key winregistry.Key, value RegistryValueInput) error {
+	name := sanitizeValueName(value.Name)
+	switch strings.ToUpper(strings.TrimSpace(value.Type)) {
+	case "REG_SZ":
+		return key.SetStringValue(name, value.Data)
+	case "REG_EXPAND_SZ":
+		return key.SetExpandStringValue(name, value.Data)
+	case "REG_MULTI_SZ":
+		segments := splitMultiString(value.Data)
+		return key.SetStringsValue(name, segments)
+	case "REG_DWORD":
+		parsed, err := parseIntegerValue(value.Data, 32)
+		if err != nil {
+			return err
+		}
+		return key.SetDWordValue(name, uint32(parsed))
+	case "REG_QWORD":
+		parsed, err := parseIntegerValue(value.Data, 64)
+		if err != nil {
+			return err
+		}
+		return key.SetQWordValue(name, parsed)
+	case "REG_BINARY":
+		bytes, err := parseHexBytes(value.Data)
+		if err != nil {
+			return err
+		}
+		return key.SetBinaryValue(name, bytes)
+	default:
+		return fmt.Errorf("unsupported registry value type %q", value.Type)
+	}
+}
+
+func mapHiveName(name string) (winregistry.Key, error) {
+	switch strings.ToUpper(strings.TrimSpace(name)) {
+	case "HKEY_LOCAL_MACHINE":
+		return winregistry.LOCAL_MACHINE, nil
+	case "HKEY_CURRENT_USER":
+		return winregistry.CURRENT_USER, nil
+	case "HKEY_USERS":
+		return winregistry.USERS, nil
+	default:
+		return winregistry.Key(0), fmt.Errorf("unsupported registry hive %q", name)
+	}
+}
+
+func openWritableKey(root winregistry.Key, path string) (winregistry.Key, bool, error) {
+	if path == "" {
+		return winregistry.Key(root), false, nil
+	}
+	key, err := winregistry.OpenKey(root, path, registryAccess)
+	if err != nil {
+		return 0, false, err
+	}
+	return key, true, nil
+}
+
+func normalizeRegistryPath(path string) string {
+	trimmed := strings.TrimSpace(path)
+	trimmed = strings.Trim(trimmed, "\\")
+	return trimmed
+}
+
+func joinRegistryPath(parent, child string) string {
+	if parent == "" {
+		return strings.Trim(child, "\\")
+	}
+	return strings.Trim(parent, "\\") + "\\" + strings.Trim(child, "\\")
+}
+
+func splitRegistryPath(path string) (string, string) {
+	trimmed := normalizeRegistryPath(path)
+	if trimmed == "" {
+		return "", ""
+	}
+	idx := strings.LastIndex(trimmed, "\\")
+	if idx < 0 {
+		return "", trimmed
+	}
+	return trimmed[:idx], trimmed[idx+1:]
+}
+
+func parentPath(path string) string {
+	parent, _ := splitRegistryPath(path)
+	return parent
+}
+
+func lastSegment(path string) string {
+	_, name := splitRegistryPath(path)
+	if name == "" {
+		return path
+	}
+	return name
+}
+
+func defaultValueName() string {
+	return "(Default)"
+}
+
+func stringPointer(value string) *string {
+	v := value
+	return &v
+}
+
+func sanitizeValueName(name string) string {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" || trimmed == defaultValueName() {
+		return ""
+	}
+	return trimmed
+}
+
+func splitMultiString(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return []string{""}
+	}
+	parts := strings.Split(value, "\n")
+	for i, part := range parts {
+		parts[i] = strings.TrimRight(part, "\r")
+	}
+	return parts
+}
+
+func parseIntegerValue(input string, bits int) (uint64, error) {
+	trimmed := strings.TrimSpace(strings.ToLower(input))
+	if strings.HasPrefix(trimmed, "0x") {
+		return strconv.ParseUint(trimmed[2:], 16, bits)
+	}
+	return strconv.ParseUint(trimmed, 10, bits)
+}
+
+func parseHexBytes(input string) ([]byte, error) {
+	sanitized := strings.ReplaceAll(input, " ", "")
+	sanitized = strings.ReplaceAll(sanitized, "\n", "")
+	sanitized = strings.ReplaceAll(sanitized, "\r", "")
+	if len(sanitized)%2 != 0 {
+		sanitized = "0" + sanitized
+	}
+	return hex.DecodeString(sanitized)
+}
+
+func hexWithSpaces(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+	encoded := strings.ToUpper(hex.EncodeToString(data))
+	builder := strings.Builder{}
+	for i := 0; i < len(encoded); i += 2 {
+		if i > 0 {
+			builder.WriteByte(' ')
+		}
+		end := i + 2
+		if end > len(encoded) {
+			end = len(encoded)
+		}
+		builder.WriteString(encoded[i:end])
+	}
+	return builder.String()
+}
+
+func utf16Length(value string) int {
+	if value == "" {
+		return 0
+	}
+	return len(utf16.Encode([]rune(value)))
+}

--- a/tenvy-server/src/lib/data/registry.ts
+++ b/tenvy-server/src/lib/data/registry.ts
@@ -1,0 +1,202 @@
+import {
+  registryListResultSchema,
+  registryMutationResultSchema,
+  type RegistryHiveName,
+  type RegistryValueInput,
+} from '$lib/types/registry';
+
+interface FetchRegistryOptions {
+  hive?: RegistryHiveName;
+  path?: string;
+  depth?: number;
+  signal?: AbortSignal;
+}
+
+interface CreateKeyInput {
+  hive: RegistryHiveName;
+  parentPath?: string | null;
+  name: string;
+  signal?: AbortSignal;
+}
+
+interface CreateValueInput {
+  hive: RegistryHiveName;
+  keyPath: string;
+  value: RegistryValueInput;
+  signal?: AbortSignal;
+}
+
+interface UpdateKeyInput {
+  hive: RegistryHiveName;
+  path: string;
+  name: string;
+  signal?: AbortSignal;
+}
+
+interface UpdateValueInput {
+  hive: RegistryHiveName;
+  keyPath: string;
+  value: RegistryValueInput;
+  originalName?: string | null;
+  signal?: AbortSignal;
+}
+
+interface DeleteKeyInput {
+  hive: RegistryHiveName;
+  path: string;
+  signal?: AbortSignal;
+}
+
+interface DeleteValueInput {
+  hive: RegistryHiveName;
+  keyPath: string;
+  name: string;
+  signal?: AbortSignal;
+}
+
+async function parseError(response: Response): Promise<Error> {
+  let message = response.statusText || 'Request failed';
+  try {
+    const payload = (await response.json()) as { message?: string; error?: string };
+    message = payload?.message || payload?.error || message;
+  } catch {
+    // ignore json parse errors
+  }
+  return new Error(message);
+}
+
+export async function fetchRegistrySnapshot(
+  agentId: string,
+  options: FetchRegistryOptions = {}
+) {
+  const params = new URLSearchParams();
+  if (options.hive) {
+    params.set('hive', options.hive);
+  }
+  if (options.path) {
+    params.set('path', options.path);
+  }
+  if (typeof options.depth === 'number') {
+    params.set('depth', String(options.depth));
+  }
+  const response = await fetch(
+    `/api/agents/${agentId}/registry${params.size > 0 ? `?${params.toString()}` : ''}`,
+    { signal: options.signal }
+  );
+  if (!response.ok) {
+    throw await parseError(response);
+  }
+  const data = await response.json();
+  const parsed = registryListResultSchema.parse(data);
+  return parsed;
+}
+
+async function requestRegistryMutation(
+  agentId: string,
+  method: 'POST' | 'PATCH' | 'DELETE',
+  body: unknown,
+  signal?: AbortSignal
+) {
+  const response = await fetch(`/api/agents/${agentId}/registry`, {
+    method,
+    signal,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  });
+  if (!response.ok) {
+    throw await parseError(response);
+  }
+  const data = await response.json();
+  const parsed = registryMutationResultSchema.parse(data);
+  return parsed;
+}
+
+export async function createRegistryKey(agentId: string, input: CreateKeyInput) {
+  return requestRegistryMutation(
+    agentId,
+    'POST',
+    {
+      operation: 'create',
+      target: 'key',
+      hive: input.hive,
+      parentPath: input.parentPath ?? undefined,
+      name: input.name,
+    },
+    input.signal
+  );
+}
+
+export async function createRegistryValue(agentId: string, input: CreateValueInput) {
+  return requestRegistryMutation(
+    agentId,
+    'POST',
+    {
+      operation: 'create',
+      target: 'value',
+      hive: input.hive,
+      keyPath: input.keyPath,
+      value: input.value,
+    },
+    input.signal
+  );
+}
+
+export async function updateRegistryKey(agentId: string, input: UpdateKeyInput) {
+  return requestRegistryMutation(
+    agentId,
+    'PATCH',
+    {
+      operation: 'update',
+      target: 'key',
+      hive: input.hive,
+      path: input.path,
+      name: input.name,
+    },
+    input.signal
+  );
+}
+
+export async function updateRegistryValue(agentId: string, input: UpdateValueInput) {
+  return requestRegistryMutation(
+    agentId,
+    'PATCH',
+    {
+      operation: 'update',
+      target: 'value',
+      hive: input.hive,
+      keyPath: input.keyPath,
+      value: input.value,
+      originalName: input.originalName ?? undefined,
+    },
+    input.signal
+  );
+}
+
+export async function deleteRegistryKey(agentId: string, input: DeleteKeyInput) {
+  return requestRegistryMutation(
+    agentId,
+    'DELETE',
+    {
+      operation: 'delete',
+      target: 'key',
+      hive: input.hive,
+      path: input.path,
+    },
+    input.signal
+  );
+}
+
+export async function deleteRegistryValue(agentId: string, input: DeleteValueInput) {
+  return requestRegistryMutation(
+    agentId,
+    'DELETE',
+    {
+      operation: 'delete',
+      target: 'value',
+      hive: input.hive,
+      keyPath: input.keyPath,
+      name: input.name,
+    },
+    input.signal
+  );
+}

--- a/tenvy-server/src/lib/server/rat/registry.ts
+++ b/tenvy-server/src/lib/server/rat/registry.ts
@@ -1,0 +1,175 @@
+import type {
+  RegistryCommandRequest,
+  RegistryCommandResponse,
+  RegistryListResult,
+  RegistryMutationResult,
+} from '$lib/types/registry';
+import {
+  registryCommandPayloadSchema,
+  registryCommandResponseSchema,
+} from '$lib/types/registry';
+import { registry, RegistryError } from './store';
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MUTATION_TIMEOUT_MS = 30_000;
+const MAX_TIMEOUT_MS = 120_000;
+const POLL_INTERVAL_MS = 250;
+
+export class RegistryAgentError extends Error {
+  status: number;
+  code?: string;
+  details?: unknown;
+
+  constructor(message: string, status = 500, options: { code?: string; details?: unknown } = {}) {
+    super(message);
+    this.name = 'RegistryAgentError';
+    this.status = status;
+    this.code = options.code;
+    this.details = options.details;
+  }
+}
+
+interface DispatchOptions {
+  operatorId?: string;
+  timeoutMs?: number;
+}
+
+type RegistryRequestResult<T extends RegistryCommandRequest> = T extends { operation: 'list' }
+  ? RegistryListResult
+  : RegistryMutationResult;
+
+function normalizeTimeout(operation: RegistryCommandRequest['operation'], requested?: number) {
+  const baseline = operation === 'list' ? DEFAULT_TIMEOUT_MS : MUTATION_TIMEOUT_MS;
+  if (typeof requested !== 'number' || Number.isNaN(requested) || requested <= 0) {
+    return baseline;
+  }
+  const clamped = Math.min(Math.max(Math.floor(requested), 1_000), MAX_TIMEOUT_MS);
+  return Math.max(clamped, baseline);
+}
+
+function ensureCommandPayload(request: RegistryCommandRequest) {
+  return registryCommandPayloadSchema.parse({ request });
+}
+
+async function waitForCommandResult(agentId: string, commandId: string, timeoutMs: number) {
+  const start = Date.now();
+  let delay = POLL_INTERVAL_MS;
+
+  while (Date.now() - start <= timeoutMs) {
+    let snapshot: ReturnType<typeof registry.getAgent>;
+    try {
+      snapshot = registry.getAgent(agentId);
+    } catch (err) {
+      if (err instanceof RegistryError) {
+        throw new RegistryAgentError(err.message, err.status);
+      }
+      throw err;
+    }
+    const match = snapshot.recentResults.find((result) => result.commandId === commandId);
+    if (match) {
+      return match;
+    }
+    const elapsed = Date.now() - start;
+    const remaining = timeoutMs - elapsed;
+    if (remaining <= 0) {
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, Math.min(delay, remaining)));
+    delay = Math.min(delay * 2, 1_000);
+  }
+
+  throw new RegistryAgentError('Timed out waiting for agent response', 504);
+}
+
+type CommandResultSnapshot = {
+  commandId: string;
+  success: boolean;
+  output?: string;
+  error?: string;
+  completedAt: string;
+};
+
+function extractResult<T extends RegistryCommandRequest>(
+  request: T,
+  decoded: RegistryCommandResponse
+): RegistryRequestResult<T> {
+  if (decoded.operation !== request.operation) {
+    throw new RegistryAgentError('Agent returned mismatched registry response', 502);
+  }
+
+  if (decoded.status === 'error') {
+    throw new RegistryAgentError(
+      decoded.error || 'Agent reported registry operation failure',
+      502,
+      {
+        code: decoded.code,
+        details: decoded.details,
+      }
+    );
+  }
+
+  if (decoded.status !== 'ok') {
+    throw new RegistryAgentError('Agent returned an unknown registry response', 502);
+  }
+
+  if (!('result' in decoded)) {
+    throw new RegistryAgentError('Agent response missing registry payload', 502);
+  }
+
+  return decoded.result as RegistryRequestResult<T>;
+}
+
+export async function dispatchRegistryCommand<T extends RegistryCommandRequest>(
+  agentId: string,
+  request: T,
+  options: DispatchOptions = {}
+): Promise<RegistryRequestResult<T>> {
+  let queuedCommandId: string;
+  try {
+    const payload = ensureCommandPayload(request);
+    const queued = registry.queueCommand(
+      agentId,
+      { name: 'registry', payload },
+      { operatorId: options.operatorId }
+    );
+    queuedCommandId = queued.command.id;
+  } catch (err) {
+    if (err instanceof RegistryError) {
+      throw new RegistryAgentError(err.message, err.status);
+    }
+    throw new RegistryAgentError('Failed to queue registry command', 500);
+  }
+
+  const timeout = normalizeTimeout(request.operation, options.timeoutMs);
+
+  let result: CommandResultSnapshot;
+  try {
+    result = await waitForCommandResult(agentId, queuedCommandId, timeout);
+  } catch (err) {
+    if (err instanceof RegistryError) {
+      throw new RegistryAgentError(err.message, err.status);
+    }
+    throw err;
+  }
+
+  if (!result.success) {
+    throw new RegistryAgentError(result.error || 'Agent failed to execute registry command', 502);
+  }
+
+  if (!result.output) {
+    throw new RegistryAgentError('Agent response missing registry payload', 502);
+  }
+
+  let decoded: RegistryCommandResponse;
+  try {
+    const parsed = JSON.parse(result.output) as unknown;
+    decoded = registryCommandResponseSchema.parse(parsed);
+  } catch (err) {
+    throw new RegistryAgentError(
+      `Agent response payload malformed: ${(err as Error).message || 'invalid JSON'}`,
+      502
+    );
+  }
+
+  return extractResult(request, decoded);
+}

--- a/tenvy-server/src/lib/types/registry.ts
+++ b/tenvy-server/src/lib/types/registry.ts
@@ -1,35 +1,45 @@
-export type RegistryHiveName = 'HKEY_LOCAL_MACHINE' | 'HKEY_CURRENT_USER' | 'HKEY_USERS';
+export {
+  registryHiveNameSchema,
+  registryValueTypeSchema,
+  registryValueSchema,
+  registryValueInputSchema,
+  registryKeySchema,
+  registryHiveSchema,
+  registrySnapshotSchema,
+  registryListRequestSchema,
+  registryCreateKeyRequestSchema,
+  registryCreateValueRequestSchema,
+  registryUpdateKeyRequestSchema,
+  registryUpdateValueRequestSchema,
+  registryDeleteKeyRequestSchema,
+  registryDeleteValueRequestSchema,
+  registryCommandRequestSchema,
+  registryCommandPayloadSchema,
+  registryListResultSchema,
+  registryMutationResultSchema,
+  registryCommandResponseSchema,
+} from '../../../../shared/types/registry';
 
-export type RegistryValueType =
-	| 'REG_SZ'
-	| 'REG_EXPAND_SZ'
-	| 'REG_MULTI_SZ'
-	| 'REG_DWORD'
-	| 'REG_QWORD'
-	| 'REG_BINARY';
-
-export interface RegistryValue {
-	name: string;
-	type: RegistryValueType;
-	data: string;
-	size: number;
-	lastModified: string;
-	description?: string;
-}
-
-export interface RegistryKey {
-	hive: RegistryHiveName;
-	name: string;
-	path: string;
-	parentPath: string | null;
-	values: RegistryValue[];
-	subKeys: string[];
-	lastModified: string;
-	wow64Mirrored: boolean;
-	owner: string;
-	description?: string;
-}
-
-export type RegistryHive = Record<string, RegistryKey>;
-
-export type RegistrySnapshot = Record<RegistryHiveName, RegistryHive>;
+export type {
+  RegistryHiveName,
+  RegistryValueType,
+  RegistryValue,
+  RegistryValueInput,
+  RegistryKey,
+  RegistryHive,
+  RegistrySnapshot,
+  RegistryListRequest,
+  RegistryCreateKeyRequest,
+  RegistryCreateValueRequest,
+  RegistryUpdateKeyRequest,
+  RegistryUpdateValueRequest,
+  RegistryDeleteKeyRequest,
+  RegistryDeleteValueRequest,
+  RegistryCommandRequest,
+  RegistryCommandPayload,
+  RegistryListResult,
+  RegistryMutationResult,
+  RegistryCommandResponse,
+  RegistryMutationOperationResponse,
+  RegistryListOperationResponse,
+} from '../../../../shared/types/registry';

--- a/tenvy-server/src/routes/api/agents/[id]/registry/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/registry/+server.ts
@@ -1,0 +1,127 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireOperator, requireViewer } from '$lib/server/authorization';
+import {
+  registryListRequestSchema,
+  registryCommandRequestSchema,
+} from '$lib/types/registry';
+import { dispatchRegistryCommand, RegistryAgentError } from '$lib/server/rat/registry';
+
+function assertAgentId(id: string | undefined): asserts id is string {
+  if (!id) {
+    throw error(400, 'Missing agent identifier');
+  }
+}
+
+function handleRegistryAgentError(err: unknown): never {
+  if (err instanceof RegistryAgentError) {
+    throw error(err.status, err.message);
+  }
+  throw err;
+}
+
+export const GET: RequestHandler = async ({ params, url, locals }) => {
+  const id = params.id;
+  assertAgentId(id);
+
+  requireViewer(locals.user);
+
+  const candidate: Record<string, unknown> = { operation: 'list' };
+  const hiveParam = url.searchParams.get('hive');
+  const pathParam = url.searchParams.get('path');
+  const depthParam = url.searchParams.get('depth');
+
+  if (hiveParam) {
+    candidate.hive = hiveParam;
+  }
+  if (pathParam) {
+    candidate.path = pathParam;
+  }
+  if (depthParam !== null) {
+    const depth = Number(depthParam);
+    if (!Number.isFinite(depth)) {
+      throw error(400, 'Depth must be a number');
+    }
+    candidate.depth = depth;
+  }
+
+  const parsed = registryListRequestSchema.safeParse(candidate);
+  if (!parsed.success) {
+    throw error(400, 'Invalid registry list parameters');
+  }
+
+  try {
+    const result = await dispatchRegistryCommand(id, parsed.data);
+    return json(result);
+  } catch (err) {
+    handleRegistryAgentError(err);
+  }
+};
+
+async function parseCommandRequest(request: Request) {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    throw error(400, 'Invalid registry payload');
+  }
+  const parsed = registryCommandRequestSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw error(400, 'Invalid registry payload');
+  }
+  return parsed.data;
+}
+
+export const POST: RequestHandler = async ({ params, request, locals }) => {
+  const id = params.id;
+  assertAgentId(id);
+
+  const user = requireOperator(locals.user);
+  const parsed = await parseCommandRequest(request);
+  if (parsed.operation !== 'create') {
+    throw error(400, 'Registry create payload required');
+  }
+
+  try {
+    const result = await dispatchRegistryCommand(id, parsed, { operatorId: user.id });
+    return json(result, { status: 201 });
+  } catch (err) {
+    handleRegistryAgentError(err);
+  }
+};
+
+export const PATCH: RequestHandler = async ({ params, request, locals }) => {
+  const id = params.id;
+  assertAgentId(id);
+
+  const user = requireOperator(locals.user);
+  const parsed = await parseCommandRequest(request);
+  if (parsed.operation !== 'update') {
+    throw error(400, 'Registry update payload required');
+  }
+
+  try {
+    const result = await dispatchRegistryCommand(id, parsed, { operatorId: user.id });
+    return json(result);
+  } catch (err) {
+    handleRegistryAgentError(err);
+  }
+};
+
+export const DELETE: RequestHandler = async ({ params, request, locals }) => {
+  const id = params.id;
+  assertAgentId(id);
+
+  const user = requireOperator(locals.user);
+  const parsed = await parseCommandRequest(request);
+  if (parsed.operation !== 'delete') {
+    throw error(400, 'Registry delete payload required');
+  }
+
+  try {
+    const result = await dispatchRegistryCommand(id, parsed, { operatorId: user.id });
+    return json(result);
+  } catch (err) {
+    handleRegistryAgentError(err);
+  }
+};

--- a/tenvy-server/tests/registry-api.test.ts
+++ b/tenvy-server/tests/registry-api.test.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const requireViewer = vi.fn((user: { id: string } | null | undefined) => user ?? { id: 'viewer-test' });
+const requireOperator = vi.fn((user: { id: string } | null | undefined) => user ?? { id: 'operator-test' });
+
+vi.mock('../src/lib/server/authorization.js', () => ({
+  requireViewer,
+  requireOperator,
+}));
+
+const dispatchRegistryCommand = vi.fn();
+
+class MockRegistryAgentError extends Error {
+  status: number;
+
+  constructor(message: string, status = 500) {
+    super(message);
+    this.status = status;
+  }
+}
+
+vi.mock('../src/lib/server/rat/registry.js', () => ({
+  dispatchRegistryCommand,
+  RegistryAgentError: MockRegistryAgentError,
+}));
+
+const modulePromise = import('../src/routes/api/agents/[id]/registry/+server.js');
+
+type Handler = Awaited<typeof modulePromise> extends infer T
+  ? T extends { GET?: infer G; POST?: infer P; PATCH?: infer U; DELETE?: infer D }
+    ? G | P | U | D
+    : never
+  : never;
+
+function createEvent<T extends Handler>(
+  handler: T,
+  init: Partial<Parameters<T>[0]> & { method?: string } = {}
+): Parameters<T>[0] {
+  const method = init.method ?? 'GET';
+  return {
+    params: { id: 'agent-1', ...(init.params ?? {}) },
+    url: init.url ?? new URL('https://controller.test/api'),
+    request:
+      init.request ??
+      new Request('https://controller.test/api', {
+        method,
+      }),
+    locals: init.locals ?? { user: { id: 'user-test' } },
+    ...init,
+  } as Parameters<T>[0];
+}
+
+describe('registry API routes', () => {
+  beforeEach(() => {
+    requireViewer.mockClear();
+    requireOperator.mockClear();
+    dispatchRegistryCommand.mockReset();
+  });
+
+  it('lists registry data for the requested agent', async () => {
+    const { GET } = await modulePromise;
+    if (!GET) throw new Error('GET handler missing');
+
+    const snapshot = {
+      HKEY_LOCAL_MACHINE: {},
+      HKEY_CURRENT_USER: {
+        Software: {
+          hive: 'HKEY_CURRENT_USER',
+          name: 'Software',
+          path: 'Software',
+          parentPath: null,
+          values: [],
+          subKeys: [],
+          lastModified: '2024-06-01T12:00:00Z',
+          wow64Mirrored: false,
+          owner: 'TEN\\Analyst',
+        },
+      },
+      HKEY_USERS: {},
+    } as unknown as Awaited<ReturnType<typeof dispatchRegistryCommand>>;
+
+    dispatchRegistryCommand.mockResolvedValue({
+      snapshot,
+      generatedAt: '2024-06-01T12:00:00Z',
+    });
+
+    const response = await GET(
+      createEvent(GET, {
+        url: new URL('https://controller.test/api?hive=HKEY_CURRENT_USER&depth=2'),
+      })
+    );
+
+    expect(requireViewer).toHaveBeenCalledWith({ id: 'user-test' });
+    expect(dispatchRegistryCommand).toHaveBeenCalledWith(
+      'agent-1',
+      {
+        operation: 'list',
+        hive: 'HKEY_CURRENT_USER',
+        depth: 2,
+      }
+    );
+
+    const body = (await response.json()) as {
+      snapshot: Record<string, unknown>;
+      generatedAt: string;
+    };
+    expect(body.snapshot).toEqual(snapshot);
+    expect(body.generatedAt).toBe('2024-06-01T12:00:00Z');
+  });
+
+  it('creates registry keys through the agent', async () => {
+    const { POST } = await modulePromise;
+    if (!POST) throw new Error('POST handler missing');
+
+    const mutationResult = {
+      hive: { SOFTWARE: { path: 'SOFTWARE', name: 'SOFTWARE', hive: 'HKEY_LOCAL_MACHINE', parentPath: null, values: [], subKeys: [], lastModified: '2024-06-01T12:00:00Z', wow64Mirrored: false, owner: 'SYSTEM' } },
+      keyPath: 'SOFTWARE',
+      mutatedAt: '2024-06-01T12:00:00Z',
+    } satisfies Awaited<ReturnType<typeof dispatchRegistryCommand>>;
+
+    dispatchRegistryCommand.mockResolvedValue(mutationResult);
+
+    const response = await POST(
+      createEvent(POST, {
+        method: 'POST',
+        request: new Request('https://controller.test/api', {
+          method: 'POST',
+          body: JSON.stringify({
+            operation: 'create',
+            target: 'key',
+            hive: 'HKEY_LOCAL_MACHINE',
+            name: 'SOFTWARE',
+          }),
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      })
+    );
+
+    expect(requireOperator).toHaveBeenCalledWith({ id: 'user-test' });
+    expect(dispatchRegistryCommand).toHaveBeenCalledWith(
+      'agent-1',
+      {
+        operation: 'create',
+        target: 'key',
+        hive: 'HKEY_LOCAL_MACHINE',
+        name: 'SOFTWARE',
+      },
+      { operatorId: 'user-test' }
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as typeof mutationResult;
+    expect(body.keyPath).toBe('SOFTWARE');
+  });
+
+  it('updates registry values through the agent', async () => {
+    const { PATCH } = await modulePromise;
+    if (!PATCH) throw new Error('PATCH handler missing');
+
+    const mutationResult = {
+      hive: {
+        'Software': {
+          path: 'Software',
+          name: 'Software',
+          hive: 'HKEY_CURRENT_USER',
+          parentPath: null,
+          values: [],
+          subKeys: [],
+          lastModified: '2024-06-01T12:30:00Z',
+          wow64Mirrored: false,
+          owner: 'TEN\\Analyst',
+        },
+      },
+      keyPath: 'Software',
+      valueName: 'Sample',
+      mutatedAt: '2024-06-01T12:30:00Z',
+    } satisfies Awaited<ReturnType<typeof dispatchRegistryCommand>>;
+
+    dispatchRegistryCommand.mockResolvedValue(mutationResult);
+
+    const response = await PATCH(
+      createEvent(PATCH, {
+        method: 'PATCH',
+        request: new Request('https://controller.test/api', {
+          method: 'PATCH',
+          body: JSON.stringify({
+            operation: 'update',
+            target: 'value',
+            hive: 'HKEY_CURRENT_USER',
+            keyPath: 'Software',
+            value: {
+              name: 'Sample',
+              type: 'REG_SZ',
+              data: 'example',
+            },
+            originalName: 'Sample',
+          }),
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      })
+    );
+
+    expect(requireOperator).toHaveBeenCalledWith({ id: 'user-test' });
+    expect(dispatchRegistryCommand).toHaveBeenCalledWith(
+      'agent-1',
+      {
+        operation: 'update',
+        target: 'value',
+        hive: 'HKEY_CURRENT_USER',
+        keyPath: 'Software',
+        value: {
+          name: 'Sample',
+          type: 'REG_SZ',
+          data: 'example',
+        },
+        originalName: 'Sample',
+      },
+      { operatorId: 'user-test' }
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as typeof mutationResult;
+    expect(body.valueName).toBe('Sample');
+  });
+
+  it('propagates registry agent errors as HTTP errors', async () => {
+    const { DELETE } = await modulePromise;
+    if (!DELETE) throw new Error('DELETE handler missing');
+
+    dispatchRegistryCommand.mockRejectedValue(new MockRegistryAgentError('denied', 409));
+
+    await expect(
+      DELETE(
+        createEvent(DELETE, {
+          method: 'DELETE',
+          request: new Request('https://controller.test/api', {
+            method: 'DELETE',
+            body: JSON.stringify({
+              operation: 'delete',
+              target: 'key',
+              hive: 'HKEY_LOCAL_MACHINE',
+              path: 'Software',
+            }),
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        })
+      )
+    ).rejects.toMatchObject({ status: 409, body: { message: 'denied' } });
+  });
+});


### PR DESCRIPTION
## Summary
- add shared registry schemas and re-export them for the SvelteKit server
- proxy registry commands through new data helpers, API route handlers, and RAT dispatcher while updating the workspace UI
- introduce a Go registry management module with Windows provider logic, tests, and agent integration

## Testing
- `bun run test:unit --run tests/registry-api.test.ts`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68fd4f552ae0832b866275e06c7bfce8