### PR TITLE
Wire open-url workspace into client tool loader

### DIFF
--- a/tenvy-server/src/lib/data/client-tool-workspaces.ts
+++ b/tenvy-server/src/lib/data/client-tool-workspaces.ts
@@ -12,6 +12,7 @@ import ClipboardManagerWorkspace from '$lib/components/workspace/tools/clipboard
 import RecoveryWorkspace from '$lib/components/workspace/tools/recovery-workspace.svelte';
 import OptionsWorkspace from '$lib/components/workspace/tools/options-workspace.svelte';
 import ClientChatWorkspace from '$lib/components/workspace/tools/client-chat-workspace.svelte';
+import OpenUrlWorkspace from '$lib/components/workspace/tools/open-url-workspace.svelte';
 import TriggerMonitorWorkspace from '$lib/components/workspace/tools/trigger-monitor-workspace.svelte';
 import IpGeolocationWorkspace from '$lib/components/workspace/tools/ip-geolocation-workspace.svelte';
 import EnvironmentVariablesWorkspace from '$lib/components/workspace/tools/environment-variables-workspace.svelte';
@@ -27,8 +28,9 @@ export const workspaceComponentMap = {
 	'registry-manager': RegistryManagerWorkspace,
 	'clipboard-manager': ClipboardManagerWorkspace,
 	recovery: RecoveryWorkspace,
-	options: OptionsWorkspace,
-	'client-chat': ClientChatWorkspace,
+        options: OptionsWorkspace,
+        'open-url': OpenUrlWorkspace,
+        'client-chat': ClientChatWorkspace,
 	'trigger-monitor': TriggerMonitorWorkspace,
 	'ip-geolocation': IpGeolocationWorkspace,
 	'environment-variables': EnvironmentVariablesWorkspace
@@ -52,8 +54,9 @@ export const workspaceToolIds = [
 	'registry-manager',
 	'clipboard-manager',
 	'recovery',
-	'options',
-	'client-chat',
+        'options',
+        'open-url',
+        'client-chat',
 	'trigger-monitor',
 	'ip-geolocation',
 	'environment-variables'


### PR DESCRIPTION
## Summary
- import and register the open-url workspace so the client tool loader resolves it
- extend the workspace tool id list and add a browser spec that ensures ClientToolWorkspace renders the open-url implementation instead of the fallback alert

## Testing
- bun test src/lib/components/workspace/tools/open-url-workspace.svelte.spec.ts *(fails: `@vitest/browser` requires browser mode; Bun's test runner executes outside of Vitest)*
- ENABLE_BROWSER_TESTS=true bun run test:unit -- --run src/lib/components/workspace/tools/open-url-workspace.svelte.spec.ts --project client *(fails: Vitest browser mode setup aborts because SvelteKit reserves `+page` filenames in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e5a54711c832bb344cf61f1598da8)