### PR TITLE
Add downloads catalogue support to trigger monitor

### DIFF
--- a/shared/types/downloads.ts
+++ b/shared/types/downloads.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const downloadCatalogueEntrySchema = z.object({
+  id: z.string().trim().min(1, "Download identifier is required."),
+  displayName: z.string().trim().min(1, "Download display name is required."),
+  description: z.string().trim().min(1).optional(),
+  version: z.string().trim().min(1).optional(),
+  executable: z.string().trim().min(1).optional(),
+  path: z.string().trim().min(1).optional(),
+  hash: z.string().trim().min(1).optional(),
+  sizeBytes: z.number().int().nonnegative().optional(),
+  tags: z.array(z.string().trim().min(1)).max(16).optional(),
+});
+
+export const downloadCatalogueSchema = z.array(downloadCatalogueEntrySchema);
+export const downloadCatalogueResponseSchema = z.object({
+  downloads: downloadCatalogueSchema,
+});
+
+export type DownloadCatalogueEntry = z.infer<
+  typeof downloadCatalogueEntrySchema
+>;
+export type DownloadCatalogue = z.infer<typeof downloadCatalogueSchema>;
+export type DownloadCatalogueResponse = z.infer<
+  typeof downloadCatalogueResponseSchema
+>;

--- a/tenvy-server/src/lib/components/workspace/tools/trigger-monitor-workspace.svelte.spec.ts
+++ b/tenvy-server/src/lib/components/workspace/tools/trigger-monitor-workspace.svelte.spec.ts
@@ -1,0 +1,194 @@
+import { page } from '@vitest/browser/context';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+
+import type { Client } from '$lib/data/clients';
+import type { ProcessListResponse } from '$lib/types/task-manager';
+
+import TriggerMonitorWorkspace from './trigger-monitor-workspace.svelte';
+
+const originalFetch = globalThis.fetch;
+
+const baseClient: Client = {
+	id: 'agent-123',
+	codename: 'FOXTROT',
+	hostname: 'test-host',
+	ip: '192.168.1.10',
+	location: 'Test Lab',
+	os: 'Linux',
+	platform: 'linux',
+	version: '1.2.3',
+	status: 'online',
+	lastSeen: new Date().toISOString(),
+	tags: [],
+	risk: 'Low'
+};
+
+function createStatus() {
+	return {
+		config: {
+			feed: 'live',
+			refreshSeconds: 5,
+			includeScreenshots: false,
+			includeCommands: true,
+			watchlist: [],
+			lastUpdatedAt: new Date().toISOString()
+		},
+		metrics: [],
+		events: [],
+		generatedAt: new Date().toISOString()
+	};
+}
+
+function createProcessList(): ProcessListResponse {
+	return {
+		generatedAt: new Date().toISOString(),
+		processes: [
+			{
+				pid: 101,
+				ppid: 1,
+				name: 'systemd',
+				command: '/usr/lib/systemd/systemd',
+				cpu: 0.8,
+				memory: 128_000,
+				status: 'running',
+				user: 'root'
+			}
+		]
+	} satisfies ProcessListResponse;
+}
+
+describe('trigger-monitor workspace suggestions', () => {
+	beforeEach(() => {
+		globalThis.fetch = vi.fn();
+	});
+
+	afterEach(() => {
+		if (originalFetch) {
+			globalThis.fetch = originalFetch;
+		} else {
+			// @ts-expect-error cleanup in tests
+			delete globalThis.fetch;
+		}
+	});
+
+	it('loads catalogue and process suggestions when available', async () => {
+		const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+		fetchMock.mockImplementation((input) => {
+			const url = typeof input === 'string' ? input : (input?.url ?? '');
+			if (url.endsWith('/misc/trigger-monitor')) {
+				return Promise.resolve(
+					new Response(JSON.stringify(createStatus()), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' }
+					})
+				);
+			}
+			if (url.endsWith('/downloads')) {
+				return Promise.resolve(
+					new Response(
+						JSON.stringify({
+							downloads: [
+								{
+									id: 'atlas.exe',
+									displayName: 'Atlas Explorer',
+									version: '2.3.1',
+									description: 'Reconnaissance utility'
+								}
+							]
+						}),
+						{
+							status: 200,
+							headers: { 'Content-Type': 'application/json' }
+						}
+					)
+				);
+			}
+			if (url.endsWith('/task-manager/processes')) {
+				return Promise.resolve(
+					new Response(JSON.stringify(createProcessList()), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' }
+					})
+				);
+			}
+			throw new Error(`Unhandled fetch: ${url}`);
+		});
+
+		const { component } = render(TriggerMonitorWorkspace, { props: { client: baseClient } });
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		const manageButton = page.getByRole('button', { name: 'Manage watchlist' });
+		manageButton.click();
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		await expect.element(page.getByText('Atlas Explorer')).toBeInTheDocument();
+		await expect.element(page.getByText('systemd')).toBeInTheDocument();
+		component.$destroy();
+	});
+
+	it('surfaces catalogue errors once and avoids repeated auto-fetching', async () => {
+		const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+		fetchMock.mockImplementation((input) => {
+			const url = typeof input === 'string' ? input : (input?.url ?? '');
+			if (url.endsWith('/misc/trigger-monitor')) {
+				return Promise.resolve(
+					new Response(JSON.stringify(createStatus()), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' }
+					})
+				);
+			}
+			if (url.endsWith('/downloads')) {
+				return Promise.resolve(
+					new Response(JSON.stringify({ message: 'Service unavailable' }), {
+						status: 503,
+						headers: { 'Content-Type': 'application/json' }
+					})
+				);
+			}
+			if (url.endsWith('/task-manager/processes')) {
+				return Promise.resolve(
+					new Response(JSON.stringify(createProcessList()), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' }
+					})
+				);
+			}
+			throw new Error(`Unhandled fetch: ${url}`);
+		});
+
+		const { component } = render(TriggerMonitorWorkspace, { props: { client: baseClient } });
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		const manageButton = page.getByRole('button', { name: 'Manage watchlist' });
+		manageButton.click();
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		await expect
+			.element(page.getByText('Downloads catalogue unavailable', { exact: false }))
+			.toBeInTheDocument();
+		await expect.element(page.getByText('systemd')).toBeInTheDocument();
+
+		const cancelButton = page.getByRole('button', { name: 'Cancel' });
+		cancelButton.click();
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		manageButton.click();
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		const downloadCalls = fetchMock.mock.calls.filter(([input]) => {
+			const url = typeof input === 'string' ? input : (input?.url ?? '');
+			return typeof url === 'string' && url.includes('/downloads');
+		});
+		expect(downloadCalls).toHaveLength(1);
+
+		component.$destroy();
+	});
+});

--- a/tenvy-server/src/lib/server/db/index.ts
+++ b/tenvy-server/src/lib/server/db/index.ts
@@ -310,5 +310,6 @@ ensureColumn('agent', 'operator_note', 'operator_note TEXT');
 ensureColumn('agent', 'operator_note_tags', 'operator_note_tags TEXT');
 ensureColumn('agent', 'operator_note_updated_at', 'operator_note_updated_at INTEGER');
 ensureColumn('agent', 'operator_note_updated_by', 'operator_note_updated_by TEXT');
+ensureColumn('agent', 'downloads_catalogue', 'downloads_catalogue TEXT');
 
 export const db = drizzle(client, { schema });

--- a/tenvy-server/src/lib/server/db/schema.ts
+++ b/tenvy-server/src/lib/server/db/schema.ts
@@ -293,17 +293,18 @@ export const agent = sqliteTable(
 		status: text('status').notNull().default('offline'),
 		connectedAt: timestamp('connected_at', { defaultNow: true }),
 		lastSeen: timestamp('last_seen', { defaultNow: true }),
-                metrics: text('metrics'),
-                config: text('config').notNull(),
-                optionsState: text('options_state'),
-                operatorNote: text('operator_note'),
-                operatorNoteTags: text('operator_note_tags'),
-                operatorNoteUpdatedAt: timestamp('operator_note_updated_at', { optional: true }),
-                operatorNoteUpdatedBy: text('operator_note_updated_by'),
-                fingerprint: text('fingerprint').notNull(),
-                createdAt: timestamp('created_at', { defaultNow: true }),
-                updatedAt: timestamp('updated_at', { defaultNow: true })
-        },
+		metrics: text('metrics'),
+		config: text('config').notNull(),
+		optionsState: text('options_state'),
+		downloadsCatalogue: text('downloads_catalogue'),
+		operatorNote: text('operator_note'),
+		operatorNoteTags: text('operator_note_tags'),
+		operatorNoteUpdatedAt: timestamp('operator_note_updated_at', { optional: true }),
+		operatorNoteUpdatedBy: text('operator_note_updated_by'),
+		fingerprint: text('fingerprint').notNull(),
+		createdAt: timestamp('created_at', { defaultNow: true }),
+		updatedAt: timestamp('updated_at', { defaultNow: true })
+	},
 	(table) => ({
 		fingerprintIdx: uniqueIndex('agent_fingerprint_idx').on(table.fingerprint)
 	})

--- a/tenvy-server/src/lib/server/rat/store.test.ts
+++ b/tenvy-server/src/lib/server/rat/store.test.ts
@@ -98,6 +98,37 @@ describe('AgentRegistry database integration', () => {
 		expect(restoredNotes[0]?.id).toBe('note-1');
 	});
 
+	it('persists downloads catalogue entries across instances', async () => {
+		const registry = new AgentRegistry();
+		const registration = registry.registerAgent({ metadata: baseMetadata });
+
+		const downloads = [
+			{
+				id: 'atlas.exe',
+				displayName: 'Atlas Explorer',
+				version: '2.3.1',
+				description: 'Reconnaissance utility',
+				tags: ['recon']
+			}
+		];
+
+		registry.updateDownloadsCatalogue(registration.agentId, downloads);
+		await registry.flush();
+
+		const restored = new AgentRegistry();
+		const restoredDownloads = restored.getDownloadsCatalogue(registration.agentId);
+
+		expect(restoredDownloads).toEqual([
+			{
+				id: 'atlas.exe',
+				displayName: 'Atlas Explorer',
+				version: '2.3.1',
+				description: 'Reconnaissance utility',
+				tags: ['recon']
+			}
+		]);
+	});
+
 	it('records audit events for queued and executed commands', async () => {
 		const registry = new AgentRegistry();
 		const registration = registry.registerAgent({ metadata: baseMetadata });

--- a/tenvy-server/src/lib/types/downloads.ts
+++ b/tenvy-server/src/lib/types/downloads.ts
@@ -1,0 +1,11 @@
+export {
+	downloadCatalogueEntrySchema,
+	downloadCatalogueSchema,
+	downloadCatalogueResponseSchema
+} from '../../../../shared/types/downloads';
+
+export type {
+	DownloadCatalogueEntry,
+	DownloadCatalogue,
+	DownloadCatalogueResponse
+} from '../../../../shared/types/downloads';

--- a/tenvy-server/src/routes/api/agents/[id]/downloads/+server.test.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/downloads/+server.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, beforeEach, afterEach, beforeAll, vi } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => import('../../../../../../tests/mocks/env-dynamic-private'));
+
+let getHandler: typeof import('./+server').GET;
+let registry: typeof import('$lib/server/rat/store').registry;
+let RegistryErrorCtor: typeof import('$lib/server/rat/store').RegistryError;
+
+beforeAll(async () => {
+	({ GET: getHandler } = await import('./+server'));
+	({ registry, RegistryError: RegistryErrorCtor } = await import('$lib/server/rat/store'));
+});
+
+function createEvent(agentId: string, userRole: 'viewer' | 'operator' = 'viewer') {
+	return {
+		params: { id: agentId },
+		locals: {
+			user: {
+				id: 'user-1',
+				role: userRole
+			}
+		}
+	} as unknown;
+}
+
+describe('/api/agents/[id]/downloads', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('returns the downloads catalogue for the requested agent', async () => {
+		const spy = vi.spyOn(registry, 'getDownloadsCatalogue').mockReturnValue([
+			{
+				id: 'atlas.exe',
+				displayName: 'Atlas Explorer',
+				version: '2.3.1',
+				description: 'Reconnaissance utility'
+			}
+		]);
+
+		const response = await getHandler(createEvent('agent-123') as any);
+		expect(spy).toHaveBeenCalledWith('agent-123');
+		expect(response.status).toBe(200);
+		const payload = await response.json();
+		expect(payload).toEqual({
+			downloads: [
+				{
+					id: 'atlas.exe',
+					displayName: 'Atlas Explorer',
+					version: '2.3.1',
+					description: 'Reconnaissance utility'
+				}
+			]
+		});
+	});
+
+	it('returns an empty array when no downloads are available', async () => {
+		vi.spyOn(registry, 'getDownloadsCatalogue').mockReturnValue([]);
+
+		const response = await getHandler(createEvent('agent-empty') as any);
+		expect(response.status).toBe(200);
+		const payload = await response.json();
+		expect(payload).toEqual({ downloads: [] });
+	});
+
+	it('propagates registry errors as HTTP errors', async () => {
+		vi.spyOn(registry, 'getDownloadsCatalogue').mockImplementation(() => {
+			throw new RegistryErrorCtor('Agent not found', 404);
+		});
+
+		try {
+			getHandler(createEvent('missing') as any);
+			throw new Error('Expected handler to throw');
+		} catch (error) {
+			const err = error as { status?: number; body?: { message?: string } };
+			expect(err.status).toBe(404);
+			expect(err.body?.message).toBe('Agent not found');
+		}
+	});
+});

--- a/tenvy-server/src/routes/api/agents/[id]/downloads/+server.ts
+++ b/tenvy-server/src/routes/api/agents/[id]/downloads/+server.ts
@@ -1,0 +1,25 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { requireViewer } from '$lib/server/authorization';
+import { registry, RegistryError } from '$lib/server/rat/store';
+import { downloadCatalogueSchema } from '$lib/types/downloads';
+
+export const GET: RequestHandler = ({ params, locals }) => {
+	const id = params.id;
+	if (!id) {
+		throw error(400, 'Missing agent identifier');
+	}
+
+	requireViewer(locals.user);
+
+	try {
+		const downloads = registry.getDownloadsCatalogue(id);
+		const payload = downloadCatalogueSchema.parse(downloads);
+		return json({ downloads: payload });
+	} catch (err) {
+		if (err instanceof RegistryError) {
+			throw error(err.status, err.message);
+		}
+		throw error(500, 'Failed to load downloads catalogue');
+	}
+};


### PR DESCRIPTION
## Summary
- add shared downloads catalogue schema and expose it through the registry persistence layer
- implement GET /api/agents/[id]/downloads to surface catalogue entries to the UI
- update the trigger monitor workspace to consume the new response and cover it with unit and browser specs

## Testing
- ✅ `bun run test:unit --run src/routes/api/agents/[id]/downloads/+server.test.ts`
- ❌ `bun run test:unit --run src/lib/components/workspace/tools/trigger-monitor-workspace.svelte.spec.ts` *(fails: Vitest browser config excludes Svelte specs; needs browser env setup)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ef1a38adc832b94bc2a722e6ec0c8)