### PR TITLE
Refactor download catalogue types to avoid missing zod

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "tweetnacl": "^1.0.3",
-    "zod": "^4.1.12"
+    "tweetnacl": "^1.0.3"
   }
 }

--- a/shared/types/downloads.ts
+++ b/shared/types/downloads.ts
@@ -1,26 +1,29 @@
-import { z } from "zod";
+/**
+ * Entry describing a downloadable artefact that can be delivered to an agent.
+ */
+export interface DownloadCatalogueEntry {
+  /** Unique identifier for the download entry. */
+  id: string;
+  /** Human readable name to show in the UI. */
+  displayName: string;
+  /** Optional description surfaced alongside the entry. */
+  description?: string;
+  /** Optional version string for the artefact. */
+  version?: string;
+  /** Optional executable name expected to be present after download. */
+  executable?: string;
+  /** Optional filesystem path to install or reference the artefact. */
+  path?: string;
+  /** Optional integrity hash for the download. */
+  hash?: string;
+  /** Optional size of the download in bytes. */
+  sizeBytes?: number;
+  /** Optional tags used for filtering and organisation. */
+  tags?: string[];
+}
 
-export const downloadCatalogueEntrySchema = z.object({
-  id: z.string().trim().min(1, "Download identifier is required."),
-  displayName: z.string().trim().min(1, "Download display name is required."),
-  description: z.string().trim().min(1).optional(),
-  version: z.string().trim().min(1).optional(),
-  executable: z.string().trim().min(1).optional(),
-  path: z.string().trim().min(1).optional(),
-  hash: z.string().trim().min(1).optional(),
-  sizeBytes: z.number().int().nonnegative().optional(),
-  tags: z.array(z.string().trim().min(1)).max(16).optional(),
-});
+export type DownloadCatalogue = DownloadCatalogueEntry[];
 
-export const downloadCatalogueSchema = z.array(downloadCatalogueEntrySchema);
-export const downloadCatalogueResponseSchema = z.object({
-  downloads: downloadCatalogueSchema,
-});
-
-export type DownloadCatalogueEntry = z.infer<
-  typeof downloadCatalogueEntrySchema
->;
-export type DownloadCatalogue = z.infer<typeof downloadCatalogueSchema>;
-export type DownloadCatalogueResponse = z.infer<
-  typeof downloadCatalogueResponseSchema
->;
+export interface DownloadCatalogueResponse {
+  downloads: DownloadCatalogue;
+}

--- a/tenvy-server/src/lib/server/rat/store.ts
+++ b/tenvy-server/src/lib/server/rat/store.ts
@@ -54,10 +54,10 @@ import type {
 import type { RemoteDesktopInputBurst } from '../../../../../shared/types/remote-desktop';
 import type { AppVncInputBurst } from '../../../../../shared/types/app-vnc';
 import {
-	downloadCatalogueSchema,
-	type DownloadCatalogue,
-	type DownloadCatalogueEntry
-} from '../../../../../shared/types/downloads';
+        downloadCatalogueSchema,
+        type DownloadCatalogue,
+        type DownloadCatalogueEntry
+} from '$lib/types/downloads';
 import { PluginTelemetryStore } from '../plugins/telemetry-store.js';
 import { getAgentSignaturePolicy } from '../plugins/signature-policy.js';
 

--- a/tenvy-server/src/lib/types/downloads.ts
+++ b/tenvy-server/src/lib/types/downloads.ts
@@ -1,11 +1,33 @@
-export {
-	downloadCatalogueEntrySchema,
-	downloadCatalogueSchema,
-	downloadCatalogueResponseSchema
+import { z } from 'zod';
+
+import type {
+        DownloadCatalogue,
+        DownloadCatalogueEntry,
+        DownloadCatalogueResponse
 } from '../../../../shared/types/downloads';
 
-export type {
-	DownloadCatalogueEntry,
-	DownloadCatalogue,
-	DownloadCatalogueResponse
-} from '../../../../shared/types/downloads';
+export const downloadCatalogueEntrySchema = z
+        .object({
+                id: z.string().trim().min(1, 'Download identifier is required.'),
+                displayName: z.string().trim().min(1, 'Download display name is required.'),
+                description: z.string().trim().min(1).optional(),
+                version: z.string().trim().min(1).optional(),
+                executable: z.string().trim().min(1).optional(),
+                path: z.string().trim().min(1).optional(),
+                hash: z.string().trim().min(1).optional(),
+                sizeBytes: z.number().int().nonnegative().optional(),
+                tags: z.array(z.string().trim().min(1)).max(16).optional()
+        })
+        satisfies z.ZodType<DownloadCatalogueEntry>;
+
+export const downloadCatalogueSchema = z
+        .array(downloadCatalogueEntrySchema)
+        satisfies z.ZodType<DownloadCatalogue>;
+
+export const downloadCatalogueResponseSchema = z
+        .object({
+                downloads: downloadCatalogueSchema
+        })
+        satisfies z.ZodType<DownloadCatalogueResponse>;
+
+export type { DownloadCatalogueEntry, DownloadCatalogue, DownloadCatalogueResponse } from '../../../../shared/types/downloads';


### PR DESCRIPTION
## Summary
- stop importing zod from the shared types package so it no longer requires a runtime dependency
- define the download catalogue zod schemas inside the server package and keep the shared package as types only
- update the registry store to use the new local schema re-exports

## Testing
- bun run check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f165f2044832ba54058668af7b3a4)