### PR TITLE
fix: ensure downloads schemas use supported type annotations

### DIFF
--- a/tenvy-server/src/lib/types/downloads.ts
+++ b/tenvy-server/src/lib/types/downloads.ts
@@ -6,7 +6,7 @@ import type {
         DownloadCatalogueResponse
 } from '../../../../shared/types/downloads';
 
-export const downloadCatalogueEntrySchema = z
+export const downloadCatalogueEntrySchema: z.ZodType<DownloadCatalogueEntry> = z
         .object({
                 id: z.string().trim().min(1, 'Download identifier is required.'),
                 displayName: z.string().trim().min(1, 'Download display name is required.'),
@@ -17,17 +17,15 @@ export const downloadCatalogueEntrySchema = z
                 hash: z.string().trim().min(1).optional(),
                 sizeBytes: z.number().int().nonnegative().optional(),
                 tags: z.array(z.string().trim().min(1)).max(16).optional()
-        })
-        satisfies z.ZodType<DownloadCatalogueEntry>;
+        });
 
-export const downloadCatalogueSchema = z
-        .array(downloadCatalogueEntrySchema)
-        satisfies z.ZodType<DownloadCatalogue>;
+export const downloadCatalogueSchema: z.ZodType<DownloadCatalogue> = z.array(
+        downloadCatalogueEntrySchema
+);
 
-export const downloadCatalogueResponseSchema = z
+export const downloadCatalogueResponseSchema: z.ZodType<DownloadCatalogueResponse> = z
         .object({
                 downloads: downloadCatalogueSchema
-        })
-        satisfies z.ZodType<DownloadCatalogueResponse>;
+        });
 
 export type { DownloadCatalogueEntry, DownloadCatalogue, DownloadCatalogueResponse } from '../../../../shared/types/downloads';


### PR DESCRIPTION
## Summary
- replace TypeScript `satisfies` expressions in download schema definitions with explicit Zod type annotations
- ensure the download catalogue schemas continue to align with shared types without relying on unsupported syntax

## Testing
- bun check (fails: existing diagnostics unrelated to the change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f1d6b09e8832ba0c56e5d55e628a5)