### PR TITLE
Implement cross-platform fallbacks for options operations

### DIFF
--- a/tenvy-client/internal/operations/options/platform_service_darwin.go
+++ b/tenvy-client/internal/operations/options/platform_service_darwin.go
@@ -45,6 +45,27 @@ func (s *darwinPlatformService) Execute(ctx context.Context, operation string, m
 			volume = 100
 		}
 		return s.setVolume(ctx, volume)
+	case "visual-distortion":
+		mode, _ := metadata["mode"].(string)
+		trimmed := strings.TrimSpace(mode)
+		if trimmed == "" {
+			trimmed = "unspecified"
+		}
+		return fmt.Sprintf("Visual distortion %s unsupported on macOS", trimmed), nil
+	case "cursor-behavior":
+		behavior, _ := metadata["behavior"].(string)
+		trimmed := strings.TrimSpace(behavior)
+		if trimmed == "" {
+			trimmed = "unspecified"
+		}
+		return fmt.Sprintf("Cursor behavior %s unsupported on macOS", trimmed), nil
+	case "fake-event-mode":
+		mode, _ := metadata["mode"].(string)
+		trimmed := strings.TrimSpace(mode)
+		if trimmed == "" || strings.EqualFold(trimmed, "none") {
+			return "Fake event mode cleared (no native integration on macOS)", nil
+		}
+		return fmt.Sprintf("Fake event mode %s unsupported on macOS", trimmed), nil
 	default:
 		return "", nil
 	}

--- a/tenvy-client/internal/operations/options/platform_service_darwin_test.go
+++ b/tenvy-client/internal/operations/options/platform_service_darwin_test.go
@@ -1,0 +1,47 @@
+//go:build darwin
+
+package options
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestDarwinUnsupportedDisplayOptions(t *testing.T) {
+	service := newPlatformService()
+	summary, err := service.Execute(context.Background(), "visual-distortion", map[string]any{"mode": "Wiggle"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(summary, "unsupported") {
+		t.Fatalf("expected unsupported summary, got %q", summary)
+	}
+
+	summary, err = service.Execute(context.Background(), "cursor-behavior", map[string]any{"behavior": "Ghost"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(summary, "unsupported") {
+		t.Fatalf("expected unsupported summary, got %q", summary)
+	}
+}
+
+func TestDarwinFakeEventFallback(t *testing.T) {
+	service := newPlatformService()
+	summary, err := service.Execute(context.Background(), "fake-event-mode", map[string]any{"mode": "None"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(summary), "cleared") {
+		t.Fatalf("expected cleared summary, got %q", summary)
+	}
+
+	summary, err = service.Execute(context.Background(), "fake-event-mode", map[string]any{"mode": "FakeUpdate"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(summary, "unsupported") {
+		t.Fatalf("expected unsupported summary, got %q", summary)
+	}
+}

--- a/tenvy-client/internal/operations/options/platform_service_linux.go
+++ b/tenvy-client/internal/operations/options/platform_service_linux.go
@@ -33,6 +33,27 @@ func (s *linuxPlatformService) Execute(ctx context.Context, operation string, me
 	case "wallpaper-mode":
 		mode, _ := metadata["mode"].(string)
 		return s.configureWallpaper(ctx, strings.TrimSpace(mode))
+	case "visual-distortion":
+		mode, _ := metadata["mode"].(string)
+		trimmed := strings.TrimSpace(mode)
+		if trimmed == "" {
+			trimmed = "unspecified"
+		}
+		return fmt.Sprintf("Visual distortion %s unsupported on Linux", trimmed), nil
+	case "cursor-behavior":
+		behavior, _ := metadata["behavior"].(string)
+		trimmed := strings.TrimSpace(behavior)
+		if trimmed == "" {
+			trimmed = "unspecified"
+		}
+		return fmt.Sprintf("Cursor behavior %s unsupported on Linux", trimmed), nil
+	case "fake-event-mode":
+		mode, _ := metadata["mode"].(string)
+		trimmed := strings.TrimSpace(mode)
+		if trimmed == "" || strings.EqualFold(trimmed, "none") {
+			return "Fake event mode cleared (no native integration on Linux)", nil
+		}
+		return fmt.Sprintf("Fake event mode %s unsupported on Linux", trimmed), nil
 	case "sound-playback":
 		enabled := state.SoundPlayback
 		if v, ok := metadata["enabled"].(bool); ok {

--- a/tenvy-client/internal/operations/options/platform_service_linux_test.go
+++ b/tenvy-client/internal/operations/options/platform_service_linux_test.go
@@ -1,0 +1,50 @@
+//go:build linux
+
+package options
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestLinuxPlatformUnsupportedVisualDistortion(t *testing.T) {
+	service := newPlatformService()
+	summary, err := service.Execute(context.Background(), "visual-distortion", map[string]any{"mode": "Pixelate"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(summary, "unsupported") {
+		t.Fatalf("expected unsupported summary, got %q", summary)
+	}
+}
+
+func TestLinuxPlatformUnsupportedCursorBehavior(t *testing.T) {
+	service := newPlatformService()
+	summary, err := service.Execute(context.Background(), "cursor-behavior", map[string]any{"behavior": "Ghost"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(summary, "unsupported") {
+		t.Fatalf("expected unsupported summary, got %q", summary)
+	}
+}
+
+func TestLinuxPlatformFakeEventReset(t *testing.T) {
+	service := newPlatformService()
+	summary, err := service.Execute(context.Background(), "fake-event-mode", map[string]any{"mode": "None"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(summary), "cleared") {
+		t.Fatalf("expected cleared summary, got %q", summary)
+	}
+
+	summary, err = service.Execute(context.Background(), "fake-event-mode", map[string]any{"mode": "NotificationStorm"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(summary, "unsupported") {
+		t.Fatalf("expected unsupported summary, got %q", summary)
+	}
+}

--- a/tenvy-client/internal/operations/options/platform_service_windows_test.go
+++ b/tenvy-client/internal/operations/options/platform_service_windows_test.go
@@ -1,0 +1,116 @@
+//go:build windows
+
+package options
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestWindowsVisualDistortionInvertColors(t *testing.T) {
+	service := &windowsPlatformService{}
+	original := configureColorFilterFunc
+	called := false
+	configureColorFilterFunc = func(ctx context.Context, active bool, filterType int) error {
+		called = true
+		if !active || filterType != 1 {
+			t.Fatalf("unexpected arguments active=%v filterType=%d", active, filterType)
+		}
+		return nil
+	}
+	t.Cleanup(func() { configureColorFilterFunc = original })
+
+	summary, err := service.Execute(context.Background(), "visual-distortion", map[string]any{"mode": "InvertColors"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if summary != "Enabled Windows color inversion filter" {
+		t.Fatalf("unexpected summary: %q", summary)
+	}
+	if !called {
+		t.Fatalf("expected ConfigureColorFilter to be invoked")
+	}
+}
+
+func TestWindowsVisualDistortionUnsupported(t *testing.T) {
+	service := &windowsPlatformService{}
+	original := configureColorFilterFunc
+	configureColorFilterFunc = func(ctx context.Context, active bool, filterType int) error {
+		t.Fatalf("ConfigureColorFilter should not be called for unsupported mode")
+		return nil
+	}
+	t.Cleanup(func() { configureColorFilterFunc = original })
+
+	summary, err := service.Execute(context.Background(), "visual-distortion", map[string]any{"mode": "Pixelate"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(summary, "unsupported") {
+		t.Fatalf("expected unsupported summary, got %q", summary)
+	}
+}
+
+func TestWindowsCursorBehaviors(t *testing.T) {
+	service := &windowsPlatformService{}
+	original := configureCursorStateFunc
+	var lastArgs struct {
+		swap   bool
+		trails int
+	}
+	configureCursorStateFunc = func(ctx context.Context, swap bool, trails int) error {
+		lastArgs.swap = swap
+		lastArgs.trails = trails
+		return nil
+	}
+	t.Cleanup(func() { configureCursorStateFunc = original })
+
+	summary, err := service.Execute(context.Background(), "cursor-behavior", map[string]any{"behavior": "Reverse"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(summary, "Swapped") {
+		t.Fatalf("unexpected summary: %q", summary)
+	}
+	if !lastArgs.swap || lastArgs.trails != 0 {
+		t.Fatalf("unexpected cursor configuration: %+v", lastArgs)
+	}
+
+	summary, err = service.Execute(context.Background(), "cursor-behavior", map[string]any{"behavior": "Ghost"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(summary, "cursor trails") {
+		t.Fatalf("unexpected summary: %q", summary)
+	}
+	if lastArgs.swap || lastArgs.trails != 7 {
+		t.Fatalf("unexpected cursor configuration: %+v", lastArgs)
+	}
+
+	summary, err = service.Execute(context.Background(), "cursor-behavior", map[string]any{"behavior": "Unknown"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(summary, "unsupported") {
+		t.Fatalf("expected unsupported summary, got %q", summary)
+	}
+}
+
+func TestWindowsFakeEventFallback(t *testing.T) {
+	service := &windowsPlatformService{}
+	summary, err := service.Execute(context.Background(), "fake-event-mode", map[string]any{"mode": "None"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(summary), "cleared") {
+		t.Fatalf("expected cleared summary, got %q", summary)
+	}
+
+	summary, err = service.Execute(context.Background(), "fake-event-mode", map[string]any{"mode": "FakeUpdate"}, State{})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !strings.Contains(summary, "unsupported") {
+		t.Fatalf("expected unsupported summary, got %q", summary)
+	}
+}

--- a/tenvy-client/internal/platform/windows/options/display_windows.go
+++ b/tenvy-client/internal/platform/windows/options/display_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package options
+
+import (
+	"context"
+	"fmt"
+)
+
+// ConfigureColorFilter updates the Windows color filtering settings.
+func ConfigureColorFilter(ctx context.Context, active bool, filterType int) error {
+	value := 0
+	if active {
+		value = 1
+	}
+	if filterType < 0 {
+		filterType = 0
+	}
+	script := fmt.Sprintf(`
+$ErrorActionPreference = 'Stop'
+$base = 'HKCU:\Software\Microsoft\ColorFiltering'
+if (-not (Test-Path $base)) {
+    New-Item -Path $base -Force | Out-Null
+}
+New-ItemProperty -Path $base -Name 'Active' -PropertyType DWord -Value %d -Force | Out-Null
+New-ItemProperty -Path $base -Name 'ColorFilterHotkeyEnabled' -PropertyType DWord -Value 0 -Force | Out-Null
+New-ItemProperty -Path $base -Name 'FilterType' -PropertyType DWord -Value %d -Force | Out-Null
+`, value, filterType)
+	return runPowerShell(ctx, script)
+}
+
+// ConfigureCursorState toggles mouse button layout and pointer trails.
+func ConfigureCursorState(ctx context.Context, swapButtons bool, trails int) error {
+	if trails < 0 {
+		trails = 0
+	}
+	if trails > 10 {
+		trails = 10
+	}
+	swapValue := "0"
+	if swapButtons {
+		swapValue = "1"
+	}
+	script := fmt.Sprintf(`
+$ErrorActionPreference = 'Stop'
+$mousePath = 'HKCU:\Control Panel\Mouse'
+if (-not (Test-Path $mousePath)) {
+    New-Item -Path $mousePath -Force | Out-Null
+}
+New-ItemProperty -Path $mousePath -Name 'SwapMouseButtons' -PropertyType String -Value '%s' -Force | Out-Null
+New-ItemProperty -Path $mousePath -Name 'MouseTrails' -PropertyType String -Value '%d' -Force | Out-Null
+& $env:SystemRoot\System32\rundll32.exe user32.dll,UpdatePerUserSystemParameters
+`, swapValue, trails)
+	return runPowerShell(ctx, script)
+}


### PR DESCRIPTION
## Summary
- extend the Windows platform service to apply color filters and cursor tweaks while reporting unsupported fake-event modes
- surface clear unsupported messaging for visual distortion, cursor behavior, and fake event options on Linux and macOS
- add platform-targeted tests to exercise the new option handling logic across environments

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ffcafdc760832bbe3d09f36732dff6