### PR TITLE
Queue client chat commands via agent API

### DIFF
--- a/tenvy-server/src/lib/components/workspace/tools/client-chat-workspace.svelte
+++ b/tenvy-server/src/lib/components/workspace/tools/client-chat-workspace.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { Button } from '$lib/components/ui/button/index.js';
+        import { createEventDispatcher } from 'svelte';
+        import { Button } from '$lib/components/ui/button/index.js';
 	import { Input } from '$lib/components/ui/input/index.js';
 	import {
 		Card,
@@ -11,12 +12,13 @@
 	} from '$lib/components/ui/card/index.js';
 	import { getClientTool } from '$lib/data/client-tools';
 	import type { Client } from '$lib/data/clients';
-	import {
-		appendWorkspaceLog,
-		createWorkspaceLogEntry,
-		formatWorkspaceTimestamp
-	} from '$lib/workspace/utils';
-	import type { WorkspaceLogEntry } from '$lib/workspace/types';
+        import {
+                appendWorkspaceLog,
+                createWorkspaceLogEntry,
+                formatWorkspaceTimestamp
+        } from '$lib/workspace/utils';
+        import type { WorkspaceLogEntry } from '$lib/workspace/types';
+        import type { CommandQueueResponse } from '../../../../../../shared/types/messages';
 
 	type ChatMessage = {
 		id: string;
@@ -25,37 +27,129 @@
 		timestamp: string;
 	};
 
-	const { client } = $props<{ client: Client }>();
+        const { client } = $props<{ client: Client }>();
 
-	const tool = getClientTool('client-chat');
-	void tool;
+        const tool = getClientTool('client-chat');
+        void tool;
 
-	let messages = $state<ChatMessage[]>([
-		{
-			id: 'seed-1',
-			sender: 'client',
+        const dispatch = createEventDispatcher<{ logchange: WorkspaceLogEntry[] }>();
+
+        let messages = $state<ChatMessage[]>([
+                {
+                        id: 'seed-1',
+                        sender: 'client',
 			body: 'Connected. Awaiting operator instructions.',
 			timestamp: new Date().toISOString()
 		}
 	]);
-	let draft = $state('');
-	let log = $state<WorkspaceLogEntry[]>([]);
+        let draft = $state('');
+        let log = $state<WorkspaceLogEntry[]>([]);
+        let dispatching = $state(false);
 
-	function sendMessage(status: WorkspaceLogEntry['status']) {
-		if (!draft.trim()) return;
-		const entry: ChatMessage = {
-			id: `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
-			sender: 'operator',
-			body: draft.trim(),
-			timestamp: new Date().toISOString()
-		};
-		messages = [...messages, entry];
-		draft = '';
-		log = appendWorkspaceLog(
-			log,
-			createWorkspaceLogEntry('Chat message staged', entry.body, status)
-		);
-	}
+        function createChatMessage(body: string): ChatMessage {
+                return {
+                        id: `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+                        sender: 'operator',
+                        body,
+                        timestamp: new Date().toISOString()
+                } satisfies ChatMessage;
+        }
+
+        function updateLogEntry(id: string, updates: Partial<WorkspaceLogEntry>) {
+                log = log.map((entry) => (entry.id === id ? { ...entry, ...updates } : entry));
+        }
+
+        function recordDraft() {
+                const trimmed = draft.trim();
+                if (!trimmed) {
+                        return;
+                }
+                const entry = createChatMessage(trimmed);
+                messages = [...messages, entry];
+                draft = '';
+                log = appendWorkspaceLog(
+                        log,
+                        createWorkspaceLogEntry('Chat message staged', entry.body, 'draft')
+                );
+        }
+
+        function recordFailure(message: string) {
+                log = appendWorkspaceLog(
+                        log,
+                        createWorkspaceLogEntry('Chat message failed', message, 'failed')
+                );
+        }
+
+        async function sendMessage() {
+                if (dispatching) {
+                        return;
+                }
+
+                const trimmed = draft.trim();
+                if (!trimmed) {
+                        recordFailure('Message body is required');
+                        return;
+                }
+
+                const message = createChatMessage(trimmed);
+                messages = [...messages, message];
+                draft = '';
+
+                const logEntry = createWorkspaceLogEntry(
+                        'Chat message dispatched',
+                        trimmed,
+                        'queued'
+                );
+                log = appendWorkspaceLog(log, logEntry);
+
+                dispatching = true;
+
+                try {
+                        const response = await fetch(`/api/agents/${client.id}/commands`, {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({
+                                        name: 'client-chat',
+                                        payload: {
+                                                action: 'send-message',
+                                                message: { body: trimmed }
+                                        }
+                                })
+                        });
+
+                        if (!response.ok) {
+                                const message = (await response.text())?.trim() || 'Failed to queue chat message';
+                                updateLogEntry(logEntry.id, {
+                                        status: 'complete',
+                                        detail: message
+                                });
+                                return;
+                        }
+
+                        const data = (await response.json()) as CommandQueueResponse;
+                        const delivery = data?.delivery === 'session' ? 'session' : 'queued';
+                        const detail =
+                                delivery === 'session'
+                                        ? 'Delivered to active chat session'
+                                        : 'Queued for next agent poll';
+                        updateLogEntry(logEntry.id, {
+                                status: 'in-progress',
+                                detail
+                        });
+                } catch (err) {
+                        const message = err instanceof Error ? err.message : 'Failed to queue chat message';
+                        updateLogEntry(logEntry.id, {
+                                status: 'complete',
+                                detail: message
+                        });
+                } finally {
+                        dispatching = false;
+                }
+        }
+
+        $effect(() => {
+                dispatch('logchange', log);
+        });
 </script>
 
 <div class="space-y-6">
@@ -84,16 +178,22 @@
 			</div>
 		</CardContent>
 		<CardFooter class="gap-3">
-			<Input
-				value={draft}
-				placeholder="Type a message"
-				oninput={(event) => (draft = event.currentTarget.value)}
-				class="flex-1"
-			/>
-			<Button type="button" variant="outline" onclick={() => sendMessage('draft')}>
-				Save draft
-			</Button>
-			<Button type="button" onclick={() => sendMessage('queued')}>Send</Button>
-		</CardFooter>
-	</Card>
+                        <Input
+                                value={draft}
+                                placeholder="Type a message"
+                                oninput={(event) => (draft = event.currentTarget.value)}
+                                class="flex-1"
+                        />
+                        <Button type="button" variant="outline" onclick={recordDraft}>
+                                Save draft
+                        </Button>
+                        <Button type="button" onclick={sendMessage} disabled={dispatching}>
+                                {#if dispatching}
+                                        Sending…
+                                {:else}
+                                        Send
+                                {/if}
+                        </Button>
+                </CardFooter>
+        </Card>
 </div>

--- a/tenvy-server/src/lib/components/workspace/tools/client-chat-workspace.svelte.spec.ts
+++ b/tenvy-server/src/lib/components/workspace/tools/client-chat-workspace.svelte.spec.ts
@@ -1,0 +1,151 @@
+import { page } from '@vitest/browser/context';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+
+import type { Client } from '$lib/data/clients';
+import type { WorkspaceLogEntry } from '$lib/workspace/types';
+
+import ClientChatWorkspace from './client-chat-workspace.svelte';
+
+const originalFetch = globalThis.fetch;
+
+const baseClient: Client = {
+        id: 'agent-321',
+        codename: 'SIERRA',
+        hostname: 'demo-host',
+        ip: '10.1.2.3',
+        location: 'QA Lab',
+        os: 'Windows',
+        platform: 'windows',
+        version: '1.0.0',
+        status: 'online',
+        lastSeen: new Date().toISOString(),
+        tags: [],
+        risk: 'Low'
+};
+
+describe('client chat workspace', () => {
+        beforeEach(() => {
+                globalThis.fetch = vi.fn();
+        });
+
+        afterEach(() => {
+                if (originalFetch) {
+                        globalThis.fetch = originalFetch;
+                } else {
+                        // @ts-expect-error cleanup in tests
+                        delete globalThis.fetch;
+                }
+        });
+
+        it('delivers the message to an active session immediately', async () => {
+                const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+                fetchMock.mockResolvedValue(
+                        Promise.resolve({
+                                ok: true,
+                                json: vi.fn().mockResolvedValue({
+                                        delivery: 'session',
+                                        command: {
+                                                id: 'cmd-client-chat-session',
+                                                name: 'client-chat',
+                                                payload: {
+                                                        action: 'send-message',
+                                                        message: { body: 'Hello agent' }
+                                                },
+                                                createdAt: new Date().toISOString()
+                                        }
+                                })
+                        } as unknown as Response)
+                );
+
+                const { component } = render(ClientChatWorkspace, { props: { client: baseClient } });
+                const logs: WorkspaceLogEntry[][] = [];
+                component.$on('logchange', (event) => {
+                        logs.push(event.detail);
+                });
+
+                const messageField = page.getByPlaceholder('Type a message');
+                await expect.element(messageField).toBeInTheDocument();
+                await messageField.fill('Hello agent');
+
+                const sendButton = page.getByRole('button', { name: 'Send' });
+                await expect.element(sendButton).toBeInTheDocument();
+                await sendButton.click();
+
+                await new Promise((resolve) => setTimeout(resolve, 0));
+
+                expect(fetchMock).toHaveBeenCalledWith(`/api/agents/${baseClient.id}/commands`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                                name: 'client-chat',
+                                payload: {
+                                        action: 'send-message',
+                                        message: { body: 'Hello agent' }
+                                }
+                        })
+                });
+
+                const finalLog = logs.at(-1);
+                expect(finalLog?.[0]).toMatchObject({
+                        status: 'in-progress',
+                        detail: 'Delivered to active chat session'
+                });
+
+                component.$destroy();
+        });
+
+        it('records a queued message when the agent is offline', async () => {
+                const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+                fetchMock.mockResolvedValue(
+                        Promise.resolve({
+                                ok: true,
+                                json: vi.fn().mockResolvedValue({
+                                        delivery: 'queued',
+                                        command: {
+                                                id: 'cmd-client-chat-queued',
+                                                name: 'client-chat',
+                                                payload: {
+                                                        action: 'send-message',
+                                                        message: { body: 'Queued message' }
+                                                },
+                                                createdAt: new Date().toISOString()
+                                        }
+                                })
+                        } as unknown as Response)
+                );
+
+                const { component } = render(ClientChatWorkspace, { props: { client: baseClient } });
+                const logs: WorkspaceLogEntry[][] = [];
+                component.$on('logchange', (event) => {
+                        logs.push(event.detail);
+                });
+
+                const messageField = page.getByPlaceholder('Type a message');
+                await messageField.fill('Queued message');
+
+                const sendButton = page.getByRole('button', { name: 'Send' });
+                await sendButton.click();
+
+                await new Promise((resolve) => setTimeout(resolve, 0));
+
+                const finalLog = logs.at(-1);
+                expect(finalLog?.[0]).toMatchObject({
+                        status: 'in-progress',
+                        detail: 'Queued for next agent poll'
+                });
+
+                const [, options] = fetchMock.mock.calls[0] ?? [];
+                expect(options?.body).toBe(
+                        JSON.stringify({
+                                name: 'client-chat',
+                                payload: {
+                                        action: 'send-message',
+                                        message: { body: 'Queued message' }
+                                }
+                        })
+                );
+
+                component.$destroy();
+        });
+});

--- a/tenvy-server/src/lib/components/workspace/tools/open-url-workspace.svelte.spec.ts
+++ b/tenvy-server/src/lib/components/workspace/tools/open-url-workspace.svelte.spec.ts
@@ -1,0 +1,139 @@
+import { page } from '@vitest/browser/context';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+
+import type { Client } from '$lib/data/clients';
+import type { WorkspaceLogEntry } from '$lib/workspace/types';
+
+import OpenUrlWorkspace from './open-url-workspace.svelte';
+
+const originalFetch = globalThis.fetch;
+
+const baseClient: Client = {
+        id: 'agent-321',
+        codename: 'SIERRA',
+        hostname: 'demo-host',
+        ip: '10.1.2.3',
+        location: 'QA Lab',
+        os: 'Windows',
+        platform: 'windows',
+        version: '1.0.0',
+        status: 'online',
+        lastSeen: new Date().toISOString(),
+        tags: [],
+        risk: 'Low'
+};
+
+describe('open-url workspace', () => {
+        beforeEach(() => {
+                globalThis.fetch = vi.fn();
+        });
+
+        afterEach(() => {
+                if (originalFetch) {
+                        globalThis.fetch = originalFetch;
+                } else {
+                        // @ts-expect-error cleanup in tests
+                        delete globalThis.fetch;
+                }
+        });
+
+        it('dispatches a URL launch immediately when the agent session is active', async () => {
+                const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+                fetchMock.mockResolvedValue(
+                        Promise.resolve({
+                                ok: true,
+                                json: vi.fn().mockResolvedValue({
+                                        delivery: 'session',
+                                        command: {
+                                                id: 'cmd-open-url',
+                                                name: 'open-url',
+                                                payload: { url: 'https://example.com' },
+                                                createdAt: new Date().toISOString()
+                                        }
+                                })
+                        } as unknown as Response)
+                );
+
+                const { component } = render(OpenUrlWorkspace, { props: { client: baseClient } });
+                const logs: WorkspaceLogEntry[][] = [];
+                component.$on('logchange', (event) => {
+                        logs.push(event.detail);
+                });
+
+                const urlField = page.getByLabelText('URL');
+                await expect.element(urlField).toBeInTheDocument();
+                await urlField.fill('https://example.com');
+
+                const queueButton = page.getByRole('button', { name: 'Queue launch' });
+                await expect.element(queueButton).toBeInTheDocument();
+                await queueButton.click();
+
+                await new Promise((resolve) => setTimeout(resolve, 0));
+
+                expect(fetchMock).toHaveBeenCalledWith(`/api/agents/${baseClient.id}/commands`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                                name: 'open-url',
+                                payload: { url: 'https://example.com' }
+                        })
+                });
+
+                const finalLog = logs.at(-1);
+                expect(finalLog?.[0]).toMatchObject({
+                        status: 'in-progress',
+                        detail: 'Launch dispatched to live session'
+                });
+
+                component.$destroy();
+        });
+
+        it('records a queued delivery when the command awaits the next agent poll', async () => {
+                const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+                fetchMock.mockResolvedValue(
+                        Promise.resolve({
+                                ok: true,
+                                json: vi.fn().mockResolvedValue({
+                                        delivery: 'queued',
+                                        command: {
+                                                id: 'cmd-open-url-queued',
+                                                name: 'open-url',
+                                                payload: { url: 'https://queued.example.com' },
+                                                createdAt: new Date().toISOString()
+                                        }
+                                })
+                        } as unknown as Response)
+                );
+
+                const { component } = render(OpenUrlWorkspace, { props: { client: baseClient } });
+                const logs: WorkspaceLogEntry[][] = [];
+                component.$on('logchange', (event) => {
+                        logs.push(event.detail);
+                });
+
+                const urlField = page.getByLabelText('URL');
+                await urlField.fill('https://queued.example.com');
+
+                const queueButton = page.getByRole('button', { name: 'Queue launch' });
+                await queueButton.click();
+
+                await new Promise((resolve) => setTimeout(resolve, 0));
+
+                const finalLog = logs.at(-1);
+                expect(finalLog?.[0]).toMatchObject({
+                        status: 'in-progress',
+                        detail: 'Awaiting agent execution'
+                });
+
+                const [, options] = fetchMock.mock.calls[0] ?? [];
+                expect(options?.body).toBe(
+                        JSON.stringify({
+                                name: 'open-url',
+                                payload: { url: 'https://queued.example.com' }
+                        })
+                );
+
+                component.$destroy();
+        });
+});


### PR DESCRIPTION
## Summary
- refactor the client chat workspace to submit `client-chat` commands through the agent API and surface delivery results
- guard duplicate submissions, emit workspace log updates, and show progress while chat messages dispatch
- add browser-based component tests that stub `fetch` to confirm the queued requests and resulting log state transitions

## Testing
- ENABLE_BROWSER_TESTS=true VITEST_BROWSER=true npm run test:unit -- --run --project client src/lib/components/workspace/tools/client-chat-workspace.svelte.spec.ts *(fails: Vitest requires Browser Mode to be enabled instead of `test.environment = "browser"`)*

------
https://chatgpt.com/codex/tasks/task_e_68fe5a9692a0832bb63dee6c9fa0d241