### PR TITLE
Persist client notes via notes dialog

### DIFF
--- a/tenvy-server/src/lib/components/client-tool-dialog.svelte
+++ b/tenvy-server/src/lib/components/client-tool-dialog.svelte
@@ -76,6 +76,78 @@
 		requestClose();
 	}
 
+	function parseTags(input: string): string[] {
+		return input
+			.split(/[,\s]+/)
+			.map((tag) => tag.trim())
+			.filter(Boolean);
+	}
+
+	function clearNoteFeedback() {
+		noteSaveError = null;
+		noteSaveSuccess = null;
+	}
+
+	async function handleNotesSubmit(event: SubmitEvent) {
+		event.preventDefault();
+
+		noteSaveError = null;
+		noteSaveSuccess = null;
+
+		if (!browser) {
+			noteSaveError = 'Notes cannot be saved in this environment';
+			return;
+		}
+
+		const trimmed = noteText.trimEnd();
+		const tags = parseTags(noteTagsInput);
+
+		noteSavePending = true;
+
+		try {
+			const response = await fetch(`/api/agents/${client.id}/notes`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ note: trimmed, tags })
+			});
+
+			if (!response.ok) {
+				const message = (await response.text())?.trim();
+				noteSaveError = message || 'Failed to save notes';
+				return;
+			}
+
+			let responseBody: unknown = null;
+			try {
+				responseBody = await response.json();
+			} catch {
+				responseBody = null;
+			}
+
+			let nextNote = trimmed;
+			if (responseBody && typeof (responseBody as Record<string, unknown>).note === 'string') {
+				const received = (responseBody as { note: string }).note ?? '';
+				nextNote = received.trimEnd();
+			}
+
+			let nextTags = tags;
+			if (responseBody && Array.isArray((responseBody as Record<string, unknown>).tags)) {
+				nextTags = (responseBody as { tags: unknown[] }).tags
+					.map((tag) => `${tag}`.trim())
+					.filter(Boolean);
+			}
+
+			noteText = nextNote;
+			client.notes = nextNote;
+			noteTagsInput = nextTags.join(' ');
+			noteSaveSuccess = 'Notes saved';
+		} catch (err) {
+			noteSaveError = err instanceof Error ? err.message : 'Failed to save notes';
+		} finally {
+			noteSavePending = false;
+		}
+	}
+
 	const tool = getClientTool(toolId);
 
 	const workspaceComponentMap = {
@@ -132,8 +204,8 @@
 	const missingAgent = $derived(workspaceRequiresAgent.has(toolId) && !agent);
 
 	const windowWidth = $derived(
-		!isWorkspaceDialog ? 640 : toolId === 'system-monitor' ? 1180 : 980
-	);
+                !isWorkspaceDialog ? 640 : toolId === 'system-monitor' ? 1180 : 980
+        );
 	const windowHeight = $derived(
 		isWorkspaceDialog ? (toolId === 'system-monitor' ? 720 : 640) : 540
 	);
@@ -159,6 +231,10 @@
 		'flex h-9 w-full min-w-0 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs ring-offset-background transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:bg-input/30';
 
 	let noteText = $state(client.notes ?? '');
+	let noteTagsInput = $state(client.tags?.join(' ') ?? '');
+	let noteSavePending = $state(false);
+	let noteSaveError = $state<string | null>(null);
+	let noteSaveSuccess = $state<string | null>(null);
 	let url = $state('https://');
 	let urlContext = $state('');
 	let messageTitle = $state('');
@@ -310,7 +386,7 @@
 					{:else if toolId === 'system-info'}
 						<SystemInformationDialog {client} />
 					{:else if toolId === 'notes'}
-						<form class="flex h-full flex-col" onsubmit={handleFormSubmit}>
+						<form class="flex h-full flex-col" onsubmit={handleNotesSubmit}>
 							<div class="flex-1 space-y-6 overflow-auto px-6 py-5">
 								<div class="grid gap-2">
 									<Label for={notesFieldId}>Operational notes</Label>
@@ -318,16 +394,24 @@
 										id={notesFieldId}
 										class="min-h-32"
 										bind:value={noteText}
+										on:input={clearNoteFeedback}
 										placeholder="Add context, requirements, or follow-up actions for {client.codename}."
 									/>
 								</div>
 								<div class="grid gap-2">
 									<Label for={`${notesFieldId}-tags`}>Quick tags</Label>
-									<Input id={`${notesFieldId}-tags`} placeholder="intel priority staging" />
-									<p class="text-xs text-muted-foreground">
-										Tags are not persisted yet; this scaffold highlights the planned structure.
-									</p>
+									<Input
+										id={`${notesFieldId}-tags`}
+										bind:value={noteTagsInput}
+										on:input={clearNoteFeedback}
+										placeholder="intel priority staging"
+									/>
 								</div>
+								{#if noteSaveError}
+									<p class="text-sm text-destructive">{noteSaveError}</p>
+								{:else if noteSaveSuccess}
+									<p class="text-sm text-emerald-600">{noteSaveSuccess}</p>
+								{/if}
 							</div>
 							<div
 								class="flex items-center justify-end gap-2 border-t border-border/70 bg-muted/30 px-6 py-4"
@@ -337,7 +421,13 @@
 										<Button variant="outline" {...props}>Cancel</Button>
 									{/snippet}
 								</Dialog.Close>
-								<Button type="submit">Save draft</Button>
+								<Button type="submit" disabled={noteSavePending}>
+									{#if noteSavePending}
+										Saving…
+									{:else}
+										Save draft
+									{/if}
+								</Button>
 							</div>
 						</form>
 					{:else if toolId === 'open-url'}


### PR DESCRIPTION
## Summary
- post notes from the dialog to `/api/agents/{client.id}/notes` and refresh the cached text on success
- wire the quick tags input into the request payload and normalise the saved value
- surface pending/success/error states in the notes form so operators see save feedback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fea4109be8832bb19bc7c0dc16c277