### PR TITLE
Fix type issues surfaced by bun check

### DIFF
--- a/tenvy-server/src/lib/components/client-tool-dialog.svelte.test.ts
+++ b/tenvy-server/src/lib/components/client-tool-dialog.svelte.test.ts
@@ -7,7 +7,7 @@ import type { AppVncSessionState } from '$lib/types/app-vnc';
 
 type EventListenerMap = Map<string, Set<(event: MessageEvent) => void>>;
 
-class MockEventSource implements EventSource {
+class MockEventSource {
 	static lastInstance: MockEventSource | null = null;
 
 	readonly url: string;
@@ -27,12 +27,16 @@ class MockEventSource implements EventSource {
 		this.readyState = 2;
 	}
 
-	addEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
-		if (!listener) {
-			return;
-		}
-		const handler = typeof listener === 'function' ? listener : listener.handleEvent.bind(listener);
-		let bucket = this.listeners.get(type);
+        addEventListener(
+                type: string,
+                listener: EventListenerOrEventListenerObject | null,
+                _options?: boolean | AddEventListenerOptions
+        ): void {
+                if (!listener) {
+                        return;
+                }
+                const handler = typeof listener === 'function' ? listener : listener.handleEvent.bind(listener);
+                let bucket = this.listeners.get(type);
 		if (!bucket) {
 			bucket = new Set();
 			this.listeners.set(type, bucket);
@@ -40,12 +44,16 @@ class MockEventSource implements EventSource {
 		bucket.add(handler as (event: MessageEvent) => void);
 	}
 
-	removeEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
-		if (!listener) {
-			return;
-		}
-		const handler = typeof listener === 'function' ? listener : listener.handleEvent.bind(listener);
-		this.listeners.get(type)?.delete(handler as (event: MessageEvent) => void);
+        removeEventListener(
+                type: string,
+                listener: EventListenerOrEventListenerObject | null,
+                _options?: boolean | EventListenerOptions
+        ): void {
+                if (!listener) {
+                        return;
+                }
+                const handler = typeof listener === 'function' ? listener : listener.handleEvent.bind(listener);
+                this.listeners.get(type)?.delete(handler as (event: MessageEvent) => void);
 	}
 
 	dispatchEvent(_event: Event): boolean {

--- a/tenvy-server/src/lib/components/ui/input/input.svelte
+++ b/tenvy-server/src/lib/components/ui/input/input.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { HTMLInputAttributes, HTMLInputTypeAttribute } from 'svelte/elements';
+        import type { HTMLInputAttributes, HTMLInputTypeAttribute } from 'svelte/elements';
 	import { cn, type WithElementRef } from '$lib/utils.js';
 
 	type InputType = Exclude<HTMLInputTypeAttribute, 'file'>;
@@ -9,6 +9,11 @@
 			({ type: 'file'; files?: FileList } | { type?: InputType; files?: undefined })
 	>;
 
+        export interface $$Events {
+                input: Event & { currentTarget: HTMLInputElement };
+                change: Event & { currentTarget: HTMLInputElement };
+        }
+
         let {
                 ref = $bindable(null),
                 value = $bindable(),
@@ -16,7 +21,7 @@
                 files = $bindable(),
                 class: className,
                 ...restProps
-        }: Props = $props<Props, HTMLInputAttributes['on']>();
+        }: Props = $props();
 </script>
 
 {#if type === 'file'}

--- a/tenvy-server/src/lib/components/ui/textarea/textarea.svelte
+++ b/tenvy-server/src/lib/components/ui/textarea/textarea.svelte
@@ -1,15 +1,20 @@
 <script lang="ts">
-	import type { HTMLTextareaAttributes } from 'svelte/elements';
+        import type { HTMLTextareaAttributes } from 'svelte/elements';
 	import { cn, type WithElementRef } from '$lib/utils.js';
 
 	type Props = WithElementRef<HTMLTextareaAttributes, HTMLTextAreaElement>;
+
+        export interface $$Events {
+                input: Event & { currentTarget: HTMLTextAreaElement };
+                change: Event & { currentTarget: HTMLTextAreaElement };
+        }
 
         let {
                 ref = $bindable(null),
                 value = $bindable(),
                 class: className,
                 ...restProps
-        }: Props = $props<Props, HTMLTextareaAttributes['on']>();
+        }: Props = $props();
 </script>
 
 <textarea

--- a/tenvy-server/src/lib/components/workspace/tools/app-vnc-workspace.svelte
+++ b/tenvy-server/src/lib/components/workspace/tools/app-vnc-workspace.svelte
@@ -81,10 +81,9 @@
 	let seedDeleting = $state<string | null>(null);
 	let selectedSeedAppId = $state(applications[0]?.id ?? '');
 
-	const selectedSeedApplication = $derived<AppVncApplicationDescriptor | null>(() => {
-		const trimmed = selectedSeedAppId.trim();
-		return applications.find((app) => app.id === trimmed) ?? null;
-	});
+        const selectedSeedApplication = $derived(
+                applications.find((app) => app.id === selectedSeedAppId.trim()) ?? null
+        );
 
 	const {
 		session,
@@ -117,17 +116,17 @@
 	let pointerActive = false;
 	let activePointerId: number | null = null;
 
-        const normalizedAppId = $derived<string>(() => appId.trim());
-	const selectedApp = $derived<AppVncApplicationDescriptor | null>(() => {
-		const trimmed = normalizedAppId;
-		return applications.find((app) => app.id === trimmed) ?? null;
-	});
-	const appSelectionLabel = $derived(() => {
-		if (selectedApp) {
-			return selectedApp.name;
-		}
-		return normalizedAppId ? `Custom · ${normalizedAppId}` : 'Manual selection';
-	});
+        const normalizedAppId = $derived(appId.trim());
+        const selectedApp = $derived(
+                applications.find((app) => app.id === normalizedAppId) ?? null
+        );
+        const appSelectionLabel = $derived(
+                selectedApp
+                        ? selectedApp.name
+                        : normalizedAppId
+                          ? `Custom · ${normalizedAppId}`
+                          : 'Manual selection'
+        );
 
 	function bundleKey(
 		platform: AppVncApplicationDescriptor['platforms'][number],

--- a/tenvy-server/src/lib/components/workspace/tools/file-manager-workspace.svelte
+++ b/tenvy-server/src/lib/components/workspace/tools/file-manager-workspace.svelte
@@ -471,8 +471,8 @@
 
         function applyFilePreview(resource: FileContent) {
                 filePreview = resource;
-                editorEncoding = resource.encoding ?? 'utf-8';
-                editorContent = resource.encoding === 'utf-8' ? resource.content : '';
+                editorEncoding = (resource.encoding ?? 'utf-8') as FileContent['encoding'];
+                editorContent = resource.encoding === 'utf-8' ? resource.content ?? '' : '';
         }
 
 	function pushHistory(path: string) {

--- a/tenvy-server/src/lib/components/workspace/tools/notes-workspace.svelte
+++ b/tenvy-server/src/lib/components/workspace/tools/notes-workspace.svelte
@@ -7,7 +7,7 @@
 	import { Button } from '$lib/components/ui/button/index.js';
 	import type { Client } from '$lib/data/clients';
 
-        const { client, class: className = '' } = $props<
+        const { client, class: className = '', secondary } = $props<
                 {
                         client: Client;
                         class?: string;
@@ -39,7 +39,7 @@
 		return value.map((tag) => `${tag ?? ''}`.trim()).filter((tag) => tag.length > 0);
 	}
 
-        function clearNoteFeedback(_: Event) {
+        function clearNoteFeedback() {
                 noteSaveError = null;
                 noteSaveSuccess = null;
         }
@@ -185,22 +185,22 @@
 	<div class="flex-1 space-y-6 overflow-auto px-6 py-5">
 		<div class="grid gap-2">
 			<Label for={notesFieldId}>Operational notes</Label>
-			<Textarea
-				id={notesFieldId}
-				class="min-h-32"
-				bind:value={noteText}
-				on:input={clearNoteFeedback}
-				placeholder={`Add context, requirements, or follow-up actions for ${client.codename}.`}
-			/>
+                        <Textarea
+                                id={notesFieldId}
+                                class="min-h-32"
+                                bind:value={noteText}
+                                on:input={() => clearNoteFeedback()}
+                                placeholder={`Add context, requirements, or follow-up actions for ${client.codename}.`}
+                        />
 		</div>
 		<div class="grid gap-2">
 			<Label for={`${notesFieldId}-tags`}>Quick tags</Label>
-			<Input
-				id={`${notesFieldId}-tags`}
-				bind:value={noteTagsInput}
-				on:input={clearNoteFeedback}
-				placeholder="intel priority staging"
-			/>
+                        <Input
+                                id={`${notesFieldId}-tags`}
+                                bind:value={noteTagsInput}
+                                on:input={() => clearNoteFeedback()}
+                                placeholder="intel priority staging"
+                        />
 		</div>
 		{#if noteSaveError}
 			<p class="text-sm text-destructive">{noteSaveError}</p>
@@ -208,9 +208,11 @@
 			<p class="text-sm text-emerald-600">{noteSaveSuccess}</p>
 		{/if}
 	</div>
-	<div class="flex items-center justify-end gap-2 border-t border-border/70 bg-muted/30 px-6 py-4">
-		<slot name="secondary" let:noteSavePending />
-		<Button type="submit" disabled={noteSavePending}>
+        <div class="flex items-center justify-end gap-2 border-t border-border/70 bg-muted/30 px-6 py-4">
+                {#if secondary}
+                        {@render secondary({ noteSavePending })}
+                {/if}
+                <Button type="submit" disabled={noteSavePending}>
 			{#if noteSavePending}
 				Saving…
 			{:else}

--- a/tenvy-server/src/lib/components/workspace/tools/remote-desktop-workspace.svelte
+++ b/tenvy-server/src/lib/components/workspace/tools/remote-desktop-workspace.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
-	import { onMount } from 'svelte';
+        import { onMount } from 'svelte';
 	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import { Card, CardContent, CardFooter } from '$lib/components/ui/card/index.js';
 	import { Button } from '$lib/components/ui/button/index.js';
@@ -86,7 +86,7 @@
 	let encoder = $state<RemoteDesktopSettings['encoder']>('auto');
 	let transportPreference = $state<RemoteDesktopTransport>('webrtc');
 	let hardwarePreference = $state<RemoteDesktopHardwarePreference>('auto');
-	let targetBitrateKbps = $state<number | null>(null);
+        let targetBitrateKbps = $state<number | null>(null);
 	let mode = $state<RemoteDesktopSettings['mode']>('video');
 	let monitor = $state(0);
 	let mouseEnabled = $state(false);
@@ -105,13 +105,13 @@
 	let errorMessage = $state<string | null>(null);
 	let infoMessage = $state<string | null>(null);
 	let monitors = $state<RemoteDesktopMonitor[]>(fallbackMonitors);
-	let sessionActive = $state(false);
-	let sessionId = $state('');
-	let viewportEl: HTMLDivElement | null = null;
-	let webrtcVideoEl: HTMLVideoElement | null = null;
-	let viewportFocused = $state(false);
+        let sessionActive = $state(false);
+        let sessionId = $state('');
+        let viewportEl: HTMLDivElement | null = null;
+        let webrtcVideoEl: HTMLVideoElement | null = null;
+        let viewportFocused = $state(false);
 	let pointerCaptured = $state(false);
-	let activePointerId: number | null = null;
+        let activePointerId: number | null = null;
 	interface RemoteDesktopInputDispatchResponse {
 		accepted?: boolean;
 		delivered?: boolean;
@@ -1422,11 +1422,11 @@
 		}
 	}
 
-	async function updateSession(partial: RemoteDesktopSettingsPatch) {
-		if (!client || !session?.sessionId) return;
-		if (Object.keys(partial).length === 0) {
-			return;
-		}
+        async function updateSession(partial: RemoteDesktopSettingsPatch) {
+                if (!client || !session?.sessionId) return;
+                if (Object.keys(partial).length === 0) {
+                        return;
+                }
 		isUpdating = true;
 		try {
 			const response = await fetch(`/api/agents/${client.id}/remote-desktop/session`, {
@@ -1443,16 +1443,33 @@
 		} catch (err) {
 			errorMessage =
 				err instanceof Error ? err.message : 'Failed to update remote desktop settings';
-		} finally {
-			isUpdating = false;
-		}
-	}
+                } finally {
+                        isUpdating = false;
+                }
+        }
 
-	function queueInput(event: RemoteDesktopInputEvent) {
-		if (!browser || !sessionActive || !sessionId || !client || !inputChannel) {
-			return;
-		}
-		inputChannel.enqueue(event);
+        function handleBitrateInput(event: Event) {
+                const element = event.currentTarget as HTMLInputElement;
+                const parsed = Number.parseInt(element.value, 10);
+                if (Number.isNaN(parsed) || parsed <= 0) {
+                        targetBitrateKbps = null;
+                        element.value = '';
+                        if (sessionActive) {
+                                void updateSession({ targetBitrateKbps: 0 });
+                        }
+                        return;
+                }
+                targetBitrateKbps = parsed;
+                if (sessionActive) {
+                        void updateSession({ targetBitrateKbps: parsed });
+                }
+        }
+
+        function queueInput(event: RemoteDesktopInputEvent) {
+                if (!browser || !sessionActive || !sessionId || !client || !inputChannel) {
+                        return;
+                }
+                inputChannel.enqueue(event);
 	}
 
 	function queueInputBatch(events: RemoteDesktopInputEvent[]) {
@@ -2100,31 +2117,16 @@
 			</div>
 			<div class="w-56">
 				<Label class="text-sm font-medium" for="bitrate-input">Target bitrate (kbps)</Label>
-				<Input
-					id="bitrate-input"
-					type="number"
-					min="0"
-					step="100"
-					placeholder="Auto"
-					value={targetBitrateKbps ?? ''}
-					disabled={!sessionActive || isUpdating}
-                                        on:input={(event) => {
-                                                const element = event.currentTarget as HTMLInputElement;
-                                                const parsed = Number.parseInt(element.value, 10);
-                                                if (Number.isNaN(parsed) || parsed <= 0) {
-                                                        targetBitrateKbps = null;
-							element.value = '';
-							if (sessionActive) {
-								void updateSession({ targetBitrateKbps: 0 });
-							}
-							return;
-						}
-						targetBitrateKbps = parsed;
-						if (sessionActive) {
-							void updateSession({ targetBitrateKbps: parsed });
-						}
-					}}
-				/>
+                                <Input
+                                        id="bitrate-input"
+                                        type="number"
+                                        min="0"
+                                        step="100"
+                                        placeholder="Auto"
+                                        value={targetBitrateKbps ?? ''}
+                                        disabled={!sessionActive || isUpdating}
+                                        on:input={handleBitrateInput}
+                                />
 			</div>
 			<div class="flex items-center gap-2">
 				<p class="text-sm font-medium">Mouse control</p>

--- a/tenvy-server/src/routes/(app)/clients/[clientId]/modules/workspace-container.svelte
+++ b/tenvy-server/src/routes/(app)/clients/[clientId]/modules/workspace-container.svelte
@@ -22,21 +22,28 @@
         import { ArrowLeft, X } from '@lucide/svelte';
         import type { Snippet } from 'svelte';
 
-	let {
-		client,
-		agent = null,
-		tools,
+        export interface $$Slots {
+                empty?: () => Snippet;
+        }
+
+        let {
+                client,
+                agent = null,
+                tools,
                 activeTool = null,
                 segments = [],
                 empty
-        }: {
-                client: Client;
-                agent?: AgentSnapshot | null;
-                tools: ClientToolDefinition[];
-                activeTool?: ClientToolDefinition | null;
-                segments?: string[];
-                empty?: Snippet;
-        } = $props();
+        } = $props<
+                {
+                        client: Client;
+                        agent?: AgentSnapshot | null;
+                        tools: ClientToolDefinition[];
+                        activeTool?: ClientToolDefinition | null;
+                        segments?: string[];
+                },
+                Record<string, never>,
+                $$Slots
+        >();
 
         const categoryLabels: Record<string, string> = {
 		overview: 'Overview',
@@ -62,7 +69,9 @@
                                         key,
                                         label:
                                                 categoryLabels[key] ??
-                                                key.replace(/-/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase()),
+                                                key
+                                                        .replace(/-/g, ' ')
+                                                        .replace(/\b\w/g, (char: string) => char.toUpperCase()),
                                         items: []
                                 } satisfies Group;
                                 index.set(key, group);
@@ -180,7 +189,7 @@
 					</CardContent>
 				</Card>
                         {:else if empty}
-                                {@render empty()}
+                                {@render empty!()}
                         {:else}
                                 <Card class="border-dashed">
                                         <CardHeader>


### PR DESCRIPTION
## Summary
- replace incorrect `$derived` generic usage in the App VNC workspace with direct expressions
- expose DOM event typings for the Input/Textarea components and adapt the notes/remote desktop workspaces
- tighten workspace container slot typing, adjust file manager preview handling, and relax the mock EventSource test helper

## Testing
- bun check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f44a3b6dc832b985f6003ab4e05df)