### PR TITLE
Stream App VNC frames to controller

### DIFF
--- a/docs/app-vnc-workflow.md
+++ b/docs/app-vnc-workflow.md
@@ -11,8 +11,9 @@ On receipt, the Go agent's `app-vnc` module performs the following steps:
 2. Clone any referenced profile or data seed paths into that workspace.
 3. Apply environment overrides supplied by the virtualization plan.
 4. Launch the requested application full-screen on the private surface.
-5. Monitor heartbeats, configuration updates, and operator input until the session ends.
+5. Begin a capture loop that snapshots the virtual surface, packages each frame as an `AppVncFramePacket` (with optional cursor metadata), and POSTs it to `/api/agents/{id}/app-vnc/frames`.
+6. Monitor heartbeats, configuration updates, and operator input until the session ends.
 
-When the operator stops the session (or the process exits), the module tears down the spawned process and removes the cloned
-workspace to avoid persistence. Additional instrumentation records cloning and launch failures in the agent log, making it easier
-to troubleshoot mismatched seed paths or unsupported executables.
+Frame delivery honours the negotiated session settings: quality presets select PNG or JPEG encoding, the cursor overlay is only included when `captureCursor` is enabled, and clipboard relay remains idle unless operators request sync. Each POST reuses the agent's bearer token and user agent so the controller can validate provenance before handing the payload to `AppVncManager.ingestFrame`.
+
+When the operator stops the session (or the process exits), the module tears down the spawned process, cancels the capture loop, and removes the cloned workspace to avoid persistence. Additional instrumentation records cloning and launch failures in the agent log, making it easier to troubleshoot mismatched seed paths or unsupported executables.

--- a/tenvy-client/internal/agent/modules.go
+++ b/tenvy-client/internal/agent/modules.go
@@ -1160,6 +1160,11 @@ func (m *appVncModule) configure(cfg Config) error {
 	controller.Update(appvnc.Config{
 		Logger:        cfg.Logger,
 		WorkspaceRoot: root,
+		AgentID:       cfg.AgentID,
+		BaseURL:       cfg.BaseURL,
+		AuthKey:       cfg.AuthKey,
+		Client:        cfg.HTTPClient,
+		UserAgent:     cfg.UserAgent,
 	})
 	return nil
 }

--- a/tenvy-client/internal/modules/control/appvnc/controller_test.go
+++ b/tenvy-client/internal/modules/control/appvnc/controller_test.go
@@ -2,7 +2,12 @@ package appvnc
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/rootbay/tenvy-client/internal/protocol"
 )
@@ -104,3 +109,170 @@ func TestHandleInputBurstQueuesEvents(t *testing.T) {
 		t.Fatalf("unexpected last sequence: %d", controller.session.lastSequence)
 	}
 }
+
+func TestCaptureLoopPostsFrames(t *testing.T) {
+	controller := NewController()
+	t.Cleanup(func() { controller.Shutdown(context.Background()) })
+
+	frameCh := make(chan protocol.AppVncFramePacket, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/api/agents/test-agent/app-vnc/frames" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Errorf("unexpected authorization header: %s", got)
+		}
+		if got := r.Header.Get("User-Agent"); got != "TestAgent" {
+			t.Errorf("unexpected user agent: %s", got)
+		}
+		defer r.Body.Close()
+
+		var packet protocol.AppVncFramePacket
+		if err := json.NewDecoder(r.Body).Decode(&packet); err != nil {
+			t.Errorf("decode frame packet: %v", err)
+		} else {
+			select {
+			case frameCh <- packet:
+			default:
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"accepted":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	controller.Update(Config{
+		WorkspaceRoot: t.TempDir(),
+		AgentID:       "test-agent",
+		BaseURL:       server.URL,
+		AuthKey:       "secret",
+		Client:        server.Client(),
+		UserAgent:     "TestAgent",
+	})
+	controller.captureFactory = func(*sessionState) (surfaceCapturer, error) {
+		return newFakeSurfaceCapturer(), nil
+	}
+	controller.frameInterval = func(protocol.AppVncQuality) time.Duration { return 10 * time.Millisecond }
+	controller.requestTimeout = 500 * time.Millisecond
+	controller.now = func() time.Time { return time.Unix(0, 0) }
+
+	appID := "browser"
+	window := "Test Window"
+	payload := protocol.AppVncCommandPayload{
+		SessionID: "session-1",
+		Application: &protocol.AppVncApplicationDescriptor{
+			Platforms: []protocol.AppVncPlatform{protocol.AppVncPlatformLinux},
+			Executable: map[protocol.AppVncPlatform]string{
+				protocol.AppVncPlatformLinux: "/bin/true",
+			},
+		},
+		Settings: &protocol.AppVncSessionSettingsPatch{
+			AppID:       &appID,
+			WindowTitle: &window,
+		},
+	}
+
+	if err := controller.start(context.Background(), payload); err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+
+	var packet protocol.AppVncFramePacket
+	select {
+	case packet = <-frameCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for frame")
+	}
+
+	if packet.SessionID != "session-1" {
+		t.Fatalf("unexpected session id: %s", packet.SessionID)
+	}
+	if packet.Sequence <= 0 {
+		t.Fatalf("unexpected sequence: %d", packet.Sequence)
+	}
+	if packet.Width != 2 || packet.Height != 2 {
+		t.Fatalf("unexpected dimensions: %dx%d", packet.Width, packet.Height)
+	}
+	if packet.Encoding != "jpeg" && packet.Encoding != "png" {
+		t.Fatalf("unexpected encoding: %s", packet.Encoding)
+	}
+	if packet.Cursor == nil || !packet.Cursor.Visible {
+		t.Fatalf("expected cursor metadata, got: %+v", packet.Cursor)
+	}
+	if packet.Metadata == nil {
+		t.Fatalf("expected metadata")
+	}
+	if packet.Metadata.AppID != "browser" {
+		t.Fatalf("unexpected metadata app id: %s", packet.Metadata.AppID)
+	}
+	if packet.Metadata.WindowTitle != "Test Window" {
+		t.Fatalf("unexpected metadata window title: %s", packet.Metadata.WindowTitle)
+	}
+	if packet.Metadata.ProcessID == 0 {
+		t.Fatalf("expected process id metadata")
+	}
+	if packet.Timestamp == "" {
+		t.Fatalf("expected timestamp")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, packet.Timestamp); err != nil {
+		t.Fatalf("unexpected timestamp format: %v", err)
+	}
+	if len(packet.Image) == 0 {
+		t.Fatalf("expected image data")
+	}
+	if _, err := base64.StdEncoding.DecodeString(packet.Image); err != nil {
+		t.Fatalf("decode image payload: %v", err)
+	}
+
+	if err := controller.stop("session-1"); err != nil {
+		t.Fatalf("stop session: %v", err)
+	}
+}
+
+type fakeSurfaceCapturer struct {
+	frame *surfaceFrame
+}
+
+func newFakeSurfaceCapturer() *fakeSurfaceCapturer {
+	data := []byte{
+		0x00, 0x01, 0x02, 0x03,
+		0x04, 0x05, 0x06, 0x07,
+		0x08, 0x09, 0x0a, 0x0b,
+		0x0c, 0x0d, 0x0e, 0x0f,
+	}
+	return &fakeSurfaceCapturer{
+		frame: &surfaceFrame{
+			image: &surfaceImage{
+				width:  2,
+				height: 2,
+				stride: 8,
+				data:   data,
+			},
+			cursor: &protocol.AppVncCursorState{X: 0.5, Y: 0.5, Visible: true},
+		},
+	}
+}
+
+func (f *fakeSurfaceCapturer) Capture(ctx context.Context) (*surfaceFrame, error) {
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+	}
+	copyData := append([]byte(nil), f.frame.image.data...)
+	return &surfaceFrame{
+		image: &surfaceImage{
+			width:  f.frame.image.width,
+			height: f.frame.image.height,
+			stride: f.frame.image.stride,
+			data:   copyData,
+		},
+		cursor: f.frame.cursor,
+	}, nil
+}
+
+func (f *fakeSurfaceCapturer) Close() error { return nil }

--- a/tenvy-client/internal/modules/control/appvnc/surface_capture.go
+++ b/tenvy-client/internal/modules/control/appvnc/surface_capture.go
@@ -1,0 +1,56 @@
+package appvnc
+
+import (
+	"context"
+	"errors"
+	"image"
+
+	"github.com/kbinani/screenshot"
+	"github.com/rootbay/tenvy-client/internal/modules/control/screen"
+)
+
+type screenshotSurfaceCapturer struct {
+	bounds image.Rectangle
+}
+
+func defaultSurfaceCaptureFactory(*sessionState) (surfaceCapturer, error) {
+	displays := screenshot.NumActiveDisplays()
+	if displays <= 0 {
+		return nil, errors.New("no active displays")
+	}
+	bounds := screenshot.GetDisplayBounds(0)
+	if bounds.Dx() <= 0 || bounds.Dy() <= 0 {
+		return nil, errors.New("invalid display bounds")
+	}
+	return &screenshotSurfaceCapturer{bounds: bounds}, nil
+}
+
+func (c *screenshotSurfaceCapturer) Capture(ctx context.Context) (*surfaceFrame, error) {
+	if ctx != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+	}
+	img, err := screen.SafeCaptureRect(c.bounds)
+	if err != nil {
+		return nil, err
+	}
+	if img == nil {
+		return nil, errors.New("nil capture result")
+	}
+	frame := &surfaceFrame{
+		image: &surfaceImage{
+			width:  img.Rect.Dx(),
+			height: img.Rect.Dy(),
+			stride: img.Stride,
+			data:   append([]byte(nil), img.Pix...),
+		},
+	}
+	return frame, nil
+}
+
+func (c *screenshotSurfaceCapturer) Close() error {
+	return nil
+}

--- a/tenvy-client/internal/protocol/types.go
+++ b/tenvy-client/internal/protocol/types.go
@@ -329,6 +329,31 @@ type AppVncSessionSettingsPatch struct {
 	WindowTitle       *string        `json:"windowTitle,omitempty"`
 }
 
+type AppVncSessionMetadata struct {
+	AppID          string `json:"appId,omitempty"`
+	WindowTitle    string `json:"windowTitle,omitempty"`
+	ProcessID      int    `json:"processId,omitempty"`
+	VirtualDisplay bool   `json:"virtualDisplay,omitempty"`
+}
+
+type AppVncCursorState struct {
+	X       float64 `json:"x"`
+	Y       float64 `json:"y"`
+	Visible bool    `json:"visible"`
+}
+
+type AppVncFramePacket struct {
+	SessionID string                 `json:"sessionId"`
+	Sequence  int64                  `json:"sequence"`
+	Timestamp string                 `json:"timestamp"`
+	Width     int                    `json:"width"`
+	Height    int                    `json:"height"`
+	Encoding  string                 `json:"encoding"`
+	Image     string                 `json:"image"`
+	Cursor    *AppVncCursorState     `json:"cursor,omitempty"`
+	Metadata  *AppVncSessionMetadata `json:"metadata,omitempty"`
+}
+
 type AppVncVirtualizationHints struct {
 	ProfileSeeds map[AppVncPlatform]string            `json:"profileSeeds,omitempty"`
 	DataRoots    map[AppVncPlatform]string            `json:"dataRoots,omitempty"`


### PR DESCRIPTION
## Summary
- add a frame capture loop to the App VNC controller that encodes surfaces, attaches cursor metadata, and posts the packets to the ingest endpoint
- wire the controller with the agent HTTP client configuration, introduce a default screenshot capturer, and extend the protocol with AppVncFramePacket types
- cover the capture path with a posting test and document the new streaming workflow

## Testing
- go test ./internal/modules/control/appvnc -count=1

------
https://chatgpt.com/codex/tasks/task_e_6900e0887bf0832b90f02fc115d03b17