### PR TITLE
Handle SQLite file URIs during database init

### DIFF
--- a/tenvy-server/src/lib/server/db/index.ts
+++ b/tenvy-server/src/lib/server/db/index.ts
@@ -10,12 +10,14 @@ const normalizedDbPath = env.DATABASE_URL.startsWith('file:')
         ? env.DATABASE_URL.slice('file:'.length)
         : env.DATABASE_URL;
 
+const useFileUri = env.DATABASE_URL.startsWith('file:');
+
 if (!env.DATABASE_URL.startsWith('file::memory:') && env.DATABASE_URL !== ':memory:') {
         const filePath = normalizedDbPath.split('?')[0];
         await ensureParentDirectory(filePath);
 }
 
-const client = new Database(env.DATABASE_URL);
+const client = new Database(env.DATABASE_URL, { uri: useFileUri });
 
 client.pragma('foreign_keys = ON');
 


### PR DESCRIPTION
## Summary
- track whether DATABASE_URL is a file URI and use it when creating the SQLite client

## Testing
- bun check *(fails: svelte-kit command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e05c4d9e8832b9ec2f330ae03dfe0)