### PR TITLE
Add trigger monitor watchlist schema to shared contract

### DIFF
--- a/shared/types/trigger-monitor.ts
+++ b/shared/types/trigger-monitor.ts
@@ -3,11 +3,44 @@ import { z } from 'zod';
 export const triggerMonitorFeedSchema = z.enum(['live', 'batch']);
 export type TriggerMonitorFeed = z.infer<typeof triggerMonitorFeedSchema>;
 
-export const triggerMonitorConfigSchema = z.object({
+export const triggerMonitorWatchlistEntrySchema = z.object({
+  kind: z.enum(['app', 'url']),
+  id: z.string().min(1),
+  displayName: z.string().min(1),
+  alertOnOpen: z.boolean(),
+  alertOnClose: z.boolean(),
+});
+export type TriggerMonitorWatchlistEntry = z.infer<
+  typeof triggerMonitorWatchlistEntrySchema
+>;
+
+export const triggerMonitorWatchlistSchema = z.array(
+  triggerMonitorWatchlistEntrySchema,
+);
+export type TriggerMonitorWatchlist = z.infer<
+  typeof triggerMonitorWatchlistSchema
+>;
+
+export const triggerMonitorWatchlistInputSchema =
+  triggerMonitorWatchlistSchema.default([]);
+export type TriggerMonitorWatchlistInput = z.input<
+  typeof triggerMonitorWatchlistInputSchema
+>;
+
+const triggerMonitorConfigBaseSchema = z.object({
   feed: triggerMonitorFeedSchema,
   refreshSeconds: z.number().int().min(1).max(3600),
   includeScreenshots: z.boolean(),
   includeCommands: z.boolean(),
+  watchlist: triggerMonitorWatchlistInputSchema,
+});
+
+export const triggerMonitorConfigInputSchema = triggerMonitorConfigBaseSchema;
+export type TriggerMonitorConfigInput = z.input<
+  typeof triggerMonitorConfigInputSchema
+>;
+
+export const triggerMonitorConfigSchema = triggerMonitorConfigBaseSchema.extend({
   lastUpdatedAt: z.string(),
 });
 export type TriggerMonitorConfig = z.infer<typeof triggerMonitorConfigSchema>;
@@ -32,12 +65,7 @@ export const triggerMonitorCommandRequestSchema = z.discriminatedUnion('action',
   }),
   z.object({
     action: z.literal('configure'),
-    config: z.object({
-      feed: triggerMonitorFeedSchema,
-      refreshSeconds: z.number().int().min(1).max(3600),
-      includeScreenshots: z.boolean(),
-      includeCommands: z.boolean(),
-    }),
+    config: triggerMonitorConfigInputSchema,
   }),
 ]);
 export type TriggerMonitorCommandRequest = z.infer<typeof triggerMonitorCommandRequestSchema>;

--- a/tenvy-server/src/lib/components/workspace/tools/trigger-monitor-workspace.svelte
+++ b/tenvy-server/src/lib/components/workspace/tools/trigger-monitor-workspace.svelte
@@ -24,7 +24,10 @@
                 fetchTriggerMonitorStatus,
                 updateTriggerMonitorConfig
         } from '$lib/data/trigger-monitor';
-        import type { TriggerMonitorMetric } from '$lib/types/trigger-monitor';
+        import type {
+                TriggerMonitorMetric,
+                TriggerMonitorWatchlist
+        } from '$lib/types/trigger-monitor';
         import { appendWorkspaceLog, createWorkspaceLogEntry } from '$lib/workspace/utils';
         import type { WorkspaceLogEntry } from '$lib/workspace/types';
 
@@ -37,6 +40,7 @@
         let refreshSeconds = $state(5);
         let includeScreenshots = $state(false);
         let includeCommands = $state(true);
+        let watchlist = $state<TriggerMonitorWatchlist>([]);
         let metrics = $state<TriggerMonitorMetric[]>([]);
         let generatedAt = $state<string | null>(null);
         let log = $state<WorkspaceLogEntry[]>([]);
@@ -59,6 +63,7 @@
                         refreshSeconds = status.config.refreshSeconds;
                         includeScreenshots = status.config.includeScreenshots;
                         includeCommands = status.config.includeCommands;
+                        watchlist = status.config.watchlist;
                         metrics = status.metrics;
                         generatedAt = status.generatedAt;
                 } catch (err) {
@@ -85,12 +90,14 @@
                                 feed,
                                 refreshSeconds,
                                 includeScreenshots,
-                                includeCommands
+                                includeCommands,
+                                watchlist
                         });
                         feed = updated.config.feed;
                         refreshSeconds = updated.config.refreshSeconds;
                         includeScreenshots = updated.config.includeScreenshots;
                         includeCommands = updated.config.includeCommands;
+                        watchlist = updated.config.watchlist;
                         metrics = updated.metrics;
                         generatedAt = updated.generatedAt;
                         log = appendWorkspaceLog(

--- a/tenvy-server/src/lib/data/trigger-monitor.ts
+++ b/tenvy-server/src/lib/data/trigger-monitor.ts
@@ -2,18 +2,15 @@ import {
   triggerMonitorStatusSchema,
   triggerMonitorCommandRequestSchema,
 } from '$lib/types/trigger-monitor';
+import type { TriggerMonitorConfigInput } from '$lib/types/trigger-monitor';
 
 interface FetchTriggerMonitorOptions {
   signal?: AbortSignal;
 }
 
-interface UpdateTriggerMonitorInput {
-  feed: 'live' | 'batch';
-  refreshSeconds: number;
-  includeScreenshots: boolean;
-  includeCommands: boolean;
+type UpdateTriggerMonitorInput = TriggerMonitorConfigInput & {
   signal?: AbortSignal;
-}
+};
 
 async function parseError(response: Response) {
   let message = response.statusText || 'Request failed';
@@ -37,20 +34,19 @@ export async function fetchTriggerMonitorStatus(agentId: string, options: FetchT
   return triggerMonitorStatusSchema.parse(data);
 }
 
-export async function updateTriggerMonitorConfig(agentId: string, input: UpdateTriggerMonitorInput) {
+export async function updateTriggerMonitorConfig(
+  agentId: string,
+  input: UpdateTriggerMonitorInput,
+) {
+  const { signal, ...config } = input;
   const body = triggerMonitorCommandRequestSchema.parse({
     action: 'configure',
-    config: {
-      feed: input.feed,
-      refreshSeconds: input.refreshSeconds,
-      includeScreenshots: input.includeScreenshots,
-      includeCommands: input.includeCommands,
-    },
+    config,
   });
 
   const response = await fetch(`/api/agents/${agentId}/misc/trigger-monitor`, {
     method: 'POST',
-    signal: input.signal,
+    signal,
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });

--- a/tenvy-server/src/lib/types/trigger-monitor.ts
+++ b/tenvy-server/src/lib/types/trigger-monitor.ts
@@ -1,18 +1,26 @@
 export {
   triggerMonitorFeedSchema,
   triggerMonitorConfigSchema,
+  triggerMonitorConfigInputSchema,
   triggerMonitorMetricSchema,
   triggerMonitorStatusSchema,
   triggerMonitorCommandRequestSchema,
   triggerMonitorCommandResponseSchema,
+  triggerMonitorWatchlistEntrySchema,
+  triggerMonitorWatchlistSchema,
+  triggerMonitorWatchlistInputSchema,
 } from '../../../../shared/types/trigger-monitor';
 
 export type {
   TriggerMonitorFeed,
   TriggerMonitorConfig,
+  TriggerMonitorConfigInput,
   TriggerMonitorMetric,
   TriggerMonitorStatus,
   TriggerMonitorCommandRequest,
   TriggerMonitorCommandResponse,
+  TriggerMonitorWatchlistEntry,
+  TriggerMonitorWatchlist,
+  TriggerMonitorWatchlistInput,
 } from '../../../../shared/types/trigger-monitor';
 


### PR DESCRIPTION
## Summary
- add shared trigger monitor watchlist schemas and config input helpers
- propagate the watchlist through controller data flow so status and configure share one contract
- update the Go trigger monitor manager to persist and sanitize watchlist entries

## Testing
- bun check *(fails: Files prefixed with + are reserved (saw src/routes/(app)/activity/+page.svelte.test.ts))*

------
https://chatgpt.com/codex/tasks/task_e_68feb6a5f0e8832ba7d668fde15d3e23