### PR TITLE
feat: persist operator notes and expose through UI

### DIFF
--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -31,6 +31,13 @@ export interface AgentMetrics {
   latencyMs?: number;
 }
 
+export interface AgentOperatorNote {
+  note: string;
+  tags: string[];
+  updatedAt: string | null;
+  updatedBy?: string | null;
+}
+
 export interface AgentSnapshot {
   id: string;
   metadata: AgentMetadata;
@@ -41,6 +48,7 @@ export interface AgentSnapshot {
   pendingCommands: number;
   recentResults: CommandResult[];
   liveSession?: boolean;
+  operatorNote?: AgentOperatorNote;
 }
 
 export interface AgentListResponse {

--- a/tenvy-server/src/lib/components/workspace/tools/notes-workspace.svelte.test.ts
+++ b/tenvy-server/src/lib/components/workspace/tools/notes-workspace.svelte.test.ts
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import NotesWorkspace from './notes-workspace.svelte';
+import type { Client } from '$lib/data/clients';
+
+describe('NotesWorkspace', () => {
+        const client: Client = {
+                id: 'agent-123',
+                codename: 'ORBIT',
+                hostname: 'orbit-host',
+                ip: '10.0.0.5',
+                location: 'Lisbon, PT',
+                os: 'Windows 11 Pro',
+                platform: 'windows',
+                version: '1.0.0',
+                status: 'online',
+                lastSeen: 'Just now',
+                tags: ['vip'],
+                risk: 'Medium',
+                notes: '',
+                noteTags: []
+        };
+
+        const originalFetch = globalThis.fetch;
+
+        beforeEach(() => {
+                vi.restoreAllMocks();
+                globalThis.fetch = vi.fn() as any;
+        });
+
+        afterEach(() => {
+                vi.restoreAllMocks();
+                globalThis.fetch = originalFetch;
+        });
+
+        it('loads existing notes and persists updates', async () => {
+                const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+
+                fetchMock.mockResolvedValueOnce(
+                        new Response(
+                                JSON.stringify({
+                                        note: 'Stored operator context',
+                                        tags: ['alpha'],
+                                        updatedAt: '2024-01-01T00:00:00.000Z',
+                                        updatedBy: 'operator-1'
+                                }),
+                                { status: 200 }
+                        )
+                );
+
+                fetchMock.mockResolvedValueOnce(
+                        new Response(
+                                JSON.stringify({
+                                        note: 'Updated directive',
+                                        tags: ['beta'],
+                                        updatedAt: '2024-01-02T00:00:00.000Z',
+                                        updatedBy: 'operator-2'
+                                }),
+                                { status: 200 }
+                        )
+                );
+
+                render(NotesWorkspace, { client });
+
+                await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+                const textarea = await screen.findByLabelText(/Operational notes/i);
+                expect(textarea).toHaveValue('Stored operator context');
+
+                const tagsInput = screen.getByLabelText(/Quick tags/i);
+                expect(tagsInput).toHaveValue('alpha');
+
+                await fireEvent.input(textarea, { target: { value: 'Updated note body' } });
+                await fireEvent.input(tagsInput, { target: { value: 'beta' } });
+
+                const saveButton = screen.getByRole('button', { name: /save draft/i });
+                await fireEvent.click(saveButton);
+
+                await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+                const [, requestInit] = fetchMock.mock.calls[1];
+                expect(fetchMock.mock.calls[1]?.[0]).toBe(`/api/agents/${client.id}/notes`);
+                expect(requestInit?.method).toBe('POST');
+                expect(requestInit?.body).toBe(JSON.stringify({ note: 'Updated note body', tags: ['beta'] }));
+
+                expect(textarea).toHaveValue('Updated directive');
+                expect(tagsInput).toHaveValue('beta');
+                expect(client.notes).toBe('Updated directive');
+                expect(client.noteTags).toEqual(['beta']);
+                expect(client.noteUpdatedBy).toBe('operator-2');
+
+                await screen.findByText(/Notes saved/i);
+        });
+});

--- a/tenvy-server/src/lib/data/clients.ts
+++ b/tenvy-server/src/lib/data/clients.ts
@@ -14,8 +14,11 @@ export type Client = {
 	status: ClientStatus;
 	lastSeen: string;
 	tags: string[];
-	risk: ClientRisk;
-	notes?: string;
+        risk: ClientRisk;
+        notes?: string;
+        noteTags?: string[];
+        noteUpdatedAt?: string | null;
+        noteUpdatedBy?: string | null;
 };
 
 export const clients: Client[] = [

--- a/tenvy-server/src/lib/server/db/index.ts
+++ b/tenvy-server/src/lib/server/db/index.ts
@@ -306,5 +306,9 @@ ensureColumn('plugin', 'signature_chain', 'signature_chain TEXT');
 ensureColumn('audit_event', 'acknowledged_at', 'acknowledged_at INTEGER');
 ensureColumn('audit_event', 'acknowledgement', 'acknowledgement TEXT');
 ensureColumn('agent', 'options_state', 'options_state TEXT');
+ensureColumn('agent', 'operator_note', 'operator_note TEXT');
+ensureColumn('agent', 'operator_note_tags', 'operator_note_tags TEXT');
+ensureColumn('agent', 'operator_note_updated_at', 'operator_note_updated_at INTEGER');
+ensureColumn('agent', 'operator_note_updated_by', 'operator_note_updated_by TEXT');
 
 export const db = drizzle(client, { schema });

--- a/tenvy-server/src/lib/server/db/schema.ts
+++ b/tenvy-server/src/lib/server/db/schema.ts
@@ -293,13 +293,17 @@ export const agent = sqliteTable(
 		status: text('status').notNull().default('offline'),
 		connectedAt: timestamp('connected_at', { defaultNow: true }),
 		lastSeen: timestamp('last_seen', { defaultNow: true }),
-		metrics: text('metrics'),
-		config: text('config').notNull(),
-		optionsState: text('options_state'),
-		fingerprint: text('fingerprint').notNull(),
-		createdAt: timestamp('created_at', { defaultNow: true }),
-		updatedAt: timestamp('updated_at', { defaultNow: true })
-	},
+                metrics: text('metrics'),
+                config: text('config').notNull(),
+                optionsState: text('options_state'),
+                operatorNote: text('operator_note'),
+                operatorNoteTags: text('operator_note_tags'),
+                operatorNoteUpdatedAt: timestamp('operator_note_updated_at', { optional: true }),
+                operatorNoteUpdatedBy: text('operator_note_updated_by'),
+                fingerprint: text('fingerprint').notNull(),
+                createdAt: timestamp('created_at', { defaultNow: true }),
+                updatedAt: timestamp('updated_at', { defaultNow: true })
+        },
 	(table) => ({
 		fingerprintIdx: uniqueIndex('agent_fingerprint_idx').on(table.fingerprint)
 	})

--- a/tenvy-server/src/routes/(app)/clients/+page.svelte
+++ b/tenvy-server/src/routes/(app)/clients/+page.svelte
@@ -666,25 +666,29 @@
 		return status === 'error' ? 'High' : 'Medium';
 	}
 
-	function mapAgentToClient(agent: AgentSnapshot): Client {
-		const tags = agent.metadata.tags ?? [];
+        function mapAgentToClient(agent: AgentSnapshot): Client {
+                const tags = agent.metadata.tags ?? [];
+                const operatorNote = agent.operatorNote;
 
-		return {
-			id: agent.id,
-			codename: agent.metadata.hostname?.toUpperCase() ?? agent.id.toUpperCase(),
-			hostname: agent.metadata.hostname,
+                return {
+                        id: agent.id,
+                        codename: agent.metadata.hostname?.toUpperCase() ?? agent.id.toUpperCase(),
+                        hostname: agent.metadata.hostname,
 			ip: agent.metadata.publicIpAddress ?? agent.metadata.ipAddress ?? 'Unknown',
 			location: getAgentLocation(agent).label,
 			os: agent.metadata.os,
 			platform: inferClientPlatform(agent.metadata.os),
 			version: agent.metadata.version ?? 'Unknown',
-			status: mapAgentStatusToClientStatus(agent.status),
-			lastSeen: formatRelative(agent.lastSeen),
-			tags,
-			risk: determineClientRisk(agent.status),
-			notes: tags.length > 0 ? `Tags: ${tags.join(', ')}` : undefined
-		};
-	}
+                        status: mapAgentStatusToClientStatus(agent.status),
+                        lastSeen: formatRelative(agent.lastSeen),
+                        tags,
+                        risk: determineClientRisk(agent.status),
+                        notes: operatorNote?.note ?? '',
+                        noteTags: operatorNote?.tags ?? [],
+                        noteUpdatedAt: operatorNote?.updatedAt ?? null,
+                        noteUpdatedBy: operatorNote?.updatedBy ?? null
+                };
+        }
 
 	function openSection(section: SectionKey, agent: AgentSnapshot) {
 		const toolId = sectionToolMap[section];

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/+layout.ts
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/+layout.ts
@@ -37,24 +37,28 @@ function formatLastSeen(value: string): string {
 }
 
 function mapAgentToClient(agent: AgentSnapshot): Client {
-	const hostname = agent.metadata.hostname || agent.id;
-	const tags = agent.metadata.tags ?? [];
+        const hostname = agent.metadata.hostname || agent.id;
+        const tags = agent.metadata.tags ?? [];
+        const operatorNote = agent.operatorNote;
 
-	return {
-		id: agent.id,
-		codename: hostname.toUpperCase(),
-		hostname,
+        return {
+                id: agent.id,
+                codename: hostname.toUpperCase(),
+                hostname,
 		ip: agent.metadata.publicIpAddress ?? agent.metadata.ipAddress ?? 'Unknown',
 		location: 'Unknown',
 		os: agent.metadata.os,
 		platform: inferClientPlatform(agent.metadata.os),
-		version: agent.metadata.version ?? 'Unknown',
-		status: mapAgentStatus(agent.status),
-		lastSeen: formatLastSeen(agent.lastSeen),
-		tags,
-		risk: determineClientRisk(agent.status),
-		notes: agent.metadata.username ? `User: ${agent.metadata.username}` : undefined
-	} satisfies Client;
+                version: agent.metadata.version ?? 'Unknown',
+                status: mapAgentStatus(agent.status),
+                lastSeen: formatLastSeen(agent.lastSeen),
+                tags,
+                risk: determineClientRisk(agent.status),
+                notes: operatorNote?.note ?? '',
+                noteTags: operatorNote?.tags ?? [],
+                noteUpdatedAt: operatorNote?.updatedAt ?? null,
+                noteUpdatedBy: operatorNote?.updatedBy ?? null
+        } satisfies Client;
 }
 
 export const load = (async ({ params, fetch }) => {

--- a/tenvy-server/src/routes/api/agents/[id]/notes/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/notes/+server.ts
@@ -1,41 +1,101 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { registry, RegistryError } from '$lib/server/rat/store';
+import { requireOperator } from '$lib/server/authorization';
 import type { NoteSyncRequest } from '../../../../../../../shared/types/notes';
+import type { AgentOperatorNote } from '../../../../../../../shared/types/agent';
 
 function getBearerToken(header: string | null): string | undefined {
-	if (!header) {
-		return undefined;
-	}
-	const match = header.match(/^Bearer\s+(.+)$/i);
-	return match?.[1]?.trim();
+        if (!header) {
+                return undefined;
+        }
+        const match = header.match(/^Bearer\s+(.+)$/i);
+        return match?.[1]?.trim();
 }
 
-export const POST: RequestHandler = async ({ params, request }) => {
-	const id = params.id;
-	if (!id) {
-		throw error(400, 'Missing agent identifier');
-	}
+function parseOperatorPayload(input: unknown): { note: string; tags: string[] } {
+        if (!input || typeof input !== 'object') {
+                return { note: '', tags: [] };
+        }
 
-	let payload: NoteSyncRequest;
-	try {
-		payload = (await request.json()) as NoteSyncRequest;
-	} catch {
-		throw error(400, 'Invalid note payload');
-	}
+        const { note, tags } = input as { note?: unknown; tags?: unknown };
+        const normalizedNote = typeof note === 'string' ? note : '';
+        const normalizedTags = Array.isArray(tags)
+                ? tags.map((tag) => `${tag ?? ''}`.trim()).filter((tag) => tag.length > 0)
+                : [];
 
-	const token = getBearerToken(request.headers.get('authorization'));
-	if (!token) {
-		throw error(401, 'Missing agent key');
-	}
+        return { note: normalizedNote, tags: normalizedTags };
+}
 
-	try {
-		const notes = registry.syncSharedNotes(id, token, payload?.notes ?? []);
-		return json({ notes });
-	} catch (err) {
-		if (err instanceof RegistryError) {
-			throw error(err.status, err.message);
-		}
-		throw error(500, 'Failed to sync notes');
-	}
+function toResponsePayload(note: AgentOperatorNote): AgentOperatorNote {
+        return {
+                note: note.note,
+                tags: [...note.tags],
+                updatedAt: note.updatedAt ?? null,
+                updatedBy: note.updatedBy ?? null
+        } satisfies AgentOperatorNote;
+}
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        const operator = requireOperator(locals.user);
+
+        try {
+                const note = registry.getOperatorNote(id);
+                return json(toResponsePayload(note));
+        } catch (err) {
+                if (err instanceof RegistryError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to load operator note');
+        }
+};
+
+export const POST: RequestHandler = async ({ params, request, locals }) => {
+        const id = params.id;
+        if (!id) {
+                throw error(400, 'Missing agent identifier');
+        }
+
+        let body: unknown;
+        try {
+                body = await request.json();
+        } catch {
+                throw error(400, 'Invalid note payload');
+        }
+
+        const token = getBearerToken(request.headers.get('authorization'));
+        if (token) {
+                const payload = body as NoteSyncRequest;
+                try {
+                        const notes = registry.syncSharedNotes(id, token, payload?.notes ?? []);
+                        return json({ notes });
+                } catch (err) {
+                        if (err instanceof RegistryError) {
+                                throw error(err.status, err.message);
+                        }
+                        throw error(500, 'Failed to sync notes');
+                }
+        }
+
+        if (!locals.user) {
+                throw error(401, 'Missing agent key');
+        }
+
+        const operator = requireOperator(locals.user);
+        const payload = parseOperatorPayload(body);
+
+        try {
+                const note = registry.updateOperatorNote(id, payload, { operatorId: operator.id });
+                return json(toResponsePayload(note));
+        } catch (err) {
+                if (err instanceof RegistryError) {
+                        throw error(err.status, err.message);
+                }
+                throw error(500, 'Failed to save operator note');
+        }
 };

--- a/tenvy-server/tests/notes-api.test.ts
+++ b/tenvy-server/tests/notes-api.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const requireOperator = vi.fn(
+        (user: { id: string } | null | undefined) => user ?? { id: 'operator-1' }
+);
+
+vi.mock('../src/lib/server/authorization.js', () => ({
+        requireOperator
+}));
+
+const syncSharedNotes = vi.fn();
+const getOperatorNote = vi.fn();
+const updateOperatorNote = vi.fn();
+
+class MockRegistryError extends Error {
+        status: number;
+
+        constructor(message: string, status = 400) {
+                super(message);
+                this.status = status;
+        }
+}
+
+vi.mock('../src/lib/server/rat/store.js', () => ({
+        registry: {
+                syncSharedNotes,
+                getOperatorNote,
+                updateOperatorNote
+        },
+        RegistryError: MockRegistryError
+}));
+
+const modulePromise = import('../src/routes/api/agents/[id]/notes/+server.js');
+
+type Handler =
+        Awaited<typeof modulePromise> extends infer T
+                ? T extends { GET?: infer G; POST?: infer P }
+                        ? G | P
+                        : never
+                : never;
+
+function createEvent<T extends Handler>(
+        handler: T,
+        init: Partial<Parameters<T>[0]> & { method?: string } = {}
+) {
+        const method = init.method ?? 'GET';
+        return {
+                params: { id: 'agent-1', ...(init.params ?? {}) },
+                request:
+                        init.request ??
+                        new Request('https://controller.test/api', {
+                                method,
+                                headers: init.request?.headers,
+                                body: init.request?.body
+                        }),
+                locals: init.locals ?? { user: { id: 'operator-1' } },
+                ...init
+        } as Parameters<T>[0];
+}
+
+describe('agent notes API', () => {
+        beforeEach(() => {
+                requireOperator.mockClear();
+                syncSharedNotes.mockReset();
+                getOperatorNote.mockReset();
+                updateOperatorNote.mockReset();
+        });
+
+        it('returns stored operator notes for authenticated viewers', async () => {
+                const { GET } = await modulePromise;
+                if (!GET) throw new Error('GET handler missing');
+
+                const stored = {
+                        note: 'Existing context',
+                        tags: ['intel'],
+                        updatedAt: '2024-01-01T00:00:00.000Z',
+                        updatedBy: 'operator-9'
+                } satisfies Awaited<ReturnType<typeof getOperatorNote>>;
+
+                getOperatorNote.mockReturnValueOnce(stored);
+
+                const response = await GET(
+                        createEvent(GET, { locals: { user: { id: 'viewer-1', role: 'operator' } } })
+                );
+
+                expect(requireOperator).toHaveBeenCalledWith({ id: 'viewer-1', role: 'operator' });
+                expect(await response.json()).toEqual(stored);
+        });
+
+        it('updates operator notes when submitted by an operator', async () => {
+                const { POST } = await modulePromise;
+                if (!POST) throw new Error('POST handler missing');
+
+                const saved = {
+                        note: 'Refined objective',
+                        tags: ['priority', 'followup'],
+                        updatedAt: '2024-02-01T08:30:00.000Z',
+                        updatedBy: 'operator-77'
+                } satisfies Awaited<ReturnType<typeof updateOperatorNote>>;
+
+                updateOperatorNote.mockReturnValueOnce(saved);
+
+                const request = new Request('https://controller.test/api', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ note: 'Refined objective', tags: ['priority', 'followup'] })
+                });
+
+                const locals = { user: { id: 'operator-77', role: 'operator' } };
+
+                const response = await POST(
+                        createEvent(POST, {
+                                method: 'POST',
+                                request,
+                                locals
+                        })
+                );
+
+                expect(requireOperator).toHaveBeenCalledWith(locals.user);
+                expect(updateOperatorNote).toHaveBeenCalledWith(
+                        'agent-1',
+                        { note: 'Refined objective', tags: ['priority', 'followup'] },
+                        { operatorId: 'operator-77' }
+                );
+                expect(await response.json()).toEqual(saved);
+        });
+
+        it('passes sync requests from agents through to the registry', async () => {
+                const { POST } = await modulePromise;
+                if (!POST) throw new Error('POST handler missing');
+
+                const envelopes = [
+                        {
+                                id: 'note-1',
+                                visibility: 'shared',
+                                ciphertext: 'cipher',
+                                nonce: 'nonce',
+                                digest: 'digest',
+                                version: 2,
+                                updatedAt: '2024-03-01T00:00:00.000Z'
+                        }
+                ];
+
+                syncSharedNotes.mockReturnValueOnce(envelopes);
+
+                const request = new Request('https://controller.test/api', {
+                        method: 'POST',
+                        headers: {
+                                'Content-Type': 'application/json',
+                                Authorization: 'Bearer agent-token'
+                        },
+                        body: JSON.stringify({ notes: envelopes })
+                });
+
+                const response = await POST(
+                        createEvent(POST, {
+                                method: 'POST',
+                                request,
+                                locals: { user: null }
+                        })
+                );
+
+                expect(requireOperator).not.toHaveBeenCalled();
+                expect(syncSharedNotes).toHaveBeenCalledWith('agent-1', 'agent-token', envelopes);
+                expect(await response.json()).toEqual({ notes: envelopes });
+        });
+});


### PR DESCRIPTION
## Summary
- add operator note persistence to the registry/database layer and surface it on agent snapshots
- expand the notes API to serve operator requests while keeping agent sync flows intact
- hydrate the notes workspace with stored data and add targeted server/component tests

## Testing
- bun run test:unit --run tests/notes-api.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e6fc568d4832b9df6c9b45943b359)