### PR TITLE
Skip SSE frame parsing during WebRTC playback

### DIFF
--- a/tenvy-server/src/lib/components/workspace/tools/remote-desktop-workspace.svelte
+++ b/tenvy-server/src/lib/components/workspace/tools/remote-desktop-workspace.svelte
@@ -883,15 +883,18 @@
 			}
 		});
 
-		eventSource.addEventListener('frame', (event) => {
-			const frame = parseFrameEvent(event as MessageEvent);
-			if (frame) {
-				enqueueFrame(frame);
-				if (frame.media && frame.media.length > 0) {
-					void handleMediaSamples(frame.sessionId, frame.media);
-				}
-			}
-		});
+                eventSource.addEventListener('frame', (event) => {
+                        if (webrtcVideoActive) {
+                                return;
+                        }
+                        const frame = parseFrameEvent(event as MessageEvent);
+                        if (frame) {
+                                enqueueFrame(frame);
+                                if (frame.media && frame.media.length > 0) {
+                                        void handleMediaSamples(frame.sessionId, frame.media);
+                                }
+                        }
+                });
 
 		eventSource.addEventListener('media', (event) => {
 			const detail = parseMediaEvent(event as MessageEvent);


### PR DESCRIPTION
## Summary
- stop parsing SSE frame payloads whenever WebRTC video streaming is active to avoid unnecessary work
- keep the HTTP fallback path unchanged so frames continue to render when negotiation fails

## Testing
- not run (not feasible in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ef1161518832bb4ce05cdcd967505)