### PR TITLE
Add release signer configuration for plugin verification

### DIFF
--- a/tenvy-server/resources/plugin-signers.json
+++ b/tenvy-server/resources/plugin-signers.json
@@ -1,0 +1,6 @@
+{
+  "sha256AllowList": [],
+  "ed25519PublicKeys": {
+    "release": "ea9ceca1c7c7176859b235e095cbca9b5755746b741865cab5458d6f0e754cc2"
+  }
+}


### PR DESCRIPTION
## Summary
- add the server-local plugin signer policy with the release Ed25519 key so verification options include the trusted signer

## Testing
- bun test *(fails: bun's built-in test runner does not provide `vi.mock`; requires Vitest environment)*

------
https://chatgpt.com/codex/tasks/task_e_6900e9ab0310832b85b0601a223bb1c7