### PR TITLE
Harden WebAuthn typings and sanitize build payload helpers

### DIFF
--- a/tenvy-server/src/lib/server/auth/webauthn-utils.ts
+++ b/tenvy-server/src/lib/server/auth/webauthn-utils.ts
@@ -1,0 +1,110 @@
+export type WebAuthnChallengeOptions = Record<string, unknown> & {
+        challenge: string;
+};
+
+export function ensureChallengeOptions(
+        value: unknown,
+        context: 'authentication' | 'registration'
+): WebAuthnChallengeOptions {
+        if (typeof value !== 'object' || value === null) {
+                throw new TypeError(`Invalid WebAuthn ${context} options.`);
+        }
+
+        const challenge = Reflect.get(value, 'challenge');
+        if (typeof challenge !== 'string' || challenge.length === 0) {
+                throw new TypeError(`Invalid WebAuthn ${context} options.`);
+        }
+
+        return value as WebAuthnChallengeOptions;
+}
+
+export type WebAuthnAuthenticationVerification = {
+        verified: boolean;
+        authenticationInfo?: (Record<string, unknown> & { newCounter: number }) | null;
+};
+
+export function ensureAuthenticationVerification(
+        value: unknown
+): WebAuthnAuthenticationVerification {
+        if (typeof value !== 'object' || value === null) {
+                throw new TypeError('Invalid WebAuthn authentication verification result.');
+        }
+
+        const verified = Reflect.get(value, 'verified');
+        if (typeof verified !== 'boolean') {
+                throw new TypeError('Invalid WebAuthn authentication verification result.');
+        }
+
+        const authenticationInfo = Reflect.get(value, 'authenticationInfo');
+        if (
+                authenticationInfo != null &&
+                (typeof authenticationInfo !== 'object' ||
+                        typeof Reflect.get(authenticationInfo, 'newCounter') !== 'number')
+        ) {
+                throw new TypeError('Invalid WebAuthn authentication verification result.');
+        }
+
+        return value as WebAuthnAuthenticationVerification;
+}
+
+export type WebAuthnRegistrationVerification =
+        | { verified: false }
+        | ({
+                        verified: true;
+                        registrationInfo: (Record<string, unknown> & {
+                                credential: Record<string, unknown> & {
+                                        id: string;
+                                        publicKey: Uint8Array;
+                                        counter: number;
+                                        transports?: string[];
+                                };
+                                credentialDeviceType: string;
+                                credentialBackedUp: boolean;
+                        }) | null;
+                });
+
+export function ensureRegistrationVerification(
+        value: unknown
+): WebAuthnRegistrationVerification {
+        if (typeof value !== 'object' || value === null) {
+                throw new TypeError('Invalid WebAuthn registration verification result.');
+        }
+
+        const verified = Reflect.get(value, 'verified');
+        if (typeof verified !== 'boolean') {
+                throw new TypeError('Invalid WebAuthn registration verification result.');
+        }
+
+        if (!verified) {
+                return { verified: false };
+        }
+
+        const registrationInfo = Reflect.get(value, 'registrationInfo');
+        if (typeof registrationInfo !== 'object' || registrationInfo === null) {
+                throw new TypeError('Invalid WebAuthn registration verification result.');
+        }
+
+        const credential = Reflect.get(registrationInfo, 'credential');
+        if (
+                typeof credential !== 'object' ||
+                credential === null ||
+                typeof Reflect.get(credential, 'id') !== 'string' ||
+                typeof Reflect.get(credential, 'counter') !== 'number'
+        ) {
+                throw new TypeError('Invalid WebAuthn registration verification result.');
+        }
+
+        const publicKey = Reflect.get(credential, 'publicKey');
+        if (!(publicKey instanceof Uint8Array)) {
+                throw new TypeError('Invalid WebAuthn registration verification result.');
+        }
+
+        const credentialDeviceType = Reflect.get(registrationInfo, 'credentialDeviceType');
+        const credentialBackedUp = Reflect.get(registrationInfo, 'credentialBackedUp');
+
+        if (typeof credentialDeviceType !== 'string' || typeof credentialBackedUp !== 'boolean') {
+                throw new TypeError('Invalid WebAuthn registration verification result.');
+        }
+
+        return value as WebAuthnRegistrationVerification;
+}

--- a/tenvy-server/src/routes/(app)/build/+page.svelte
+++ b/tenvy-server/src/routes/(app)/build/+page.svelte
@@ -9,8 +9,9 @@
 		CardHeader,
 		CardTitle
 	} from '$lib/components/ui/card/index.js';
-	import { Tabs, TabsContent, TabsList, TabsTrigger } from '$lib/components/ui/tabs/index.js';
-import { onDestroy, onMount, tick } from 'svelte';
+        import { Tabs, TabsContent, TabsList, TabsTrigger } from '$lib/components/ui/tabs/index.js';
+        import { onDestroy, onMount, tick } from 'svelte';
+        import type { Component } from 'svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 	import { toast } from 'svelte-sonner';
 	import ConnectionTab from './components/ConnectionTab.svelte';
@@ -103,28 +104,28 @@ import { onDestroy, onMount, tick } from 'svelte';
 	const DEFAULT_TAB: BuildTab = 'connection';
 	let activeTab = $state<BuildTab>(DEFAULT_TAB);
 
-type TabComponent = new (...args: any[]) => import('svelte').SvelteComponent;
+type TabComponent = Component<any, any, any>;
 type TabLoader = () => Promise<{ default: TabComponent }>;
 
         const TAB_COMPONENT_LOADERS: Record<BuildTab, TabLoader> = {
                 connection: async () => ({ default: ConnectionTab }),
                 persistence: async () => {
                         const module = await import('./components/PersistenceTab.svelte');
-                        return { default: module.default as TabComponent };
+                        return { default: module.default };
                 },
                 execution: async () => {
                         const module = await import('./components/ExecutionTab.svelte');
-                        return { default: module.default as TabComponent };
+                        return { default: module.default };
                 },
                 presentation: async () => {
                         const module = await import('./components/PresentationTab.svelte');
-                        return { default: module.default as TabComponent };
+                        return { default: module.default };
                 }
         };
 
-	let tabComponents = $state<Partial<Record<BuildTab, TabComponent>>>({
-		connection: ConnectionTab
-	});
+        let tabComponents = $state<Partial<Record<BuildTab, TabComponent>>>({
+                connection: ConnectionTab
+        });
 	let tabLoading = $state<Record<BuildTab, boolean>>({
 		connection: false,
 		persistence: false,

--- a/tenvy-server/src/routes/(app)/build/lib/build-request.spec.ts
+++ b/tenvy-server/src/routes/(app)/build/lib/build-request.spec.ts
@@ -52,20 +52,22 @@ function createInput(overrides: Partial<BuildRequestInput> = {}): BuildRequestIn
 		modules: agentModules.map((module) => module.id)
 	};
 
-	return {
-		...base,
-		...overrides,
-		customHeaders: overrides.customHeaders
-			? overrides.customHeaders.map((header) => ({ ...header }))
-			: [],
-		customCookies: overrides.customCookies
-			? overrides.customCookies.map((cookie) => ({ ...cookie }))
-			: [],
-		fileInformation: overrides.fileInformation
-			? { ...overrides.fileInformation }
-			: { ...base.fileInformation },
-		modules: overrides.modules ? [...overrides.modules] : [...base.modules]
-	};
+        const modules = overrides.modules ?? base.modules ?? [];
+
+        return {
+                ...base,
+                ...overrides,
+                customHeaders: overrides.customHeaders
+                        ? overrides.customHeaders.map((header) => ({ ...header }))
+                        : [],
+                customCookies: overrides.customCookies
+                        ? overrides.customCookies.map((cookie) => ({ ...cookie }))
+                        : [],
+                fileInformation: overrides.fileInformation
+                        ? { ...overrides.fileInformation }
+                        : { ...base.fileInformation },
+                modules: [...modules]
+        };
 }
 
 describe('prepareBuildRequest', () => {

--- a/tenvy-server/src/routes/api/auth/webauthn/login/verify/+server.ts
+++ b/tenvy-server/src/routes/api/auth/webauthn/login/verify/+server.ts
@@ -7,6 +7,10 @@ import { eq } from 'drizzle-orm';
 import { decodeBase64url } from '@oslojs/encoding';
 import * as auth from '$lib/server/auth';
 import { limitWebAuthn } from '$lib/server/rate-limiters';
+import {
+        ensureAuthenticationVerification,
+        type WebAuthnAuthenticationVerification
+} from '$lib/server/auth/webauthn-utils';
 
 const CHALLENGE_COOKIE = 'webauthn-auth-challenge';
 
@@ -59,29 +63,30 @@ export const POST: RequestHandler = async (event) => {
 		return json({ message: 'Voucher inactive. Renew your license to continue.' }, { status: 403 });
 	}
 
-	let verification;
-	try {
-		const parsedTransports = record.passkey.transports
-			? (JSON.parse(record.passkey.transports) as string[] | undefined)
-			: undefined;
+        let verification: WebAuthnAuthenticationVerification;
+        try {
+                const parsedTransports = record.passkey.transports
+                        ? (JSON.parse(record.passkey.transports) as string[] | undefined)
+                        : undefined;
 
-		verification = await verifyAuthenticationResponse({
-			response: body,
-			expectedChallenge: challenge,
-			expectedOrigin: event.url.origin,
-			expectedRPID: event.url.hostname,
-			requireUserVerification: true,
-			credential: {
-				id: record.passkey.id,
-				publicKey: decodeBase64url(record.passkey.publicKey),
-				counter: record.passkey.counter,
-				transports: parsedTransports
-			}
-		});
-	} catch (error) {
-		const message = error instanceof Error ? error.message : 'Failed to verify passkey.';
-		return json({ message }, { status: 400 });
-	}
+                const result = await verifyAuthenticationResponse({
+                        response: body,
+                        expectedChallenge: challenge,
+                        expectedOrigin: event.url.origin,
+                        expectedRPID: event.url.hostname,
+                        requireUserVerification: true,
+                        credential: {
+                                id: record.passkey.id,
+                                publicKey: decodeBase64url(record.passkey.publicKey),
+                                counter: record.passkey.counter,
+                                transports: parsedTransports
+                        }
+                });
+                verification = ensureAuthenticationVerification(result);
+        } catch (error) {
+                const message = error instanceof Error ? error.message : 'Failed to verify passkey.';
+                return json({ message }, { status: 400 });
+        }
 
 	if (!verification.verified || !verification.authenticationInfo) {
 		return json({ message: 'Invalid passkey response.' }, { status: 400 });

--- a/tenvy-server/src/routes/api/auth/webauthn/register/verify/+server.ts
+++ b/tenvy-server/src/routes/api/auth/webauthn/register/verify/+server.ts
@@ -8,6 +8,10 @@ import { encodeBase64url } from '@oslojs/encoding';
 import * as auth from '$lib/server/auth';
 import { issueRecoveryCodes } from '$lib/server/auth/recovery';
 import { limitWebAuthn } from '$lib/server/rate-limiters';
+import {
+        ensureRegistrationVerification,
+        type WebAuthnRegistrationVerification
+} from '$lib/server/auth/webauthn-utils';
 
 export const POST: RequestHandler = async (event) => {
 	const sessionUser = event.locals.user;
@@ -42,19 +46,20 @@ export const POST: RequestHandler = async (event) => {
 		return json({ message: 'Registration challenge expired. Please try again.' }, { status: 400 });
 	}
 
-	let verification;
-	try {
-		verification = await verifyRegistrationResponse({
-			expectedChallenge: userRecord.currentChallenge,
-			expectedOrigin: event.url.origin,
-			expectedRPID: event.url.hostname,
-			response: body,
-			requireUserVerification: true
-		});
-	} catch (error) {
-		const message = error instanceof Error ? error.message : 'Failed to verify passkey.';
-		return json({ message }, { status: 400 });
-	}
+        let verification: WebAuthnRegistrationVerification;
+        try {
+                const result = await verifyRegistrationResponse({
+                        expectedChallenge: userRecord.currentChallenge,
+                        expectedOrigin: event.url.origin,
+                        expectedRPID: event.url.hostname,
+                        response: body,
+                        requireUserVerification: true
+                });
+                verification = ensureRegistrationVerification(result);
+        } catch (error) {
+                const message = error instanceof Error ? error.message : 'Failed to verify passkey.';
+                return json({ message }, { status: 400 });
+        }
 
 	if (!verification.verified || !verification.registrationInfo) {
 		return json({ message: 'Passkey could not be verified.' }, { status: 400 });

--- a/tenvy-server/src/routes/api/build/normalizer.ts
+++ b/tenvy-server/src/routes/api/build/normalizer.ts
@@ -520,21 +520,24 @@ function sanitizeHeaderValue(value: unknown): string | null {
 }
 
 export function sanitizeCustomHeaders(
-	payload: BuildRequest['customHeaders'] | null | undefined
+        payload: BuildRequest['customHeaders'] | null | undefined
 ): NormalizedCustomHeader[] {
-	if (!Array.isArray(payload) || payload.length === 0) {
-		return [];
-	}
-	const normalized: NormalizedCustomHeader[] = [];
-	for (const header of payload) {
-		if (!header || typeof header !== 'object') {
-			continue;
-		}
-		const key = sanitizeHeaderValue((header as BuildRequest['customHeaders'][number]).key);
-		const value = sanitizeHeaderValue((header as BuildRequest['customHeaders'][number]).value);
-		if (!key || !value) {
-			continue;
-		}
+        if (!Array.isArray(payload) || payload.length === 0) {
+                return [];
+        }
+        const normalized: NormalizedCustomHeader[] = [];
+        for (const header of payload as unknown[]) {
+                if (!header || typeof header !== 'object') {
+                        continue;
+                }
+                const typedHeader = header as Partial<
+                        NonNullable<BuildRequest['customHeaders']>[number]
+                >;
+                const key = sanitizeHeaderValue(typedHeader?.key);
+                const value = sanitizeHeaderValue(typedHeader?.value);
+                if (!key || !value) {
+                        continue;
+                }
 		normalized.push({ key, value });
 		if (normalized.length >= 32) {
 			break;
@@ -544,21 +547,24 @@ export function sanitizeCustomHeaders(
 }
 
 export function sanitizeCustomCookies(
-	payload: BuildRequest['customCookies'] | null | undefined
+        payload: BuildRequest['customCookies'] | null | undefined
 ): NormalizedCustomCookie[] {
-	if (!Array.isArray(payload) || payload.length === 0) {
-		return [];
-	}
-	const normalized: NormalizedCustomCookie[] = [];
-	for (const cookie of payload) {
-		if (!cookie || typeof cookie !== 'object') {
-			continue;
-		}
-		const name = sanitizeHeaderValue((cookie as BuildRequest['customCookies'][number]).name);
-		const value = sanitizeHeaderValue((cookie as BuildRequest['customCookies'][number]).value);
-		if (!name || !value) {
-			continue;
-		}
+        if (!Array.isArray(payload) || payload.length === 0) {
+                return [];
+        }
+        const normalized: NormalizedCustomCookie[] = [];
+        for (const cookie of payload as unknown[]) {
+                if (!cookie || typeof cookie !== 'object') {
+                        continue;
+                }
+                const typedCookie = cookie as Partial<
+                        NonNullable<BuildRequest['customCookies']>[number]
+                >;
+                const name = sanitizeHeaderValue(typedCookie?.name);
+                const value = sanitizeHeaderValue(typedCookie?.value);
+                if (!name || !value) {
+                        continue;
+                }
 		normalized.push({ name, value });
 		if (normalized.length >= 32) {
 			break;

--- a/tenvy-server/tsconfig.json
+++ b/tenvy-server/tsconfig.json
@@ -1,17 +1,34 @@
 {
 	"extends": "./.svelte-kit/tsconfig.json",
-	"compilerOptions": {
-		"allowJs": true,
-		"checkJs": true,
-		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true,
-		"resolveJsonModule": true,
-		"skipLibCheck": true,
-		"sourceMap": true,
-		"strict": true,
-		"moduleResolution": "bundler"
-	}
-	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
+        "compilerOptions": {
+                "allowJs": true,
+                "checkJs": true,
+                "esModuleInterop": true,
+                "forceConsistentCasingInFileNames": true,
+                "resolveJsonModule": true,
+                "skipLibCheck": true,
+                "sourceMap": true,
+                "strict": true,
+                "moduleResolution": "bundler",
+                "types": ["vitest", "vitest/globals"]
+        },
+        "include": [
+                "./.svelte-kit/ambient.d.ts",
+                "./.svelte-kit/non-ambient.d.ts",
+                "./.svelte-kit/types/**/$types.d.ts",
+                "./vite.config.ts",
+                "./vite.config.js",
+                "./src/**/*.ts",
+                "./src/**/*.js",
+                "./src/**/*.svelte",
+                "./tests/**/*.ts",
+                "./tests/**/*.js",
+                "./tests/**/*.svelte",
+                "../shared/types/**/*.ts",
+                "../shared/types/**/*.d.ts"
+        ],
+        "exclude": ["../shared/types/**/*.test.ts"]
+        // Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files
 	//
 	// To make changes to top-level options such as include and exclude, we recommend extending


### PR DESCRIPTION
## Summary
- add shared WebAuthn utilities to validate generated options and verification responses
- relax build tab component typing and guard build-request spec when overrides omit modules
- harden custom header/cookie sanitizers and exclude shared test files from the server tsconfig

## Testing
- bun check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f6389f270832bb2a3340669be5311)