### PR TITLE
Add embedded modules workspace for client tools

### DIFF
--- a/tenvy-server/src/lib/components/client-context-menu.svelte
+++ b/tenvy-server/src/lib/components/client-context-menu.svelte
@@ -12,13 +12,14 @@
 	import { browser } from '$app/environment';
 	import type { Client } from '$lib/data/clients';
 	import ClientToolDialog from '$lib/components/client-tool-dialog.svelte';
-	import {
-		buildClientToolUrl,
-		getClientTool,
-		isDialogTool,
-		type ClientToolId,
-		type DialogToolId
-	} from '$lib/data/client-tools';
+        import {
+                buildClientToolUrl,
+                getClientTool,
+                isDialogTool,
+                type ClientToolId,
+                type DialogToolId
+        } from '$lib/data/client-tools';
+        import { isWorkspaceTool } from '$lib/data/client-tool-workspaces';
 	import { createEventDispatcher } from 'svelte';
 	import { notifyToolActivationCommand } from '$lib/utils/agent-commands.js';
 	import type {
@@ -164,17 +165,26 @@
 			return;
 		}
 
-		if (browser) {
-			notifyToolActivationCommand(client.id, toolId, {
-				action: 'open',
-				metadata: { surface: 'context-menu' }
-			});
-		}
+                if (browser) {
+                        notifyToolActivationCommand(client.id, toolId, {
+                                action: 'open',
+                                metadata: { surface: 'context-menu' }
+                        });
+                }
 
-		if (target === 'dialog') {
-			dialogTool = isDialogTool(toolId) ? toolId : (toolId as DialogToolId);
-			return;
-		}
+                if (isWorkspaceTool(toolId)) {
+                        dialogTool = null;
+                        const url = buildClientToolUrl(client.id, tool);
+                        if (browser) {
+                                goto(url as any);
+                        }
+                        return;
+                }
+
+                if (target === 'dialog') {
+                        dialogTool = isDialogTool(toolId) ? toolId : (toolId as DialogToolId);
+                        return;
+                }
 
 		dialogTool = null;
 

--- a/tenvy-server/src/lib/components/workspace/client-tool-workspace.svelte
+++ b/tenvy-server/src/lib/components/workspace/client-tool-workspace.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+        import { browser } from '$app/environment';
+        import { onMount } from 'svelte';
+        import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert/index.js';
+        import type { Client } from '$lib/data/clients';
+        import type { ClientToolDefinition } from '$lib/data/client-tools';
+        import type { DialogToolId } from '$lib/data/client-tools';
+        import {
+                getKeyloggerMode,
+                getWorkspaceComponent,
+                isWorkspaceTool,
+                workspaceRequiresAgent
+        } from '$lib/data/client-tool-workspaces';
+        import KeyloggerWorkspace from '$lib/components/workspace/tools/keylogger-workspace.svelte';
+        import { notifyToolActivationCommand } from '$lib/utils/agent-commands.js';
+        import type { AgentSnapshot } from '../../../../../shared/types/agent';
+        import { AlertCircle } from '@lucide/svelte';
+
+        const { client, tool, agent = null } = $props<{
+                client: Client;
+                tool: ClientToolDefinition;
+                agent?: AgentSnapshot | null;
+        }>();
+
+        const isWorkspace = $derived(isWorkspaceTool(tool.id));
+        const dialogToolId = $derived(() => (isWorkspace ? (tool.id as DialogToolId) : null));
+        const keyloggerMode = $derived(() =>
+                dialogToolId ? getKeyloggerMode(dialogToolId) : null
+        );
+        const workspaceComponent = $derived(() =>
+                dialogToolId ? getWorkspaceComponent(dialogToolId) : null
+        );
+        const requiresAgent = $derived(() =>
+                dialogToolId ? workspaceRequiresAgent.has(dialogToolId) : false
+        );
+        const missingAgent = $derived(requiresAgent && !agent);
+
+        const workspaceProps = $derived(() => {
+                if (!dialogToolId || !workspaceComponent) {
+                        return null;
+                }
+                const base: Record<string, unknown> = { client };
+                if (dialogToolId === 'cmd') {
+                        base.agent = agent;
+                }
+                if (dialogToolId === 'remote-desktop') {
+                        base.initialSession = null;
+                }
+                return base;
+        });
+
+        onMount(() => {
+                if (!browser || !dialogToolId) {
+                        return;
+                }
+
+                notifyToolActivationCommand(client.id, dialogToolId, {
+                        action: 'open',
+                        metadata: { surface: 'workspace' }
+                });
+
+                return () => {
+                        notifyToolActivationCommand(client.id, dialogToolId, {
+                                action: 'close',
+                                metadata: { surface: 'workspace' }
+                        });
+                };
+        });
+</script>
+
+{#if !isWorkspace}
+        <Alert>
+                <AlertCircle class="h-4 w-4" />
+                <AlertTitle>Workspace unavailable</AlertTitle>
+                <AlertDescription>
+                        This module doesn&rsquo;t expose an embedded workspace yet. Define the workflow before linking it to the agent.
+                </AlertDescription>
+        </Alert>
+{:else if missingAgent}
+        <Alert variant="destructive">
+                <AlertCircle class="h-4 w-4" />
+                <AlertTitle>Agent session required</AlertTitle>
+                <AlertDescription>
+                        Reconnect this client before launching the {tool.title} workspace.
+                </AlertDescription>
+        </Alert>
+{:else if keyloggerMode}
+        <KeyloggerWorkspace {client} mode={keyloggerMode} />
+{:else if workspaceComponent && workspaceProps}
+        <svelte:component this={workspaceComponent} {...workspaceProps} />
+{:else}
+        <Alert>
+                <AlertCircle class="h-4 w-4" />
+                <AlertTitle>Workspace not implemented</AlertTitle>
+                <AlertDescription>
+                        The embedded workspace for {tool.title} hasn&rsquo;t been added yet.
+                </AlertDescription>
+        </Alert>
+{/if}

--- a/tenvy-server/src/lib/data/client-tool-workspaces.ts
+++ b/tenvy-server/src/lib/data/client-tool-workspaces.ts
@@ -1,0 +1,76 @@
+import type { Component } from 'svelte';
+import type { ClientToolId, DialogToolId } from './client-tools';
+import AppVncWorkspace from '$lib/components/workspace/tools/app-vnc-workspace.svelte';
+import RemoteDesktopWorkspace from '$lib/components/workspace/tools/remote-desktop-workspace.svelte';
+import WebcamControlWorkspace from '$lib/components/workspace/tools/webcam-control-workspace.svelte';
+import AudioControlWorkspace from '$lib/components/workspace/tools/audio-control-workspace.svelte';
+import CmdWorkspace from '$lib/components/workspace/tools/cmd-workspace.svelte';
+import FileManagerWorkspace from '$lib/components/workspace/tools/file-manager-workspace.svelte';
+import SystemMonitorWorkspace from '$lib/components/workspace/tools/system-monitor-workspace.svelte';
+import RegistryManagerWorkspace from '$lib/components/workspace/tools/registry-manager-workspace.svelte';
+import ClipboardManagerWorkspace from '$lib/components/workspace/tools/clipboard-manager-workspace.svelte';
+import RecoveryWorkspace from '$lib/components/workspace/tools/recovery-workspace.svelte';
+import OptionsWorkspace from '$lib/components/workspace/tools/options-workspace.svelte';
+import ClientChatWorkspace from '$lib/components/workspace/tools/client-chat-workspace.svelte';
+import TriggerMonitorWorkspace from '$lib/components/workspace/tools/trigger-monitor-workspace.svelte';
+import IpGeolocationWorkspace from '$lib/components/workspace/tools/ip-geolocation-workspace.svelte';
+import EnvironmentVariablesWorkspace from '$lib/components/workspace/tools/environment-variables-workspace.svelte';
+
+export const workspaceComponentMap = {
+        'app-vnc': AppVncWorkspace,
+        'remote-desktop': RemoteDesktopWorkspace,
+        'webcam-control': WebcamControlWorkspace,
+        'audio-control': AudioControlWorkspace,
+        cmd: CmdWorkspace,
+        'file-manager': FileManagerWorkspace,
+        'system-monitor': SystemMonitorWorkspace,
+        'registry-manager': RegistryManagerWorkspace,
+        'clipboard-manager': ClipboardManagerWorkspace,
+        recovery: RecoveryWorkspace,
+        options: OptionsWorkspace,
+        'client-chat': ClientChatWorkspace,
+        'trigger-monitor': TriggerMonitorWorkspace,
+        'ip-geolocation': IpGeolocationWorkspace,
+        'environment-variables': EnvironmentVariablesWorkspace
+} satisfies Partial<Record<DialogToolId, Component<any>>>;
+
+const keyloggerModesMap = {
+        'keylogger-standard': 'standard',
+        'keylogger-offline': 'offline'
+} as const satisfies Partial<Record<DialogToolId, 'standard' | 'offline'>>;
+
+export const workspaceToolIds = [
+        'app-vnc',
+        'remote-desktop',
+        'webcam-control',
+        'audio-control',
+        'keylogger-standard',
+        'keylogger-offline',
+        'cmd',
+        'file-manager',
+        'system-monitor',
+        'registry-manager',
+        'clipboard-manager',
+        'recovery',
+        'options',
+        'client-chat',
+        'trigger-monitor',
+        'ip-geolocation',
+        'environment-variables'
+] as const satisfies readonly DialogToolId[];
+
+export const workspaceRequiresAgent = new Set<DialogToolId>(['cmd']);
+
+const workspaceToolSet = new Set<DialogToolId>(workspaceToolIds);
+
+export function isWorkspaceTool(id: ClientToolId): id is DialogToolId {
+        return workspaceToolSet.has(id as DialogToolId);
+}
+
+export function getWorkspaceComponent(id: DialogToolId) {
+        return workspaceComponentMap[id] ?? null;
+}
+
+export function getKeyloggerMode(id: DialogToolId) {
+        return keyloggerModesMap[id] ?? null;
+}

--- a/tenvy-server/src/routes/(app)/clients/+page.svelte
+++ b/tenvy-server/src/routes/(app)/clients/+page.svelte
@@ -33,13 +33,14 @@
 	import DeployAgentDialog from './components/deploy-agent-dialog.svelte';
 	import { sectionToolMap, type SectionKey } from '$lib/client-sections';
 	import { createClientsTableStore } from '$lib/stores/clients-table';
-	import {
-		buildClientToolUrl,
-		getClientTool,
-		isDialogTool,
-		type ClientToolId,
-		type DialogToolId
-	} from '$lib/data/client-tools';
+        import {
+                buildClientToolUrl,
+                getClientTool,
+                isDialogTool,
+                type ClientToolId,
+                type DialogToolId
+        } from '$lib/data/client-tools';
+        import { isWorkspaceTool } from '$lib/data/client-tool-workspaces';
 	import { buildLocationDisplay } from '$lib/utils/location';
 	import { isLikelyPrivateIp } from '$lib/utils/ip';
 	import { formatAgentLatency } from '$lib/utils/agent-latency';
@@ -719,17 +720,26 @@
 			return;
 		}
 
-		const tool = getClientTool(toolId);
-		const target = tool.target ?? '_blank';
+                const tool = getClientTool(toolId);
+                const target = tool.target ?? '_blank';
 
-		toolDialog = null;
+                toolDialog = null;
 
-		if (target === 'dialog' && isDialogTool(toolId)) {
-			toolDialog = { agentId: agent.id, toolId };
-			return;
-		}
+                if (isWorkspaceTool(toolId)) {
+                        if (!browser) {
+                                return;
+                        }
+                        const url = buildClientToolUrl(agent.id, tool);
+                        goto(url as any);
+                        return;
+                }
 
-		const url = buildClientToolUrl(agent.id, tool);
+                if (target === 'dialog' && isDialogTool(toolId)) {
+                        toolDialog = { agentId: agent.id, toolId };
+                        return;
+                }
+
+                const url = buildClientToolUrl(agent.id, tool);
 
 		if (!browser) {
 			return;

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/modules/+page.svelte
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/modules/+page.svelte
@@ -1,67 +1,27 @@
 <script lang="ts">
-	import {
-		Card,
-		CardContent,
-		CardDescription,
-		CardHeader,
-		CardTitle
-	} from '$lib/components/ui/card/index.js';
-	import { resolve } from '$app/paths';
-	import { buildClientToolUrl, type ClientToolDefinition } from '$lib/data/client-tools';
-	import type { PageData } from './$types';
+        import WorkspaceContainer from './workspace-container.svelte';
+        import { type ClientToolDefinition } from '$lib/data/client-tools';
+        import type { PageData } from './$types';
 
-	let { data } = $props<{ data: PageData }>();
-	const client = $derived(data.client);
-	const tools = $derived((data.tools ?? []) as ClientToolDefinition[]);
+        let { data } = $props<{ data: PageData }>();
+        const client = $derived(data.client);
+        const agent = $derived(data.agent);
+        const tools = $derived((data.tools ?? []) as ClientToolDefinition[]);
 </script>
 
-<div class="space-y-6">
-	<Card class="border-dashed">
-		<CardHeader>
-			<CardTitle>Select a module</CardTitle>
-			<CardDescription>
-				Choose an item from the client context menu to start configuring a capability.
-			</CardDescription>
-		</CardHeader>
-		<CardContent class="space-y-4 text-sm text-slate-600 dark:text-slate-400">
-			<p>
-				Each module opens in a dedicated workspace so you can prototype workflows without
-				interrupting the main client overview.
-			</p>
-			<p>
-				When features are ready, the Go agent will reuse these routes to negotiate data exchange and
-				streaming sessions.
-			</p>
-		</CardContent>
-	</Card>
-
-	<Card class="border-slate-200/80 dark:border-slate-800/80">
-		<CardHeader>
-			<CardTitle class="text-base">Available modules</CardTitle>
-			<CardDescription>
-				Launch a workspace in a new tab to begin outlining integrations for {client.codename}.
-			</CardDescription>
-		</CardHeader>
-		<CardContent>
-			<div class="grid gap-3 md:grid-cols-2">
-				{#each tools as item (item.id)}
-					<a
-						class="group flex flex-col rounded-lg border border-slate-200/70 bg-white/60 p-4 transition hover:border-sky-400 hover:shadow-sm dark:border-slate-800/70 dark:bg-slate-900/60 dark:hover:border-sky-500"
-						href={resolve(buildClientToolUrl(client.id, item))}
-						target={item.target === '_blank' ? '_blank' : undefined}
-						rel={item.target === '_blank' ? 'noopener noreferrer' : undefined}
-					>
-						<span
-							class="text-sm font-semibold text-slate-900 transition group-hover:text-sky-600 dark:text-slate-100 dark:group-hover:text-sky-400"
-						>
-							{item.title}
-						</span>
-						<span class="mt-1 line-clamp-2 text-xs text-slate-600 dark:text-slate-400">
-							{item.description}
-						</span>
-					</a>
-				{/each}
-			</div>
-		</CardContent>
-	</Card>
-</div>
+<WorkspaceContainer {client} {agent} {tools}>
+        <svelte:fragment slot="empty">
+                <div class="space-y-6">
+                        <div class="rounded-lg border border-dashed border-border/60 bg-background/50 p-6">
+                                <h2 class="text-lg font-semibold">Select a module</h2>
+                                <p class="mt-2 text-sm text-muted-foreground">
+                                        Launch a capability from the navigation panel to open its dedicated workspace inside the app.
+                                </p>
+                                <ul class="mt-4 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+                                        <li>Workspace state is isolated per tool, matching the previous floating dialog behavior.</li>
+                                        <li>Use the Close action to return to this overview or switch modules from the sidebar.</li>
+                                </ul>
+                        </div>
+                </div>
+        </svelte:fragment>
+</WorkspaceContainer>

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/modules/[...segments]/+page.svelte
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/modules/[...segments]/+page.svelte
@@ -1,107 +1,14 @@
 <script lang="ts">
-	import {
-		Card,
-		CardContent,
-		CardDescription,
-		CardHeader,
-		CardTitle
-	} from '$lib/components/ui/card/index.js';
-	import { browser } from '$app/environment';
-	import { onMount } from 'svelte';
-	import { type ClientToolId } from '$lib/data/client-tools';
-	import { notifyToolActivationCommand } from '$lib/utils/agent-commands.js';
-	import type { PageData } from './$types';
-	import AppVncWorkspace from '$lib/components/workspace/tools/app-vnc-workspace.svelte';
-	import WebcamControlWorkspace from '$lib/components/workspace/tools/webcam-control-workspace.svelte';
-	import AudioControlWorkspace from '$lib/components/workspace/tools/audio-control-workspace.svelte';
-	import KeyloggerWorkspace from '$lib/components/workspace/tools/keylogger-workspace.svelte';
-	import CmdWorkspace from '$lib/components/workspace/tools/cmd-workspace.svelte';
-	import FileManagerWorkspace from '$lib/components/workspace/tools/file-manager-workspace.svelte';
-	import SystemMonitorWorkspace from '$lib/components/workspace/tools/system-monitor-workspace.svelte';
-	import RegistryManagerWorkspace from '$lib/components/workspace/tools/registry-manager-workspace.svelte';
-	import ClipboardManagerWorkspace from '$lib/components/workspace/tools/clipboard-manager-workspace.svelte';
-	import RecoveryWorkspace from '$lib/components/workspace/tools/recovery-workspace.svelte';
-	import OptionsWorkspace from '$lib/components/workspace/tools/options-workspace.svelte';
-	import OpenUrlWorkspace from '$lib/components/workspace/tools/open-url-workspace.svelte';
-	import ClientChatWorkspace from '$lib/components/workspace/tools/client-chat-workspace.svelte';
-	import TriggerMonitorWorkspace from '$lib/components/workspace/tools/trigger-monitor-workspace.svelte';
-	import IpGeolocationWorkspace from '$lib/components/workspace/tools/ip-geolocation-workspace.svelte';
-	import EnvironmentVariablesWorkspace from '$lib/components/workspace/tools/environment-variables-workspace.svelte';
+        import WorkspaceContainer from '../workspace-container.svelte';
+        import type { ClientToolDefinition } from '$lib/data/client-tools';
+        import type { PageData } from './$types';
 
 	let { data } = $props<{ data: PageData }>();
-	const client = $derived(data.client);
-	const agent = $derived(data.agent);
-	const tool = $derived(data.tool);
-	const segments = $derived(data.segments);
-
-	const componentMap = {
-		'app-vnc': AppVncWorkspace,
-		'webcam-control': WebcamControlWorkspace,
-		'audio-control': AudioControlWorkspace,
-		'file-manager': FileManagerWorkspace,
-		'system-monitor': SystemMonitorWorkspace,
-		'registry-manager': RegistryManagerWorkspace,
-		'clipboard-manager': ClipboardManagerWorkspace,
-		recovery: RecoveryWorkspace,
-		options: OptionsWorkspace,
-		'open-url': OpenUrlWorkspace,
-		'client-chat': ClientChatWorkspace,
-		'trigger-monitor': TriggerMonitorWorkspace,
-		'ip-geolocation': IpGeolocationWorkspace,
-		'environment-variables': EnvironmentVariablesWorkspace
-	} as const;
-
-	const keyloggerModes = {
-		'keylogger-standard': 'standard',
-		'keylogger-offline': 'offline'
-	} as const;
-
-	const activeComponent = $derived(componentMap[tool.id as keyof typeof componentMap]);
-	const keyloggerMode = $derived(keyloggerModes[tool.id as keyof typeof keyloggerModes]);
-
-	onMount(() => {
-		if (!browser) {
-			return;
-		}
-
-		notifyToolActivationCommand(client.id, tool.id as ClientToolId, {
-			action: 'open',
-			metadata: { surface: 'workspace' }
-		});
-
-		return () => {
-			notifyToolActivationCommand(client.id, tool.id as ClientToolId, {
-				action: 'close',
-				metadata: { surface: 'workspace' }
-			});
-		};
-	});
+        const client = $derived(data.client);
+        const agent = $derived(data.agent);
+        const tool = $derived(data.tool);
+        const segments = $derived(data.segments);
+        const tools = $derived((data.tools ?? []) as ClientToolDefinition[]);
 </script>
 
-<div class="space-y-6">
-	{#if keyloggerMode}
-		<KeyloggerWorkspace {client} mode={keyloggerMode} />
-	{:else if tool.id === 'cmd'}
-		<CmdWorkspace {client} {agent} />
-	{:else if activeComponent}
-		{@const Workspace = activeComponent}
-		<Workspace {client} />
-	{:else}
-		<Card>
-			<CardHeader>
-				<CardTitle>{tool.title}</CardTitle>
-				<CardDescription>{tool.description}</CardDescription>
-			</CardHeader>
-			<CardContent class="space-y-4 text-sm text-slate-600 dark:text-slate-400">
-				<p>
-					modules / {segments.join(' / ')} is currently using the default planning workspace. Define
-					the implementation contract here before wiring it to the Go agent.
-				</p>
-				<p>
-					Add a dedicated workspace component for <span class="font-medium">{tool.title}</span> to elevate
-					the operator experience when you are ready.
-				</p>
-			</CardContent>
-		</Card>
-	{/if}
-</div>
+<WorkspaceContainer {client} {agent} {tools} activeTool={tool} {segments} />

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/modules/workspace-container.svelte
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/modules/workspace-container.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+        import { goto } from '$app/navigation';
+        import { resolve } from '$app/paths';
+        import { Button } from '$lib/components/ui/button/index.js';
+        import {
+                Card,
+                CardContent,
+                CardDescription,
+                CardHeader,
+                CardTitle
+        } from '$lib/components/ui/card/index.js';
+        import { Separator } from '$lib/components/ui/separator/index.js';
+        import { cn } from '$lib/utils.js';
+        import type { Client } from '$lib/data/clients';
+        import { buildClientToolUrl, type ClientToolDefinition } from '$lib/data/client-tools';
+        import ClientToolWorkspace from '$lib/components/workspace/client-tool-workspace.svelte';
+        import { isWorkspaceTool } from '$lib/data/client-tool-workspaces';
+        import type { AgentSnapshot } from '../../../../../../shared/types/agent';
+        import { ArrowLeft, X } from '@lucide/svelte';
+
+        const { client, agent = null, tools, activeTool = null, segments = [] } = $props<{
+                client: Client;
+                agent?: AgentSnapshot | null;
+                tools: ClientToolDefinition[];
+                activeTool?: ClientToolDefinition | null;
+                segments?: string[];
+        }>();
+
+        const baseModulesUrl = `/clients/${client.id}/modules`;
+
+        const categoryLabels: Record<string, string> = {
+                overview: 'Overview',
+                control: 'Control',
+                management: 'Management',
+                operations: 'Operations',
+                misc: 'Miscellaneous',
+                'system-controls': 'System Controls',
+                power: 'Power'
+        };
+
+        type Group = { key: string; label: string; items: ClientToolDefinition[] };
+
+        const groupedTools = $derived(() => {
+                const order: Group[] = [];
+                const index = new Map<string, Group>();
+
+                for (const tool of tools) {
+                        const key = tool.segments[0] ?? 'misc';
+                        let group = index.get(key);
+                        if (!group) {
+                                group = {
+                                        key,
+                                        label: categoryLabels[key] ?? key.replace(/-/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase()),
+                                        items: []
+                                } satisfies Group;
+                                index.set(key, group);
+                                order.push(group);
+                        }
+                        group.items.push(tool);
+                }
+
+                return order.map((group) => ({
+                        ...group,
+                        items: group.items.slice()
+                }));
+        });
+
+        const activeToolId = $derived(activeTool?.id ?? null);
+
+        function toWorkspaceUrl(tool: ClientToolDefinition) {
+                        return resolve(buildClientToolUrl(client.id, tool));
+        }
+
+        function closeWorkspace() {
+                goto(baseModulesUrl);
+        }
+
+        function returnToClients() {
+                goto('/clients');
+        }
+</script>
+
+<section class="space-y-6">
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                        <h1 class="text-2xl font-semibold tracking-tight">{client.codename}</h1>
+                        <p class="text-sm text-muted-foreground">
+                                Manage {client.codename}&rsquo;s capabilities without leaving the client workspace.
+                        </p>
+                </div>
+                <div class="flex flex-wrap items-center gap-2">
+                        <Button variant="outline" onclick={returnToClients} class="gap-2">
+                                <ArrowLeft class="h-4 w-4" />
+                                <span>Client overview</span>
+                        </Button>
+                        {#if activeTool}
+                                <Button variant="secondary" onclick={closeWorkspace} class="gap-2">
+                                        <X class="h-4 w-4" />
+                                        <span>Close workspace</span>
+                                </Button>
+                        {/if}
+                </div>
+        </div>
+
+        <div class="grid gap-6 lg:grid-cols-[260px_minmax(0,1fr)]">
+                <aside class="space-y-6 rounded-lg border border-border/60 bg-background/40 p-4">
+                        {#each groupedTools as group (group.key)}
+                                <div class="space-y-2">
+                                        <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                                {group.label}
+                                        </p>
+                                        <div class="flex flex-col gap-1">
+                                                {#each group.items as item (item.id)}
+                                                        {@const isActive = activeToolId === item.id}
+                                                        <a
+                                                                class={cn(
+                                                                        'flex items-center justify-between rounded-md border border-transparent px-3 py-2 text-sm transition hover:border-primary/40 hover:bg-primary/5',
+                                                                        isActive
+                                                                                ? 'border-primary/60 bg-primary/10 text-primary'
+                                                                                : 'text-muted-foreground'
+                                                                )}
+                                                                href={toWorkspaceUrl(item)}
+                                                        >
+                                                                <span class="truncate">{item.title}</span>
+                                                                {#if isWorkspaceTool(item.id)}
+                                                                        <span class={cn('text-[0.65rem] font-medium uppercase tracking-wide', isActive ? 'text-primary' : 'text-muted-foreground/70')}>
+                                                                                Workspace
+                                                                        </span>
+                                                                {/if}
+                                                        </a>
+                                                {/each}
+                                        </div>
+                                </div>
+                                {#if group !== groupedTools.at(-1)}
+                                        <Separator />
+                                {/if}
+                        {/each}
+                </aside>
+
+                <div class="space-y-4">
+                        {#if activeTool}
+                                <Card class="border-border/60 bg-background/60 shadow-sm">
+                                        <CardHeader class="space-y-1">
+                                                <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                                                        <div class="space-y-1">
+                                                                <CardTitle>{activeTool.title}</CardTitle>
+                                                                {#if segments.length > 0}
+                                                                        <CardDescription>{segments.join(' / ')}</CardDescription>
+                                                                {/if}
+                                                        </div>
+                                                        <div class="flex items-center gap-2">
+                                                                <Button variant="outline" size="sm" onclick={closeWorkspace} class="gap-2">
+                                                                        <X class="h-4 w-4" />
+                                                                        <span>Close</span>
+                                                                </Button>
+                                                        </div>
+                                                </div>
+                                        </CardHeader>
+                                        <CardContent class="space-y-4">
+                                                {#key `${client.id}-${activeTool.id}`}
+                                                        <ClientToolWorkspace {client} {agent} tool={activeTool} />
+                                                {/key}
+                                        </CardContent>
+                                </Card>
+                        {:else}
+                                <slot name="empty">
+                                        <Card class="border-dashed">
+                                                <CardHeader>
+                                                        <CardTitle>Select a module</CardTitle>
+                                                        <CardDescription>
+                                                                Choose a capability to launch its dedicated workspace for {client.codename}.
+                                                        </CardDescription>
+                                                </CardHeader>
+                                                <CardContent class="space-y-3 text-sm text-muted-foreground">
+                                                        <p>
+                                                                Workspaces preserve each tool&rsquo;s state while you evaluate remote workflows.
+                                                        </p>
+                                                        <p>
+                                                                Use the navigation panel to switch between modules or close the workspace when you&rsquo;re done.
+                                                        </p>
+                                                </CardContent>
+                                        </Card>
+                                </slot>
+                        {/if}
+                </div>
+        </div>
+</section>


### PR DESCRIPTION
## Summary
- introduce a shared workspace registry and inline component so client tool surfaces can render without opening new windows
- replace the client modules pages with a workspace container that embeds tool UIs alongside navigation and close/back controls
- update context menu and client routing logic to navigate into the embedded workspace while keeping dialog flows for non-workspace tools

## Testing
- bun check *(fails: existing route test file name uses the reserved + prefix)*

------
https://chatgpt.com/codex/tasks/task_e_68ff9de5ccd8832b8039498c69801249